### PR TITLE
fix: survive the instant-exit pty race; report signal deaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,18 @@ listed under a **Changed** or **Removed** heading.
 - Deterministic PTY fixture apps (`hello-tui`, `form-echo`, `resize-echo`,
   `unicode-torture`) used by the integration suite.
 - `inspect` example: run any command and print its rendered screen.
+- `ExitStatus::signal()`: the terminating signal's name when the child died
+  from a signal instead of exiting; `Display` now says
+  `killed by signal: … (code …)` so harness-level kills are never mistaken
+  for application exit codes. (`ExitStatus` is `Clone` but no longer `Copy`.)
+- `Screen`'s `Debug` is now the compact header+text rendering: a failing
+  `Result` test prints a readable screen instead of a one-line cell dump.
+
+### Fixed
+
+- The PTY reader thread now attaches **before** the child is spawned, so a
+  program that writes and exits within its first millisecond meets a drain
+  that is already running. This narrows (but cannot fully close — see the
+  instant-exit caveat in `docs/DESIGN.md`) an output-loss race in the OS
+  pty teardown, found by the stress workflow at roughly 1 in 80
+  instant-exit spawns on macOS.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ design. termtest's position:
   visible grid is the testable surface.
 - Unix only for now (Linux + macOS in CI). The PTY layer (`portable-pty`)
   supports ConPTY, so Windows is planned, not designed out.
+- A child that writes and exits within its first milliseconds can lose
+  output to the OS pty teardown (macOS especially). Long-lived TUIs are
+  unaffected; for run-and-exit programs, end the script with a `read` and
+  release it after asserting — see the "instant-exit caveat" in
+  [docs/DESIGN.md](docs/DESIGN.md).
 - Styles (colors/bold/…) are captured per-cell and queryable, but not part
   of the text snapshot format yet (`with_styles()` planned for v0.2).
 - Exotic grapheme clusters render as the vt100 crate renders them; the

--- a/crates/termtest/src/lib.rs
+++ b/crates/termtest/src/lib.rs
@@ -20,13 +20,14 @@
 //!     .size(80, 24)
 //!     .env("TERM", "xterm-256color") // the default; shown for completeness
 //!     .timeout(Duration::from_secs(10))
-//!     .args(["-c", "read line; echo \"got: $line\""])
+//!     .args(["-c", r#"read line; echo "got: $line"; read quit"#])
 //!     .spawn("sh")?;
 //!
 //! t.send_str("hello");
 //! t.send(Key::Enter);
 //! t.wait_until(|screen| screen.contains("got: hello"))?;
 //!
+//! t.send(Key::Enter); // release `read quit`; the script finishes
 //! let status = t.wait_exit()?;
 //! assert!(status.success());
 //! # Ok(())

--- a/crates/termtest/src/screen.rs
+++ b/crates/termtest/src/screen.rs
@@ -102,7 +102,7 @@ impl Cell {
 /// whitespace stripped per line. Trailing blanks are *preserved* inside the
 /// grid itself, so coordinate queries like [`Screen::cell`] and
 /// [`Screen::find`] are unaffected by the trimming.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Screen {
     cols: u16,
     rows: u16,
@@ -241,6 +241,18 @@ impl Screen {
             }
         }
         None
+    }
+}
+
+impl fmt::Debug for Screen {
+    /// Deliberately compact: the header plus the rendered text, exactly like
+    /// [`Display`](fmt::Display). The derived alternative — thousands of
+    /// [`Cell`]s on one line — makes `Err(Error::Timeout { .. })` in a
+    /// `Result`-returning test unreadable (and long enough that CI log
+    /// pipelines drop the line entirely). Use [`Screen::cell`] to inspect
+    /// individual cells.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Screen({self})")
     }
 }
 

--- a/crates/termtest/src/terminal.rs
+++ b/crates/termtest/src/terminal.rs
@@ -27,10 +27,11 @@ use crate::wait::{next_backoff, Expired, Monitor, INITIAL_BACKOFF, POLL_CAP};
 const DRAIN_GRACE: Duration = Duration::from_millis(500);
 
 /// Exit status of the child process.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExitStatus {
     code: u32,
     success: bool,
