### PR TITLE
docs: editorial pass over public wording; add Screen::cols/rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ listed under a **Changed** or **Removed** heading.
   for application exit codes. (`ExitStatus` is `Clone` but no longer `Copy`.)
 - `Screen`'s `Debug` is now the compact header+text rendering: a failing
   `Result` test prints a readable screen instead of a one-line cell dump.
+- `Screen::cols()` and `Screen::rows()`: named size accessors, so nobody
+  has to remember that `size()` is `(cols, rows)` while cells are
+  addressed `(row, col)`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ flowchart TB
     end
   end
   subgraph kernel["kernel"]
-    pty["real pty<br/>line discipline · TIOCSWINSZ → SIGWINCH"]
+    PTY["real PTY<br/>line discipline · TIOCSWINSZ → SIGWINCH"]
   end
   app["your app, unmodified<br/>believes it owns a terminal"]
 
   test -->|"send(Key) · send_str"| api
-  api -->|"xterm byte sequences"| pty
-  api -.->|"resize · kernel delivers SIGWINCH"| pty
-  pty -->|stdin| app
-  app -->|"stdout · escape sequences"| pty
-  pty -->|bytes| reader
+  api -->|"xterm byte sequences"| PTY
+  api -.->|"resize · kernel delivers SIGWINCH"| PTY
+  PTY -->|stdin| app
+  app -->|"stdout · escape sequences"| PTY
+  PTY -->|bytes| reader
   reader -->|"process, under one lock"| emu
   emu -->|"snapshot"| screen
   screen -->|"predicates · insta snapshots · screen dumps in every timeout"| test
@@ -126,7 +126,7 @@ design. termlens's position:
 - Unix only for now (Linux + macOS in CI). The PTY layer (`portable-pty`)
   supports ConPTY, so Windows is planned, not designed out.
 - A child that writes and exits within its first milliseconds can lose
-  output to the OS pty teardown (macOS especially). Long-lived TUIs are
+  output to the OS PTY teardown (macOS especially). Long-lived TUIs are
   unaffected; for run-and-exit programs, end the script with a `read` and
   release it after asserting — see the "instant-exit caveat" in
   [docs/DESIGN.md](docs/DESIGN.md).
@@ -151,7 +151,10 @@ reports: [SECURITY.md](SECURITY.md).
 ## License
 
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
-[MIT license](LICENSE-MIT) at your option. Unless you explicitly state
+[MIT license](LICENSE-MIT) at your option — the Rust ecosystem's standard
+dual license. Apache-2.0 carries an express patent grant; MIT is maximally
+simple and GPLv2-compatible. Offering both lets every downstream user pick
+whichever their project or policy needs. Unless you explicitly state
 otherwise, any contribution intentionally submitted for inclusion in the
 work by you, as defined in the Apache-2.0 license, shall be dual licensed
 as above, without any additional terms or conditions.

--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
     },
 
     /// A PTY control operation (open, resize, reader/writer setup) failed.
-    #[error("pty error: {0}")]
+    #[error("PTY error: {0}")]
     Pty(String),
 
     /// An OS-level I/O error (e.g. while waiting on the child process).

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -132,8 +132,22 @@ impl Screen {
         }
     }
 
