### PR TITLE
docs: upgrade architecture diagrams to mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,41 @@ exactly what the app was displaying, not "assertion failed: false".
 
 ## How it works
 
-```
- your test ──────────── send(Key) ───────────────► ┌──────────────┐
-     │                                             │  child app   │
-     │  wait_until / wait_idle / wait_exit         │ in a real pty│
-     ▼                                             └──────┬───────┘
- ┌─────────┐      ┌────────────┐      ┌─────────┐         │
- │ Screen  │ ◄──  │ VT emulator│ ◄──  │ reader  │ ◄── pty master
- │snapshots│      │  (vt100)   │      │ thread  │     (bytes)
- └─────────┘      └────────────┘      └─────────┘
+```mermaid
+flowchart TB
+  test["your test<br/>drive · wait · assert"]
+  subgraph proc["your test process · cargo test"]
+    subgraph tt["termtest"]
+      api["Terminal<br/>send · resize · wait_until / wait_idle / wait_exit"]
+      reader["reader thread<br/>drains continuously — output is never lost between waits"]
+      emu["VT emulator<br/>vt100 behind a small internal trait, swappable"]
+      screen["Screen<br/>immutable grid snapshots · cells · cursor · styles"]
+    end
+  end
+  subgraph kernel["kernel"]
+    pty["real pty<br/>line discipline · TIOCSWINSZ → SIGWINCH"]
+  end
+  app["your app, unmodified<br/>believes it owns a terminal"]
+
+  test -->|"send(Key) · send_str"| api
+  api -->|"xterm byte sequences"| pty
+  api -.->|"resize · kernel delivers SIGWINCH"| pty
+  pty -->|stdin| app
+  app -->|"stdout · escape sequences"| pty
+  pty -->|bytes| reader
+  reader -->|"process, under one lock"| emu
+  emu -->|"snapshot"| screen
+  screen -->|"predicates · insta snapshots · screen dumps in every timeout"| test
+  classDef ours fill:#2563eb,color:#ffffff,stroke:#1d4ed8,stroke-width:1px;
+  class api,reader,emu,screen ours
 ```
 
-A background thread drains the PTY into the emulator *continuously* — the
+The reader thread drains the PTY into the emulator *continuously* — the
 kernel buffer can't fill up and stall your app, and no output is lost
-between assertions. Screens are immutable snapshots taken under a lock.
-Four layers, one small internal trait between emulator and screen so the
-backend can be swapped; details in [docs/DESIGN.md](docs/DESIGN.md).
+between assertions. Screens are immutable snapshots taken under the same
+lock the reader writes through, so every assertion sees a consistent
+instant. Four layers, one small internal trait between emulator and screen
+so the backend can be swapped; details in [docs/DESIGN.md](docs/DESIGN.md).
 
 ## Comparison
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -6,26 +6,29 @@ change those only with a matching change here.
 
 ## 1. Four layers
 
-```
-┌────────────────────────────────────────────────────────────┐
-│ 4. Assertions      wait_until / wait_idle / wait_exit,     │
-│                    Screen queries, insta snapshots          │
-├────────────────────────────────────────────────────────────┤
-│ 3. Screen          immutable, Arc-backed grid snapshots     │
-│                    (Cell, Style, cursor) — termtest's own   │
-├────────────────────────────────────────────────────────────┤
-│ 2. Emulator        pub(crate) trait Emulator                │
-│                    { process, snapshot, mid_sequence,       │
-│                      set_size } — v0.1 backend: vt100       │
-├────────────────────────────────────────────────────────────┤
-│ 1. PTY             portable-pty: real kernel pty, spawn,    │
-│                    resize (TIOCSWINSZ→SIGWINCH), reader     │
-│                    thread draining master → emulator        │
-└────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+  test["test code"]
+  l4["4 · assertions<br/>wait_until / wait_idle / wait_exit · Screen queries · insta snapshots"]
+  l3["3 · Screen<br/>immutable Arc-backed grid snapshots · Cell · Style · cursor — termtest's own types"]
+  l2["2 · emulator<br/>internal trait: process · snapshot · mid_sequence · set_size — v0.1 backend: vt100"]
+  l1["1 · pty<br/>portable-pty · reader thread · resize TIOCSWINSZ → SIGWINCH · lifecycle lock"]
+  app["child app<br/>spawned in the pty, unmodified"]
+
+  app -->|"escape-sequence bytes"| l1
+  l1 -->|"reader thread · mutate under lock, notify waiters"| l2
+  l2 -->|"snapshot on demand"| l3
+  l3 -->|"predicates · dumps embedded in every timeout"| l4
+  l4 --> test
+  test -.->|"send(Key) → Key::encode · resize"| l1
+  l1 -.->|"stdin bytes · SIGWINCH"| app
+  classDef ours fill:#2563eb,color:#ffffff,stroke:#1d4ed8,stroke-width:1px;
+  class l1,l2,l3,l4 ours
 ```
 
-Data flows up: child writes → PTY master → reader thread → emulator →
-screen snapshots. Input flows down: `Key::encode()` → PTY master → child.
+Data flows up (solid): child writes → PTY master → reader thread →
+emulator → screen snapshots → assertions. Input flows down (dashed):
+`Key::encode()` → PTY master → child.
 
 **The reader thread** is the linchpin. It drains the PTY *continuously*, not
 just inside `wait_*` calls, so a chatty program can never fill the kernel


### PR DESCRIPTION
Replace the ASCII 'How it works' figure in the README and the
four-layer stack in DESIGN.md with mermaid flowcharts in the style of
openshell-driver-applecontainer's architecture diagram: subgraph
nesting (test process > termtest; kernel), multi-line node labels with
role detail, protocol-labeled edges, dashed edges for the control/
input direction, and a classDef highlighting termtest's own
components. GitHub renders these natively; on crates.io the fence
degrades to readable source, same as the old ASCII block.

Both diagrams stay exactly true to the implementation, and now show
pieces the ASCII art omitted: the resize/SIGWINCH path, the
reader-mutates-under-one-lock contract, and the pty lifecycle lock.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
