### PR TITLE
fix(ci): harden stress prebuild, squash-merge DCO, fixture deadlines

### DIFF
--- a/.github/scripts/check-dco.sh
+++ b/.github/scripts/check-dco.sh
@@ -24,6 +24,24 @@ count=0
 while IFS= read -r sha; do
   count=$((count + 1))
   author_email="$(git log -1 --format='%ae' "$sha")"
+  committer_email="$(git log -1 --format='%ce' "$sha")"
+
+  # GitHub web-flow commits (squash/merge performed by github.com itself,
+  # committer noreply@github.com) rewrite the author email to the merging
+  # account's GitHub address, so an exact sign-off==author match is
+  # impossible by construction. The underlying PR commits were already
+  # DCO-checked by this workflow's required pull_request run; for the
+  # resulting merge commit we require a sign-off to be present but skip
+  # the email match.
+  if [ "$committer_email" = "noreply@github.com" ]; then
+    if ! git log -1 --format='%B' "$sha" | grep -qi '^signed-off-by:'; then
+      echo "::error::Merge/squash commit ${sha} carries no Signed-off-by at all."
+      echo "  subject: $(git log -1 --format='%s' "$sha")"
+      fail=1
+    fi
+    continue
+  fi
+
   # The sign-off may sit anywhere in the message body: after a squash merge,
   # GitHub concatenates commit messages, which moves trailers out of the
   # strict trailer block. Match any "Signed-off-by:" line instead.

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build test binaries once
-        run: cargo build --workspace --release --tests
+        run: cargo build --workspace --release --all-targets # bins too: fixture binaries must exist before iteration 1
       - name: Run the suite repeatedly
         env:
           ITERS: ${{ inputs.iterations || '100' }}

--- a/crates/termtest/tests/fixtures.rs
+++ b/crates/termtest/tests/fixtures.rs
@@ -56,7 +56,7 @@ mod util {
 fn spawn_fixture(name: &str) -> termtest::Result<Terminal> {
     Terminal::builder()
         .size(80, 24)
-        .timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
         .env_clear()
         .spawn(util::fixture_bin(name))
 }


### PR DESCRIPTION
Findings from the first stress run and first squash merge:

1. stress.yml prebuilt with --tests, which skips bin targets — fixture
   binaries were fallback-compiled DURING iteration 1, and on a cold
   2-vCPU ubuntu runner resize-echo then missed its deadline
   (macos: 100/100 green; ubuntu: died on the cold iteration).
   Prebuild with --all-targets so iteration 1 measures the harness,
   not the linker.

2. GitHub web-flow squash commits rewrite the author email to the
   account address, making the strict sign-off==author match fail by
   construction. The PR commits were already DCO-checked by the
   required pull_request run; for committer noreply@github.com the
   check now requires a sign-off to be present but skips the email
   match.

3. Fixture-test deadline 10s -> 30s: a generous deadline costs nothing
   when green (waits return the moment the condition holds) and
   removes cold-start scheduling noise from the flake budget.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
