### PR TITLE
docs: README install section also adds insta

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ terminal.
 
 ```sh
 cargo add termlens --dev
+cargo add insta --dev    # used by the snapshot assertions below
 ```
 
 ## Example


### PR DESCRIPTION
Found by an end-to-end consumer test against the published crate: the
README example asserts with insta::assert_snapshot!, but the install
block only added termlens, so copying the example verbatim fails with
an unresolved import until insta is added too.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
