### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,13 @@ jobs:
       # Preferred auth: crates.io Trusted Publishing. Needs the one-time
       # linkage of this repo+workflow on crates.io (docs/RELEASING.md).
       # Until that exists, the step fails soft and we fall back to a
-      # CRATES_IO_TOKEN repository secret.
+      # CARGO_REGISTRY_TOKEN repository secret.
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
         continue-on-error: true
       - run: cargo publish -p termlens --locked
         env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
 
   github-release:
     name: GitHub release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-09
+
 ### Changed
 
 - Renamed the project from `termtest` to `termlens` before first publish:

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -110,7 +110,7 @@ Real-world findings the pipeline caught (working exactly as designed):
    - Fallback — token: create an API token at
      <https://crates.io/settings/tokens> (scope: `publish-new`,
      `publish-update`), then
-     `gh secret set CRATES_IO_TOKEN --repo vyncint/termlens`.
+     `gh secret set CARGO_REGISTRY_TOKEN --repo vyncint/termlens`.
 2. **Commit email + signing.** History is authored as
    `Vyncint Ng <vyncint@icloud.com>`. Add **and verify** that address on
    your GitHub account (*Settings → Emails*) — it does two things: links
@@ -127,11 +127,11 @@ Real-world findings the pipeline caught (working exactly as designed):
    # then: GitHub → Settings → SSH and GPG keys → New SSH key → type "Signing key"
    ```
 
-3. **Git remote / SSH identity on this machine.** Your ssh key
-   authenticates as `chivy1204`, which cannot see this private repo, so the
-   remote was switched to HTTPS using the `gh` credential helper (active
-   account `vyncint`). Keep it, or set up a per-account SSH alias if you
-   prefer SSH.
+3. **Git remote / SSH identity on this machine.** Your SSH key
+   authenticates as a different GitHub account with no access to this
+   repo, so the remote was switched to HTTPS using the `gh` credential
+   helper (active account `vyncint`). Keep it, or set up a per-account
+   SSH alias if you prefer SSH.
 4. **Ruleset — applied AND enforcing** (the brief's plan caveat turned out
    obsolete: rulesets now enforce on Free-plan private repos). Ruleset
    `protect-main` (id 20601249): PR required before merge (0 approvals

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,14 +12,14 @@ One page, copy-pasteable. Maintainers only.
   1. crates.io → Account Settings → API Tokens → New token: scopes
      `publish-new` + `publish-update`, crate pattern `termlens`, short
      expiry (it is needed exactly once).
-  2. `gh secret set CRATES_IO_TOKEN --repo vyncint/termlens`
+  2. `gh secret set CARGO_REGISTRY_TOKEN --repo vyncint/termlens`
   `release.yml` tries Trusted Publishing first and falls back to this
   secret automatically.
 - **After the first publish, switch to Trusted Publishing** (tokenless):
   crates.io → termlens → Settings → Trusted Publishing → GitHub:
   repository `vyncint/termlens`, workflow `release.yml`, environment
   *(none)*. Then revoke the token and
-  `gh secret delete CRATES_IO_TOKEN --repo vyncint/termlens`.
+  `gh secret delete CARGO_REGISTRY_TOKEN --repo vyncint/termlens`.
 
 ## Cutting vX.Y.Z
 


### PR DESCRIPTION
Cut the 0.1.0 changelog section; point the release workflow's token
fallback at the CARGO_REGISTRY_TOKEN secret actually configured on the
repo (cargo's canonical name); generalize a machine-specific account
detail in the handoff before the repository goes public.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