+    signal: Option<Box<str>>,
 }
 
 impl ExitStatus {
@@ -38,6 +39,7 @@ impl ExitStatus {
         Self {
             code: status.exit_code(),
             success: status.success(),
+            signal: status.signal().map(Into::into),
         }
     }
 
@@ -47,16 +49,33 @@ impl ExitStatus {
         self.success
     }
 
-    /// The raw exit code as reported by the OS.
+    /// The raw exit code as reported by the OS. Note that a signal-killed
+    /// child has no real exit code — the OS reports a placeholder (1);
+    /// check [`signal`](Self::signal) to tell the two cases apart.
     #[must_use]
     pub fn code(&self) -> u32 {
         self.code
+    }
+
+    /// The name of the signal that terminated the child, if it died from a
+    /// signal (e.g. `"Hangup"`, `"Killed: 9"`). `None` for a normal exit.
+    ///
+    /// Distinguishing "the app exited 1" from "something killed the app" is
+    /// the difference between a failing test and a failing test *harness* —
+    /// always assert with the full status in the message, e.g.
+    /// `assert_eq!(status.code(), 7, "status: {status}")`.
+    #[must_use]
+    pub fn signal(&self) -> Option<&str> {
+        self.signal.as_deref()
     }
 }
 
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "exit code {}", self.code)
+        match &self.signal {
+            Some(signal) => write!(f, "killed by signal: {signal} (code {})", self.code),
+            None => write!(f, "exit code {}", self.code),
+        }
     }
 }
 
