### PR TITLE
ci: harden the supply chain and workflow security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,12 @@ jobs:
     name: fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
           components: rustfmt
       - run: cargo fmt --all --check
 
@@ -29,11 +32,14 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   # CI runners have no TTY; termtest creates its own PTYs. This suite passing
@@ -46,26 +52,32 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --all-features
 
   msrv:
     name: msrv
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Read MSRV from Cargo.toml
         id: msrv
         run: |
           msrv="$(sed -n 's/^rust-version *= *"\(.*\)"/\1/p' Cargo.toml)"
           echo "MSRV: ${msrv}"
           echo "msrv=${msrv}" >> "$GITHUB_OUTPUT"
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo check --workspace --locked
 
   docs:
@@ -74,24 +86,45 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo doc --no-deps --all-features
 
   deny:
     name: deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2
+
+  # Workflow security audit (template injection, credential persistence,
+  # unpinned actions, …). Accepted findings live in .github/zizmor.yml.
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Audit workflows at pedantic level
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Version pinned; bump deliberately alongside a fresh local audit.
+        run: uvx zizmor==1.29.0 --persona=pedantic .github/workflows/
 
   # Single stable job name for branch protection: require this one check and
   # matrix/job changes never break the required-checks configuration.
   required-green:
     name: required-green
     if: always()
-    needs: [fmt, clippy, test, msrv, docs, deny]
+    needs: [fmt, clippy, test, msrv, docs, deny, zizmor]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every needed job succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         # Version pinned; bump deliberately alongside a fresh local audit.
-        run: uvx zizmor==1.29.0 --persona=pedantic .github/workflows/
+        # pipx ships on the runner image (uv/uvx does not).
+        run: pipx run zizmor==1.29.0 --persona=pedantic .github/workflows/
 
   # Single stable job name for branch protection: require this one check and
   # matrix/job changes never break the required-checks configuration.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           components: rustfmt
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           components: clippy
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -74,7 +74,7 @@ jobs:
           msrv="$(sed -n 's/^rust-version *= *"\(.*\)"/\1/p' Cargo.toml)"
           echo "MSRV: ${msrv}"
           echo "msrv=${msrv}" >> "$GITHUB_OUTPUT"
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -19,15 +19,22 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write # one-time failure comment on PRs
+
+concurrency:
+  group: commit-policy-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   commit-policy:
     name: commit-policy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # one-time failure comment on PRs
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0 # need full history to walk the commit range
 
       - name: Determine commit range
@@ -53,12 +60,16 @@ jobs:
           echo "range=$range" >> "$GITHUB_OUTPUT"
 
       - name: DCO sign-off
-        run: .github/scripts/check-dco.sh "${{ steps.range.outputs.range }}"
+        env:
+          RANGE: ${{ steps.range.outputs.range }}
+        run: .github/scripts/check-dco.sh "$RANGE"
 
       - name: No AI attribution
         # Run even when the DCO step failed, so one run reports everything.
         if: always() && steps.range.outcome == 'success'
-        run: .github/scripts/check-no-ai-attribution.sh "${{ steps.range.outputs.range }}"
+        env:
+          RANGE: ${{ steps.range.outputs.range }}
+        run: .github/scripts/check-no-ai-attribution.sh "$RANGE"
 
       - name: Comment on PR (policy failed)
         if: failure() && github.event_name == 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,22 @@ on:
 permissions:
   contents: read
 
+# Never cancel a release mid-publish; a duplicate tag push queues instead.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   verify-version:
     name: tag matches crate version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
       - name: Compare tag against crates/termtest version
         run: |
           tag="${GITHUB_REF_NAME#v}"
@@ -38,7 +47,9 @@ jobs:
     needs: verify-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Look for a published baseline on crates.io
         id: published
         run: |
@@ -48,7 +59,7 @@ jobs:
       - name: Skip (first release, no baseline)
         if: steps.published.outputs.found != 'true'
         run: echo "termtest is not on crates.io yet; skipping semver checks gracefully."
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         if: steps.published.outputs.found == 'true'
         with:
           package: termtest
@@ -61,13 +72,17 @@ jobs:
       contents: read
       id-token: write # crates.io Trusted Publishing (GitHub OIDC)
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
       # Preferred auth: crates.io Trusted Publishing. Needs the one-time
       # linkage of this repo+workflow on crates.io (docs/RELEASING.md).
       # Until that exists, the step fails soft and we fall back to a
       # CRATES_IO_TOKEN repository secret.
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
         continue-on-error: true
       - run: cargo publish -p termtest --locked