-    /// Screen size as `(cols, rows)` — width × height, matching
-    /// [`TerminalBuilder::size`](crate::TerminalBuilder::size).
+    /// Number of columns (the screen's width).
+    #[must_use]
+    pub fn cols(&self) -> u16 {
+        self.cols
+    }
+
+    /// Number of rows (the screen's height).
+    #[must_use]
+    pub fn rows(&self) -> u16 {
+        self.rows
+    }
+
+    /// Screen size as `([cols](Self::cols), [rows](Self::rows))` — width ×
+    /// height, matching [`TerminalBuilder::size`](crate::TerminalBuilder::size).
+    /// Note the order differs from cell addressing, which is `(row, col)`;
+    /// prefer the named accessors when in doubt.
     #[must_use]
     pub fn size(&self) -> (u16, u16) {
         (self.cols, self.rows)
@@ -347,6 +361,7 @@ mod tests {
         assert!(s.cell(0, 10).is_none());
         assert_eq!(s.cursor(), (1, 2, true));
         assert_eq!(s.size(), (10, 2));
+        assert_eq!((s.cols(), s.rows()), (10, 2));
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -29,7 +29,7 @@ const DRAIN_GRACE: Duration = Duration::from_millis(500);
 /// Serializes every PTY *lifecycle edge* (open+spawn on one side, kill+reap+
 /// master-close on the other) across all `Terminal`s in this process.
 ///
-/// Why: macOS tears ptys down with `revoke()`, and pty device numbers are
+/// Why: macOS tears PTYs down with `revoke()`, and PTY device numbers are
 /// recycled immediately. With concurrent terminals, one thread's teardown
 /// can race another thread's `openpty()` **on the same recycled device**,
 /// and the late revoke hangs up the brand-new session — the fresh child
@@ -224,7 +224,7 @@ impl TerminalBuilder {
             .join(" ");
 
         // Hold the lifecycle lock across openpty → spawn → slave close, so
-        // no concurrent Terminal teardown can revoke our fresh pty device.
+        // no concurrent Terminal teardown can revoke our fresh PTY device.
         let lifecycle = pty_lifecycle_guard();
 
         let pty = native_pty_system();
@@ -251,18 +251,18 @@ impl TerminalBuilder {
 
         // Attach the reader thread BEFORE spawning the child: a program that
         // writes and exits within its first millisecond must find a drain
-        // already running. (macOS's pty layer can discard output still
+        // already running. (macOS's PTY layer can discard output still
         // buffered at teardown — see docs/DESIGN.md §2 — so the window
         // between child start and first read must be as close to zero as
         // userspace can make it.)
         let reader = pair
             .master
             .try_clone_reader()
-            .map_err(|e| Error::Pty(format!("cloning pty reader failed: {e}")))?;
+            .map_err(|e| Error::Pty(format!("cloning PTY reader failed: {e}")))?;
         let writer = pair
             .master
             .take_writer()
-            .map_err(|e| Error::Pty(format!("taking pty writer failed: {e}")))?;
+            .map_err(|e| Error::Pty(format!("taking PTY writer failed: {e}")))?;
 
         let shared = Arc::new(Monitor::new(EmuState {
             emu: Box::new(Vt100Emulator::new(self.rows, self.cols)),
@@ -322,7 +322,7 @@ fn reader_loop(mut reader: Box<dyn Read + Send>, shared: &Monitor<EmuState>) {
 /// and reaps the child — tests never leak zombies, even on panic.
 pub struct Terminal {
     child: Box<dyn portable_pty::Child + Send + Sync>,
-    // Option only so Drop can close them under the pty lifecycle lock;
+    // Option only so Drop can close them under the PTY lifecycle lock;
     // both are Some for the entire life of the value outside Drop.
     master: Option<Box<dyn portable_pty::MasterPty + Send>>,
     writer: Option<Box<dyn Write + Send>>,
@@ -422,9 +422,8 @@ impl Terminal {
     ///
     /// This is a heuristic: "no output for N ms" is evidence, not proof,
     /// that the application finished rendering. Prefer
-    /// [`wait_until`](Self::wait_until) on visible content where possible;
-    /// see
-    /// `docs/DESIGN.md` for the discussion and the planned frame-sync
+    /// [`wait_until`](Self::wait_until) on visible content where possible.
+    /// `docs/DESIGN.md` discusses the trade-off and the planned frame-sync
     /// alternative.
     ///
     /// # Errors
@@ -550,9 +549,9 @@ impl Drop for Terminal {
     /// joined here — a grandchild holding the PTY open must not hang Drop.
     ///
     /// The whole teardown (including closing the master/writer fds) runs
-    /// under the process-wide pty lifecycle lock: on macOS, letting a
+    /// under the process-wide PTY lifecycle lock: on macOS, letting a
     /// master close overlap a concurrent `openpty()` can revoke the *other*
-    /// terminal's freshly recycled pty device (see `PTY_LIFECYCLE` in this module).
+    /// terminal's freshly recycled PTY device (see `PTY_LIFECYCLE` in this module).
     fn drop(&mut self) {
         let _lifecycle = pty_lifecycle_guard();
         if self.exit_status.is_none() {
@@ -562,7 +561,7 @@ impl Drop for Terminal {
                 let _ = self.child.wait();
             }
         }
-        // Close the pty fds while still holding the lock.
+        // Close the PTY fds while still holding the lock.
         drop(self.writer.take());
         drop(self.master.take());
     }

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -5,7 +5,7 @@
 //!
 //! Pattern note: every script that must *print something we assert on*
 //! ends with a `read` guard, and we send Enter only after the assertion.
-//! Output written immediately before exit can be discarded by macOS's pty
+//! Output written immediately before exit can be discarded by macOS's PTY
 //! teardown (docs/DESIGN.md §2); keeping the child alive until the harness
 //! has seen the bytes makes these tests deterministic on every platform.
 
@@ -21,8 +21,8 @@ fn sh(script: &str) -> termlens::Result<Terminal> {
 
 #[test]
 fn echo_reaches_the_screen_and_child_exits_cleanly() -> termlens::Result<()> {
-    let mut t = sh("echo hello from a real pty; read guard")?;
-    t.wait_until(|s| s.contains("hello from a real pty"))?;
+    let mut t = sh("echo hello from a real PTY; read guard")?;
+    t.wait_until(|s| s.contains("hello from a real PTY"))?;
     t.send(Key::Enter);
     let status = t.wait_exit()?;
     assert!(status.success(), "full status: {status}");
@@ -32,7 +32,7 @@ fn echo_reaches_the_screen_and_child_exits_cleanly() -> termlens::Result<()> {
 
 #[test]
 fn exit_codes_are_reported() -> termlens::Result<()> {
-    // The `read` keeps the exit from racing pty setup; the line discipline
+    // The `read` keeps the exit from racing PTY setup; the line discipline
     // buffers our Enter even if it lands before `read` starts.
     let mut t = sh("read guard; exit 7")?;
     t.send(Key::Enter);

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -93,7 +93,7 @@ fn form_echo_round_trips_typed_input_and_special_keys() -> termlens::Result<()> 
     t.send_str("hello");
     t.wait_until(|s| s.contains("input: hello"))?;
 
-    // Each special key must round-trip: our xterm encoding -> pty ->
+    // Each special key must round-trip: our xterm encoding -> PTY ->
     // crossterm's parser inside the fixture -> stable name on screen.
     for (key, name) in [
         (Key::Up, "last: up"),

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -12,8 +12,8 @@ flowchart TB
   l4["4 · assertions<br/>wait_until / wait_idle / wait_exit · Screen queries · insta snapshots"]
   l3["3 · Screen<br/>immutable Arc-backed grid snapshots · Cell · Style · cursor — termlens's own types"]
   l2["2 · emulator<br/>internal trait: process · snapshot · mid_sequence · set_size — v0.1 backend: vt100"]
-  l1["1 · pty<br/>portable-pty · reader thread · resize TIOCSWINSZ → SIGWINCH · lifecycle lock"]
-  app["child app<br/>spawned in the pty, unmodified"]
+  l1["1 · PTY<br/>portable-pty · reader thread · resize TIOCSWINSZ → SIGWINCH · lifecycle lock"]
+  app["child app<br/>spawned in the PTY, unmodified"]
 
   app -->|"escape-sequence bytes"| l1
   l1 -->|"reader thread · mutate under lock, notify waiters"| l2
@@ -77,10 +77,10 @@ corner of a frame, or the cursor's resting position
 an early marker and snapshotting is a race at chunk boundaries; the stress
 workflow found exactly that in our own suite.
 
-### The instant-exit caveat (macOS pty teardown)
+### The instant-exit caveat (macOS PTY teardown)
 
 A child that **writes and exits within its first milliseconds** races the
-platform's pty teardown: on macOS, bytes still buffered in the kernel when
+platform's PTY teardown: on macOS, bytes still buffered in the kernel when
 the slave side closes can be discarded, and teardown can even surface as a
 signal-death instead of the real exit code. Stress-testing found this at
 roughly 1 in 80 instant-exit spawns under load. termlens narrows the window
@@ -92,11 +92,11 @@ last action a `read` on stdin, assert on its output, then send Enter and
 `wait_exit`. Real TUI applications are unaffected — they live far longer
 than the window and exit on request.
 
-Related, and fixed inside the library: macOS tears ptys down with
-`revoke()` and recycles pty device numbers immediately, so with concurrent
+Related, and fixed inside the library: macOS tears PTYs down with
+`revoke()` and recycles PTY device numbers immediately, so with concurrent
 terminals one thread's teardown could revoke another thread's *freshly
-opened* pty and kill its child at birth (~1/800 spawns under CI load; the
-same suite ran 100/100 on Linux). termlens therefore serializes every pty
+opened* PTY and kill its child at birth (~1/800 spawns under CI load; the
+same suite ran 100/100 on Linux). termlens therefore serializes every PTY
 lifecycle edge — open+spawn on one side, kill+reap+close on the other —
 behind a process-wide lock (`PTY_LIFECYCLE` in `terminal.rs`). The lock is
 held for microseconds per edge; steady-state I/O never touches it.


### PR DESCRIPTION
Reviewed every public-facing surface (crate docs, rustdoc, README,
DESIGN, comments) for concision and consistency. The prose was already
in good shape; the concrete fixes:

- standardize 'PTY' capitalization in prose everywhere (code
  identifiers like openpty/portable-pty untouched)
- Screen::cols() and Screen::rows(): named accessors that remove the
  one real API footgun — size() returning (cols, rows) while cells are
  addressed (row, col); size() now documents the difference and points
  at the named accessors
- reflow an awkwardly wrapped wait_idle paragraph
- README license section now says WHY the dual license: Apache-2.0 for
  the patent grant, MIT for simplicity and GPLv2 compatibility, the
  ecosystem-standard pairing

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
