### PR TITLE
test: snapshot only after the app's final drawn byte

### DIFF
--- a/crates/termtest/tests/fixtures.rs
+++ b/crates/termtest/tests/fixtures.rs
@@ -67,9 +67,14 @@ fn spawn_fixture(name: &str) -> termtest::Result<Terminal> {
 #[test]
 fn hello_tui_draws_a_static_alt_screen_frame() -> termtest::Result<()> {
     let mut t = spawn_fixture("hello-tui")?;
-    t.wait_until(|s| s.contains("status: ready"))?;
+    // The bottom-right corner is the LAST byte the fixture draws — once it
+    // is on screen, the whole frame is. Waiting on an earlier line (like
+    // "status: ready") would race the rest of the frame at chunk
+    // boundaries and flake the snapshot below.
+    t.wait_until(|s| s.contains("╯"))?;
 
     let screen = t.screen();
+    assert!(screen.contains("status: ready"), "{screen}");
     let (_, _, cursor_visible) = screen.cursor();
     assert!(!cursor_visible, "hello-tui hides the cursor");
     assert_eq!(screen.find("hello-tui"), Some((1, 2)));
@@ -154,7 +159,11 @@ fn resize_reaches_the_child_as_sigwinch() -> termtest::Result<()> {
 #[test]
 fn unicode_torture_renders_with_correct_widths() -> termtest::Result<()> {
     let mut t = spawn_fixture("unicode-torture")?;
-    t.wait_until(|s| s.contains("done"))?;
+    // Wait on the cursor, not on contains("done"): the predicate would turn
+    // true before the trailing newline is processed, and the snapshot would
+    // catch the cursor mid-line. After "done\r\n" the cursor rests at the
+    // start of row 7 — that is the fixture's true "finished drawing" state.
+    t.wait_until(|s| s.cursor() == (7, 0, true))?;
 
     let screen = t.screen();
     // "width: |一二三| vs |abc|" — "width: " is 7 columns, "|一二三|" is

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -63,6 +63,17 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
 `Drop` kills + reaps the child unconditionally (unless already reaped):
 tests never leak zombies, including on panic.
 
+### Snapshot after waiting on the *last* drawn byte
+
+`wait_until(pred)` guarantees exactly this: every byte up to and including
+the ones that made `pred` true has been processed. Bytes the application
+wrote *after* your marker may still be in flight. So before snapshotting a
+whole screen, wait on the **final** thing the app draws — the bottom-right
+corner of a frame, or the cursor's resting position
+(`s.cursor() == (row, 0, true)`) — not on a line drawn midway. Waiting on
+an early marker and snapshotting is a race at chunk boundaries; the stress
+workflow found exactly that in our own suite.
+
 ### The instant-exit caveat (macOS pty teardown)
 
 A child that **writes and exits within its first milliseconds** races the


### PR DESCRIPTION
Stress caught the unicode snapshot flaking on the cursor position:
wait_until(contains("done")) turns true before the trailing newline is
processed, so the snapshot could catch the cursor mid-line (6,4 vs
7,0) at a chunk boundary. The same latent pattern sat in the hello-tui
test, which waited on a line drawn before the frame's bottom border.

Rule, now documented in DESIGN.md: wait_until guarantees bytes up to
and including your marker — before snapshotting, wait on the LAST
thing the app draws (bottom-right frame corner, or the cursor's
resting position), never a midway line. unicode-torture now waits on
cursor (7,0); hello-tui waits on the closing corner and asserts
'status: ready' afterwards.

25/25 local release-mode full-suite iterations clean on top of the
earlier 30/30.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