@@ -81,7 +96,9 @@ jobs:
     permissions:
       contents: write # create the release
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Extract notes from CHANGELOG.md
         run: .github/scripts/extract-changelog.sh "$GITHUB_REF_NAME" > "$RUNNER_TEMP/notes.md"
       - name: Create the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - name: Compare tag against crates/termtest version
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       # Preferred auth: crates.io Trusted Publishing. Needs the one-time

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: read
 
+# One stress run per ref at a time; a second dispatch queues rather than
+# cancelling a half-finished 100-iteration measurement.
+concurrency:
+  group: stress-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   stress:
     name: stress (${{ matrix.os }})
@@ -27,9 +33,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Build test binaries once
         run: cargo build --workspace --release --all-targets # bins too: fixture binaries must exist before iteration 1
       - name: Run the suite repeatedly

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# zizmor configuration — accepted findings, each with a rationale.
+# The CI `zizmor` job runs at --persona=pedantic, so anything not listed
+# here fails the build.
+
+rules:
+  # dtolnay/rust-toolchain is deliberate, not superfluous: it pins the
+  # toolchain snapshot by commit SHA, installs rustfmt/clippy components
+  # reproducibly, and honors rust-toolchain.toml — the preinstalled runner
+  # toolchain drifts with the image.
+  superfluous-actions:
+    ignore:
+      - ci.yml
+      - stress.yml
+      - release.yml

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,31 @@ intended to process untrusted input in production. That said, bugs that allow
 a spawned program's output to corrupt the harness process (e.g. memory safety
 issues in escape-sequence handling) are treated as security issues.
 
+## Posture
+
+What the project does continuously, enforced by required CI on every change:
+
+- **No `unsafe` code** in the crate (`unsafe_code` lint, clippy
+  `-D warnings`). Escape sequences from the child are parsed by pure-Rust
+  code; nothing from the terminal stream is ever executed or evaluated.
+- **Dependency policy** (`cargo-deny` job): RUSTSEC advisories, yanked
+  crates, license allowlist, and crates.io-only sources — on every PR, with
+  weekly grouped Dependabot updates and Dependabot alerts enabled.
+- **Workflow security** (`zizmor` job at `--persona=pedantic`): every
+  GitHub Action is pinned to a full commit SHA, checkouts don't persist
+  credentials, the workflow token is read-only by default with write scopes
+  granted per job, and inputs reach shell steps only via environment
+  variables. Accepted findings are documented in `.github/zizmor.yml`.
+- **Release integrity**: `v*` tags are ruleset-protected (admin-only),
+  releases re-run the full CI gates, and publishing prefers crates.io
+  Trusted Publishing (short-lived OIDC tokens) over stored secrets.
+- **Provenance**: every commit requires a DCO sign-off from a human author
+  of record; bot-authored commits are rejected by CI.
+
+Resource-exhaustion notes for the paranoid: the emulator runs with zero
+scrollback, the reader uses a fixed buffer, every wait is deadline-bounded,
+and a hostile child can at worst waste its own test's time budget.
+
 ## Supported versions
 
 | Version        | Supported          |


### PR DESCRIPTION
Audit pass with cargo-deny (fresh advisory DB), gitleaks (full
history), zizmor 1.29.0 at --persona=pedantic, and a manual review of
workflows, policy scripts, and the library's untrusted-input paths.
Scanners came back clean except zizmor; every zizmor finding is fixed:

- all 28 action references pinned to full commit SHAs (tag noted in a
  comment; Dependabot still bumps them); dtolnay/rust-toolchain gets
  explicit 'toolchain:' inputs since a SHA ref no longer names one
- persist-credentials: false on all 12 checkouts — no job pushes via
  git, so no token belongs in .git/config
- commit-policy: pull-requests:write moved from workflow to job scope
- script arguments flow through env vars, not inline template
  expansion (defense in depth; the values are SHAs either way)
- concurrency groups on commit-policy (supersede), stress and release
  (queue, never cancel mid-run/mid-publish)
- new required 'zizmor' CI job runs the same pedantic audit on every
  change; deliberately-accepted findings documented in .github/zizmor.yml
- SECURITY.md gains a Posture section describing the enforced model

Also (out-of-band, via API): active ruleset 'protect-release-tags'
restricting v* tag create/update/delete to repo admins, so only a
maintainer can trigger the release pipeline.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
