### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-08-09
+
+### Changed
+
+- Publishing runs exclusively through crates.io Trusted Publishing
+  (short-lived OIDC tokens), bound to a tag-restricted GitHub
+  environment; the repository stores no secrets at all.
+
+### Fixed
+
+- README install instructions now include `insta`, which the snapshot
+  examples use — copying the example verbatim previously failed on an
+  unresolved import.
+- README comparison table links `teatest` like every other row (first
+  external contribution).
+- CONTRIBUTING documents the fork-PR experience: the first-run approval
+  gate and where commit-policy failures are explained when the courtesy
+  comment cannot post.
+
 ## [0.1.0] - 2026-08-09
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossterm",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossterm",
 ]
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossterm",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -562,7 +562,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.1.0" }
+termlens = { path = "crates/termlens", version = "0.1.1" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
Docs-refresh patch: crates.io renders the README packaged at publish
time, so the post-0.1.0 fixes (insta in the install instructions, the
teatest link, fork-PR contributor notes) need a release to appear
there. Also the first release through the Trusted-Publishing-only,
environment-bound pipeline.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
