### PR TITLE
ci: bind publishing to the tag-restricted release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
     name: publish to crates.io
     needs: [ci, semver]
     runs-on: ubuntu-latest
+    # The `release` environment only deploys from v* tags, so an OIDC
+    # publish token can never be minted from a branch.
+    environment: release
     permissions:
       contents: read
       id-token: write # crates.io Trusted Publishing (GitHub OIDC)
@@ -78,16 +81,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
-      # Preferred auth: crates.io Trusted Publishing. Needs the one-time
-      # linkage of this repo+workflow on crates.io (docs/RELEASING.md).
-      # Until that exists, the step fails soft and we fall back to a
-      # CARGO_REGISTRY_TOKEN repository secret.
+      # Auth is crates.io Trusted Publishing (linked 2026-08-09): the
+      # action exchanges this job's OIDC token for a short-lived publish
+      # token. No stored secrets remain on the repository.
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
-        continue-on-error: true
       - run: cargo publish -p termlens --locked
         env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   github-release:
     name: GitHub release

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,24 +2,16 @@
 
 One page, copy-pasteable. Maintainers only.
 
-## Prerequisites (once)
+## Prerequisites (already satisfied)
 
-- A crates.io account (log in with GitHub) with a **verified email** —
-  publishing is refused without one.
-- **The first publish must use an API token** — crates.io has no
-  "pending publisher" feature (RFC 3691), so Trusted Publishing can only
-  be configured after the crate exists:
-  1. crates.io → Account Settings → API Tokens → New token: scopes
-     `publish-new` + `publish-update`, crate pattern `termlens`, short
-     expiry (it is needed exactly once).
-  2. `gh secret set CARGO_REGISTRY_TOKEN --repo vyncint/termlens`
-  `release.yml` tries Trusted Publishing first and falls back to this
-  secret automatically.
-- **After the first publish, switch to Trusted Publishing** (tokenless):
-  crates.io → termlens → Settings → Trusted Publishing → GitHub:
-  repository `vyncint/termlens`, workflow `release.yml`, environment
-  *(none)*. Then revoke the token and
-  `gh secret delete CARGO_REGISTRY_TOKEN --repo vyncint/termlens`.
+- Publishing auth is **crates.io Trusted Publishing** (linked
+  2026-08-09): crates.io → termlens → Settings → Trusted Publishing →
+  GitHub, repository `vyncint/termlens`, workflow `release.yml`. No
+  token or secret is stored anywhere.
+- The publish job runs in the **`release` GitHub environment**, which
+  only deploys from `v*` tags — an OIDC publish token can never be
+  minted from a branch. (Optionally set the environment name `release`
+  on the crates.io side too, for the server-side binding.)
 
 ## Cutting vX.Y.Z
 


### PR DESCRIPTION
Trusted Publishing is linked and verified end-to-end (the OIDC
exchange mints a token for this repo+workflow), so the token fallback
and its secret are gone. The publish job now runs in the new 'release'
GitHub environment, whose deployment policy only allows v* tags —
without it, anyone able to push a branch containing a release.yml
could mint a live publish token, which the verification probe itself
demonstrated. RELEASING.md prerequisites rewritten to match reality.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