@@ -79,9 +98,10 @@ struct EmuState {
 /// let mut t = Terminal::builder()
 ///     .size(80, 24)
 ///     .timeout(Duration::from_secs(10))
-///     .args(["-c", "echo builder-doc"])
+///     .args(["-c", "echo builder-doc; read quit"])
 ///     .spawn("sh")?;
 /// t.wait_until(|s| s.contains("builder-doc"))?;
+/// # t.send(termtest::Key::Enter); // release `read quit`
 /// # t.wait_exit()?; Ok(())
 /// # }
 /// ```
@@ -207,14 +227,12 @@ impl TerminalBuilder {
             cmd.env(key, value);
         }
 
-        let child = pair.slave.spawn_command(cmd).map_err(|e| Error::Spawn {
-            command: command_desc.clone(),
-            reason: e.to_string(),
-        })?;
-        // Close the parent's slave handle so the master sees EOF once the
-        // child (and its descendants) release the terminal.
-        drop(pair.slave);
-
+        // Attach the reader thread BEFORE spawning the child: a program that
+        // writes and exits within its first millisecond must find a drain
+        // already running. (macOS's pty layer can discard output still
+        // buffered at teardown — see docs/DESIGN.md §2 — so the window
+        // between child start and first read must be as close to zero as
+        // userspace can make it.)
         let reader = pair
             .master
             .try_clone_reader()
@@ -235,6 +253,14 @@ impl TerminalBuilder {
             .name("termtest-pty-reader".into())
             .spawn(move || reader_loop(reader, &reader_shared))
             .map_err(Error::Io)?;
+
+        let child = pair.slave.spawn_command(cmd).map_err(|e| Error::Spawn {
+            command: command_desc.clone(),
+            reason: e.to_string(),
+        })?;
+        // Close the parent's slave handle so the master sees EOF once the
+        // child (and its descendants) release the terminal.
+        drop(pair.slave);
 
         Ok(Terminal {
             child,
@@ -432,7 +458,7 @@ impl Terminal {
     /// [`Error::Timeout`] (with screen) if the child is still running at the
     /// deadline; [`Error::Io`] if the OS wait itself fails.
     pub fn wait_exit(&mut self) -> Result<ExitStatus> {
-        if let Some(status) = self.exit_status {
+        if let Some(status) = self.exit_status.clone() {
             return Ok(status);
         }
         let deadline = Instant::now() + self.default_timeout;
@@ -440,7 +466,7 @@ impl Terminal {
         loop {
             if let Some(status) = self.child.try_wait().map_err(Error::Io)? {
                 let status = ExitStatus::from_pty(&status);
-                self.exit_status = Some(status);
+                self.exit_status = Some(status.clone());
                 let _ = self
                     .shared
                     .wait_until(Instant::now() + DRAIN_GRACE, |state| {

--- a/crates/termtest/tests/basic.rs
+++ b/crates/termtest/tests/basic.rs
@@ -2,6 +2,12 @@
 //! control, exit codes, and the failure modes (timeout / EOF).
 //!
 //! These run headless — CI runners have no TTY, the harness makes its own.
+//!
+//! Pattern note: every script that must *print something we assert on*
+//! ends with a `read` guard, and we send Enter only after the assertion.
+//! Output written immediately before exit can be discarded by macOS's pty
+//! teardown (docs/DESIGN.md §2); keeping the child alive until the harness
+//! has seen the bytes makes these tests deterministic on every platform.
 
 use std::time::{Duration, Instant};
 
@@ -15,20 +21,24 @@ fn sh(script: &str) -> termtest::Result<Terminal> {
 
 #[test]
 fn echo_reaches_the_screen_and_child_exits_cleanly() -> termtest::Result<()> {
-    let mut t = sh("echo hello from a real pty")?;
+    let mut t = sh("echo hello from a real pty; read guard")?;
     t.wait_until(|s| s.contains("hello from a real pty"))?;
+    t.send(Key::Enter);
     let status = t.wait_exit()?;
-    assert!(status.success());
+    assert!(status.success(), "full status: {status}");
     assert_eq!(status.code(), 0);
     Ok(())
 }
 
 #[test]
 fn exit_codes_are_reported() -> termtest::Result<()> {
-    let mut t = sh("exit 7")?;
+    // The `read` keeps the exit from racing pty setup; the line discipline
+    // buffers our Enter even if it lands before `read` starts.
+    let mut t = sh("read guard; exit 7")?;
+    t.send(Key::Enter);
     let status = t.wait_exit()?;
     assert!(!status.success());
-    assert_eq!(status.code(), 7);
+    assert_eq!(status.code(), 7, "full status: {status}");
 
     // Idempotent: a second wait returns the cached status.
     assert_eq!(t.wait_exit()?, status);
@@ -36,12 +46,28 @@ fn exit_codes_are_reported() -> termtest::Result<()> {
 }
 
 #[test]
+fn signal_deaths_are_reported_as_signals_not_exit_codes() -> termtest::Result<()> {
+    let mut t = sh("read guard; kill -TERM $$")?;
+    t.send(Key::Enter);
+    let status = t.wait_exit()?;
+    assert!(!status.success());
+    // strsignal spelling differs per libc ("Terminated" / "Terminated: 15"),
+    // but the word is stable on both CI platforms.
+    let signal = status.signal().unwrap_or_else(|| {
+        panic!("expected a signal death, got: {status}");
+    });
+    assert!(signal.contains("Terminated"), "signal was: {signal}");
+    Ok(())
+}
+
+#[test]
 fn env_vars_reach_the_child() -> termtest::Result<()> {
     let mut t = Terminal::builder()
         .env("TERMTEST_MARKER", "42")
-        .args(["-c", r#"echo "marker=$TERMTEST_MARKER""#])
+        .args(["-c", r#"echo "marker=$TERMTEST_MARKER"; read guard"#])
         .spawn(SH)?;
     t.wait_until(|s| s.contains("marker=42"))?;
+    t.send(Key::Enter);
     t.wait_exit()?;
     Ok(())
 }
@@ -59,7 +85,10 @@ fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termtest::
     let mut t = Terminal::builder()
         .env_clear()
         .env("KEPT", "yes")
-        .args(["-c", r#"echo "home=${HOME:-unset} term=$TERM kept=$KEPT""#])
+        .args([
+            "-c",
+            r#"echo "home=${HOME:-unset} term=$TERM kept=$KEPT"; read guard"#,
+        ])
         .spawn(SH)?;
     t.wait_until(|s| s.contains("kept=yes"))?;
     let screen = t.screen();
@@ -71,6 +100,7 @@ fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termtest::
         screen.contains("term=xterm-256color"),
         "default TERM missing:\n{screen}"
     );
+    t.send(Key::Enter);
     t.wait_exit()?;
     Ok(())
 }
@@ -79,19 +109,21 @@ fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termtest::
 fn explicit_term_overrides_the_default() -> termtest::Result<()> {
     let mut t = Terminal::builder()
         .env("TERM", "vt100")
-        .args(["-c", r#"echo "term=$TERM""#])
+        .args(["-c", r#"echo "term=$TERM"; read guard"#])
         .spawn(SH)?;
     t.wait_until(|s| s.contains("term=vt100"))?;
+    t.send(Key::Enter);
     t.wait_exit()?;
     Ok(())
 }
 
 #[test]
 fn send_str_and_enter_round_trip_through_the_line_discipline() -> termtest::Result<()> {
-    let mut t = sh(r#"read line; echo "got: $line""#)?;
+    let mut t = sh(r#"read line; echo "got: $line"; read guard"#)?;
     t.send_str("hello");
     t.send(Key::Enter);
     t.wait_until(|s| s.contains("got: hello"))?;
+    t.send(Key::Enter);
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -122,9 +154,14 @@ fn timeout_error_embeds_the_screen_dump() {
 fn waits_fail_fast_on_eof_instead_of_burning_the_timeout() {
     let mut t = Terminal::builder()
         .timeout(Duration::from_secs(30))
-        .args(["-c", "echo bye"])
+        .args(["-c", "echo bye; read guard"])
         .spawn(SH)
         .unwrap();
+    // Deterministic sequencing: observe the output, then let the child
+    // exit, then wait for something that can never appear.
+    t.wait_until(|s| s.contains("bye")).unwrap();
+    t.send(Key::Enter);
+
     let start = Instant::now();
     let err = t.wait_until(|s| s.contains("never printed")).unwrap_err();
     let elapsed = start.elapsed();
@@ -140,7 +177,7 @@ fn waits_fail_fast_on_eof_instead_of_burning_the_timeout() {
 
 #[test]
 fn wait_idle_resolves_in_output_gaps() -> termtest::Result<()> {
-    let mut t = sh("printf a; sleep 1.5; printf b")?;
+    let mut t = sh("printf a; sleep 1.5; printf b; read guard")?;
     t.wait_until(|s| s.contains("a"))?;
     t.wait_idle(Duration::from_millis(200))?;
 
@@ -152,6 +189,7 @@ fn wait_idle_resolves_in_output_gaps() -> termtest::Result<()> {
     );
 
     t.wait_until(|s| s.contains("b"))?;
+    t.send(Key::Enter);
     t.wait_exit()?;
     Ok(())
 }

--- a/crates/termtest/tests/fixtures.rs
+++ b/crates/termtest/tests/fixtures.rs
@@ -11,13 +11,16 @@ mod util {
     use std::process::Command;
     use std::sync::Mutex;
 
-    /// Serializes fallback `cargo build` invocations across test threads.
-    static BUILD_LOCK: Mutex<()> = Mutex::new(());
+    /// Fixture names already rebuilt by this test process.
+    static BUILT: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
     /// Path to a fixture binary (a sibling workspace member, so
-    /// `CARGO_BIN_EXE_*` is unavailable). `cargo test --workspace` has
-    /// already built them; when running `cargo test -p termtest` alone, fall
-    /// back to building on demand.
+    /// `CARGO_BIN_EXE_*` is unavailable). Always runs `cargo build -p`
+    /// once per fixture per test process: `cargo test` links test
+    /// harnesses into `deps/` but does not refresh the plain bin artifact,
+    /// so an existing `target/<profile>/<name>` can be stale and would
+    /// silently test old fixture code. The build no-ops in milliseconds
+    /// when everything is fresh (and stress.yml prebuilds --all-targets).
     pub(crate) fn fixture_bin(name: &str) -> PathBuf {
         let profile = if cfg!(debug_assertions) {
             "debug"
@@ -33,12 +36,9 @@ mod util {
             PathBuf::from,
         );
         let bin = target_dir.join(profile).join(name);
-        if bin.exists() {
-            return bin;
-        }
 
-        let _guard = BUILD_LOCK.lock().unwrap();
-        if !bin.exists() {
+        let mut built = BUILT.lock().unwrap();
+        if !built.iter().any(|b| b == name) {
             let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
             let mut cmd = Command::new(cargo);
             cmd.args(["build", "-p", name]);
@@ -47,7 +47,10 @@ mod util {
             }
             let status = cmd.status().expect("failed to run cargo build");
             assert!(status.success(), "cargo build -p {name} failed");
+            built.push(name.to_owned());
         }
+        drop(built);
+
         assert!(bin.exists(), "fixture binary missing at {}", bin.display());
         bin
     }
@@ -127,7 +130,7 @@ fn form_echo_reports_nonzero_exit_codes() -> termtest::Result<()> {
     t.send(Key::Ctrl('x'));
     let status = t.wait_exit()?;
     assert!(!status.success());
-    assert_eq!(status.code(), 42);
+    assert_eq!(status.code(), 42, "full status: {status}");
     Ok(())
 }
 
@@ -160,6 +163,8 @@ fn unicode_torture_renders_with_correct_widths() -> termtest::Result<()> {
     assert_eq!(screen.find("|一二三|"), Some((5, 7)));
     insta::assert_snapshot!(screen);
 
+    // Release the fixture's stdin guard now that everything is asserted.
+    t.send(Key::Enter);
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -63,6 +63,21 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
 `Drop` kills + reaps the child unconditionally (unless already reaped):
 tests never leak zombies, including on panic.
 
+### The instant-exit caveat (macOS pty teardown)
+
+A child that **writes and exits within its first milliseconds** races the
+platform's pty teardown: on macOS, bytes still buffered in the kernel when
+the slave side closes can be discarded, and teardown can even surface as a
+signal-death instead of the real exit code. Stress-testing found this at
+roughly 1 in 80 instant-exit spawns under load. termtest narrows the window
+as far as userspace allows — the reader thread is attached *before* the
+child is spawned — but cannot close it.
+
+The deterministic pattern (used throughout our own suite): make the child's
+last action a `read` on stdin, assert on its output, then send Enter and
+`wait_exit`. Real TUI applications are unaffected — they live far longer
+than the window and exit on request.
+
 ## 3. Snapshot text format (spec)
 
 `Display for Screen` produces:

--- a/fixtures/resize-echo/src/main.rs
+++ b/fixtures/resize-echo/src/main.rs
@@ -33,6 +33,13 @@ fn main() -> io::Result<()> {
     let mut out = io::stdout();
     execute!(out, EnterAlternateScreen, Hide)?;
 
+    // Initialize crossterm's event source (which registers the SIGWINCH
+    // listener) BEFORE the first draw. The harness treats the first drawn
+    // size as "ready to be resized"; without this, a resize landing between
+    // the draw and the first event::read() is silently lost (SIGWINCH's
+    // default disposition is ignore) and the test deadlocks.
+    let _ = event::poll(std::time::Duration::from_secs(0))?;
+
     let (cols, rows) = terminal::size()?;
     draw(&mut out, cols, rows)?;
 

--- a/fixtures/unicode-torture/src/main.rs
+++ b/fixtures/unicode-torture/src/main.rs
@@ -5,7 +5,10 @@
 //! (the NFD line is spelled with explicit escapes so the source file's
 //! encoding can never change the bytes), and a wide-vs-narrow width ruler.
 //!
-//! No TTY interaction, no timing, no randomness — print and exit 0.
+//! No timing, no randomness — print, wait for one line on stdin, exit 0.
+//! The stdin guard exists because output written immediately before exit
+//! can be discarded by macOS's pty teardown; the harness observes the
+//! lines, then sends Enter to release the fixture.
 
 fn main() {
     println!("ascii: the quick brown fox");
@@ -15,4 +18,7 @@ fn main() {
     println!("viet-nfd: Tie\u{0302}\u{0301}ng Vie\u{0323}\u{0302}t");
     println!("width: |一二三| vs |abc|");
     println!("done");
+
+    let mut guard = String::new();
+    let _ = std::io::stdin().read_line(&mut guard);
 }


### PR DESCRIPTION
The stress workflow caught the suite flaking at ~1/80 instant-exit
spawns (child writes and exits within its first millisecond): the OS
pty teardown — macOS especially — can discard output still buffered at
slave close, and can surface teardown as a signal-death instead of the
real exit code. Reproduced locally at ~1/10 full-suite runs.

Harness fixes:
- attach the reader thread BEFORE spawning the child, so the drain is
  running from the child's first byte (narrows the race as far as
  userspace can; the residual kernel-side caveat is documented in
  docs/DESIGN.md and README known-limitations)
- ExitStatus now carries the terminating signal's name; Display says
  'killed by signal: ...' so harness-level kills can never be mistaken
  for application exit codes (ExitStatus: Clone, no longer Copy)
- Screen's Debug is the compact header+text rendering; a failing
  Result test prints a readable screen instead of a single-line dump
  of thousands of cells (long enough that CI log pipelines dropped it,
  which is why the first stress failures were undiagnosable)

Suite fixes:
- every instant-exit script now ends with a stdin 'read' guard and is
  released with Enter only after its output is asserted — the
  deterministic pattern, now documented in DESIGN.md; doctests teach it
- unicode-torture gained the same guard
- resize-echo initializes crossterm's event source (the SIGWINCH
  listener) before its first draw, closing a resize-before-listener
  lost-signal race
- fixture_bin() always refreshes fixture binaries once per process:
  cargo test does not relink plain bin artifacts, so an old
  target/<profile>/<name> from a previous cargo build silently tested
  stale fixture code
- exit-code assertions include the full status in their message

Validation: 30/30 full-suite release iterations at --test-threads=4
clean locally (previous flake rate ~1/10); signal reporting covered by
a new signal-death test.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
