### PR TITLE
feat(terminal): wait_frame — predicates only on complete frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Added
+
+- `Terminal::wait_frame(pred)`: evaluates the predicate only on **complete
+  frames** for applications that bracket repaints in DEC 2026 synchronized
+  updates — a torn, half-painted repaint is never observable. Apps that
+  don't emit synchronized output get a timeout error that says so and
+  points at `wait_until`.
+
+### Changed
+
+- `wait_idle` no longer resolves while a synchronized update is open: a
+  begun-but-unfinished repaint is mid-update by definition.
+
 ## [0.1.1] - 2026-08-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -109,11 +109,15 @@ design. termlens's position:
 - **Prefer `wait_until` on visible content.** It re-checks on every chunk
   of output and is exact: the condition either becomes true or you get a
   screen-carrying timeout.
-- **`wait_idle(quiet)` is an honest heuristic.** It resolves when nothing
-  arrived for `quiet` *and* the stream isn't mid-escape-sequence. Silence
-  is evidence a render finished — not proof. Use it for "the app settled",
-  not for precise sequencing. DEC mode 2026 (synchronized output) gives
-  real frame boundaries; a `wait_frame` built on it is on the roadmap.
+- **`wait_frame` gives exact frame boundaries** for apps that bracket
+  repaints in DEC 2026 synchronized updates (crossterm's
+  `BeginSynchronizedUpdate`/`EndSynchronizedUpdate`): the predicate only
+  ever sees complete frames, never a torn repaint.
+- **`wait_idle(quiet)` is an honest heuristic** for everything else. It
+  resolves when nothing arrived for `quiet`, the stream isn't
+  mid-escape-sequence, and no synchronized update is open. Silence is
+  evidence a render finished — not proof. Use it for "the app settled",
+  not for precise sequencing.
 - **Hermetic environments.** `env_clear()` blocks inheritance,
   `TERM=xterm-256color` is pinned by default, fixtures draw no clocks and
   no animations. The CI suite runs a 100-iteration

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -12,10 +12,22 @@ pub(crate) use self::vt100::Vt100Emulator;
 
 use crate::Screen;
 
+/// Outcome of feeding one segment of PTY bytes into the emulator.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Processed {
+    /// How many input bytes were consumed (> 0 for non-empty input).
+    pub(crate) consumed: usize,
+    /// True when consumption stopped because a synchronized update ended
+    /// (DEC 2026 ESU): the screen at this instant is a complete frame.
+    pub(crate) frame_complete: bool,
+}
+
 /// A VT emulator: consumes raw PTY bytes, maintains a screen grid.
 pub(crate) trait Emulator: Send {
-    /// Feed raw bytes from the PTY into the emulator.
-    fn process(&mut self, bytes: &[u8]);
+    /// Feed raw bytes from the PTY into the emulator. Stops early — with
+    /// `consumed < bytes.len()` — when a synchronized update ends, so the
+    /// caller can observe the completed frame before feeding the rest.
+    fn process(&mut self, bytes: &[u8]) -> Processed;
 
     /// Snapshot the current screen as an owned value.
     fn snapshot(&self) -> Screen;
@@ -24,6 +36,10 @@ pub(crate) trait Emulator: Send {
     /// or an incomplete UTF-8 character — used by `wait_idle` to avoid
     /// declaring idleness mid-update.
     fn mid_sequence(&self) -> bool;
+
+    /// True while the stream is inside a DEC 2026 synchronized update —
+    /// the app has begun a repaint and not finished it.
+    fn in_sync_update(&self) -> bool;
 
     /// Resize the emulated grid to `rows` × `cols`.
     fn set_size(&mut self, rows: u16, cols: u16);

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -1,11 +1,17 @@
 //! A minimal escape-sequence progress tracker.
 //!
 //! This is deliberately NOT a VT parser — the emulator interprets the
-//! stream. It answers exactly one question for `wait_idle`: *did the byte
-//! stream end in the middle of something?* — i.e. inside an escape/CSI/OSC
-//! /DCS sequence or a partially received UTF-8 character. Declaring a
-//! terminal "idle" between the two halves of a split `ESC [ 3 1 m` would
-//! hand tests a torn frame.
+//! stream. It answers two questions:
+//!
+//! 1. For `wait_idle`: *did the byte stream end in the middle of
+//!    something?* — an escape/CSI/OSC/DCS sequence or a partial UTF-8
+//!    character. Declaring a terminal "idle" between the two halves of a
+//!    split `ESC [ 3 1 m` would hand tests a torn frame.
+//! 2. For `wait_frame`: *where do synchronized updates begin and end?*
+//!    DEC private mode 2026 (`CSI ? 2026 h` / `CSI ? 2026 l`) brackets a
+//!    repaint; the byte that ends one marks a complete frame. Parameters
+//!    are parsed incrementally in O(1) space, and `?2026` is recognized
+//!    anywhere in a multi-mode list such as `CSI ? 2026 ; 25 h`.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum State {
@@ -27,11 +33,30 @@ enum State {
     DcsEsc,
 }
 
+/// What one byte did to the synchronized-update state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncEvent {
+    /// No change.
+    None,
+    /// The byte completed a `CSI ? 2026 … h`: a synchronized update began.
+    Begin,
+    /// The byte completed a `CSI ? 2026 … l`: a frame is now complete.
+    End,
+}
+
 #[derive(Debug)]
 pub(crate) struct SeqTracker {
     state: State,
     /// Continuation bytes still expected for the current UTF-8 character.
     utf8_remaining: u8,
+    /// True between a 2026 `h` and the matching `l`.
+    sync_update: bool,
+    // Incremental CSI parameter scanner (only what mode 2026 needs).
+    csi_private: bool,
+    csi_invalid: bool,
+    csi_first: bool,
+    csi_param: u32,
+    csi_saw_2026: bool,
 }
 
 impl SeqTracker {
@@ -39,9 +64,16 @@ impl SeqTracker {
         Self {
             state: State::Ground,
             utf8_remaining: 0,
+            sync_update: false,
+            csi_private: false,
+            csi_invalid: false,
+            csi_first: true,
+            csi_param: 0,
+            csi_saw_2026: false,
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn feed(&mut self, bytes: &[u8]) {
         for &b in bytes {
             self.step(b);
@@ -52,12 +84,70 @@ impl SeqTracker {
         self.state != State::Ground || self.utf8_remaining > 0
     }
 
-    fn step(&mut self, b: u8) {
+    /// True while the stream is inside a DEC 2026 synchronized update.
+    pub(crate) fn in_sync_update(&self) -> bool {
+        self.sync_update
+    }
+
+    fn reset_csi_scanner(&mut self) {
+        self.csi_private = false;
+        self.csi_invalid = false;
+        self.csi_first = true;
+        self.csi_param = 0;
+        self.csi_saw_2026 = false;
+    }
+
+    /// Track one CSI parameter/intermediate byte.
+    fn scan_csi_byte(&mut self, b: u8) {
+        match b {
+            b'?' if self.csi_first => self.csi_private = true,
+            b'0'..=b'9' => {
+                self.csi_param = self
+                    .csi_param
+                    .saturating_mul(10)
+                    .saturating_add(u32::from(b - b'0'));
+            }
+            b';' => {
+                if self.csi_param == 2026 {
+                    self.csi_saw_2026 = true;
+                }
+                self.csi_param = 0;
+            }
+            // Sub-parameters, intermediates, or other private markers:
+            // whatever this sequence is, it is not a plain mode 2026 set.
+            _ => self.csi_invalid = true,
+        }
+        self.csi_first = false;
+    }
+
+    /// The sync-state change (if any) implied by a CSI final byte.
+    fn csi_final(&mut self, b: u8) -> SyncEvent {
+        if !self.csi_private || self.csi_invalid {
+            return SyncEvent::None;
+        }
+        if !(self.csi_saw_2026 || self.csi_param == 2026) {
+            return SyncEvent::None;
+        }
+        match b {
+            b'h' => {
+                self.sync_update = true;
+                SyncEvent::Begin
+            }
+            b'l' => {
+                self.sync_update = false;
+                SyncEvent::End
+            }
+            _ => SyncEvent::None,
+        }
+    }
+
+    pub(crate) fn step(&mut self, b: u8) -> SyncEvent {
         const ESC: u8 = 0x1b;
         const CAN: u8 = 0x18;
         const SUB: u8 = 0x1a;
         const BEL: u8 = 0x07;
 
+        let mut event = SyncEvent::None;
         self.state = match self.state {
             State::Ground => {
                 if b == ESC {
@@ -69,7 +159,10 @@ impl SeqTracker {
                 }
             }
             State::Esc => match b {
-                b'[' => State::Csi,
+                b'[' => {
+                    self.reset_csi_scanner();
+                    State::Csi
+                }
                 b']' => State::Osc,
                 // DCS, SOS, PM, APC — string sequences terminated by ST.
                 b'P' | b'X' | b'^' | b'_' => State::Dcs,
@@ -86,11 +179,17 @@ impl SeqTracker {
                 _ => State::Ground,
             },
             State::Csi => match b {
-                0x40..=0x7e => State::Ground,
+                0x40..=0x7e => {
+                    event = self.csi_final(b);
+                    State::Ground
+                }
                 ESC => State::Esc,
                 CAN | SUB => State::Ground,
                 // Parameter/intermediate bytes (and embedded C0 controls).
-                _ => State::Csi,
+                _ => {
+                    self.scan_csi_byte(b);
+                    State::Csi
+                }
             },
             State::Osc => match b {
                 BEL => State::Ground,
@@ -110,11 +209,11 @@ impl SeqTracker {
                 // escape sequence; reprocess this byte in Esc state.
                 _ => {
                     self.state = State::Esc;
-                    self.step(b);
-                    return;
+                    return self.step(b);
                 }
             },
         };
+        event
     }
 
     fn track_utf8(&mut self, b: u8) {
@@ -195,6 +294,49 @@ mod tests {
     #[test]
     fn can_aborts_sequences() {
         assert!(!fed(b"\x1b[31\x18").mid_sequence());
+    }
+
+    #[test]
+    fn sync_update_events_fire_on_2026_set_and_reset() {
+        let mut t = SeqTracker::new();
+        let events: Vec<SyncEvent> = b"\x1b[?2026h".iter().map(|&b| t.step(b)).collect();
+        assert_eq!(*events.last().unwrap(), SyncEvent::Begin);
+        assert!(t.in_sync_update());
+        let events: Vec<SyncEvent> = b"\x1b[?2026l".iter().map(|&b| t.step(b)).collect();
+        assert_eq!(*events.last().unwrap(), SyncEvent::End);
+        assert!(!t.in_sync_update());
+    }
+
+    #[test]
+    fn sync_2026_is_recognized_anywhere_in_a_multi_mode_list() {
+        let mut t = SeqTracker::new();
+        t.feed(b"\x1b[?2026;25h");
+        assert!(t.in_sync_update());
+        let mut t = SeqTracker::new();
+        t.feed(b"\x1b[?25;2026h");
+        assert!(t.in_sync_update());
+    }
+
+    #[test]
+    fn lookalike_sequences_do_not_toggle_sync() {
+        let mut t = SeqTracker::new();
+        t.feed(b"\x1b[2026h"); // not private (no '?')
+        assert!(!t.in_sync_update());
+        t.feed(b"\x1b[?2026m"); // wrong final byte
+        assert!(!t.in_sync_update());
+        t.feed(b"\x1b[?2026:1h"); // sub-parameter form: not a plain mode set
+        assert!(!t.in_sync_update());
+        t.feed(b"\x1b[?20260h"); // different mode number
+        assert!(!t.in_sync_update());
+    }
+
+    #[test]
+    fn sync_survives_an_aborted_csi_inside_the_update() {
+        let mut t = SeqTracker::new();
+        t.feed(b"\x1b[?2026h\x1b[31\x18"); // CAN aborts the SGR, not the frame
+        assert!(t.in_sync_update());
+        t.feed(b"\x1b[?2026l");
+        assert!(!t.in_sync_update());
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -1,8 +1,8 @@
 //! The `vt100`-crate backend. Public types never leak from here: every
 //! snapshot converts vt100's grid into termlens's own [`Screen`].
 
-use super::seq::SeqTracker;
-use super::Emulator;
+use super::seq::{SeqTracker, SyncEvent};
+use super::{Emulator, Processed};
 use crate::screen::{Cell, Color, Screen, Style};
 
 pub(crate) struct Vt100Emulator {
@@ -21,9 +21,21 @@ impl Vt100Emulator {
 }
 
 impl Emulator for Vt100Emulator {
-    fn process(&mut self, bytes: &[u8]) {
-        self.tracker.feed(bytes);
+    fn process(&mut self, bytes: &[u8]) -> Processed {
+        for (i, &byte) in bytes.iter().enumerate() {
+            if self.tracker.step(byte) == SyncEvent::End {
+                self.parser.process(&bytes[..=i]);
+                return Processed {
+                    consumed: i + 1,
+                    frame_complete: true,
+                };
+            }
+        }
         self.parser.process(bytes);
+        Processed {
+            consumed: bytes.len(),
+            frame_complete: false,
+        }
     }
 
     fn snapshot(&self) -> Screen {
@@ -53,6 +65,10 @@ impl Emulator for Vt100Emulator {
 
     fn mid_sequence(&self) -> bool {
         self.tracker.mid_sequence()
+    }
+
+    fn in_sync_update(&self) -> bool {
+        self.tracker.in_sync_update()
     }
 
     fn set_size(&mut self, rows: u16, cols: u16) {
@@ -90,9 +106,17 @@ fn convert_color(color: ::vt100::Color) -> Color {
 mod tests {
     use super::*;
 
+    /// Feed a whole stream, looping across frame-boundary stops.
+    fn feed_all(emu: &mut Vt100Emulator, bytes: &[u8]) {
+        let mut off = 0;
+        while off < bytes.len() {
+            off += emu.process(&bytes[off..]).consumed;
+        }
+    }
+
     fn emu_with(bytes: &[u8]) -> Vt100Emulator {
         let mut emu = Vt100Emulator::new(4, 10);
-        emu.process(bytes);
+        feed_all(&mut emu, bytes);
         emu
     }
 
@@ -135,10 +159,41 @@ mod tests {
     #[test]
     fn mid_sequence_tracks_partial_escape() {
         let mut emu = Vt100Emulator::new(4, 10);
-        emu.process(b"text\x1b[3");
+        feed_all(&mut emu, b"text\x1b[3");
         assert!(emu.mid_sequence());
-        emu.process(b"1m");
+        feed_all(&mut emu, b"1m");
         assert!(!emu.mid_sequence());
+    }
+
+    #[test]
+    fn process_stops_at_the_end_of_a_synchronized_update() {
+        let mut emu = Vt100Emulator::new(4, 10);
+        let stream = b"\x1b[?2026hframe1\x1b[?2026lnext";
+
+        let first = emu.process(stream);
+        assert!(first.frame_complete);
+        // Everything through the ESU is consumed; "next" is not.
+        assert_eq!(
+            &stream[..first.consumed],
+            b"\x1b[?2026hframe1\x1b[?2026l" as &[u8]
+        );
+        // The screen at the stop is the complete frame, untouched by "next".
+        assert_eq!(emu.snapshot().text(), "frame1\n\n\n");
+        assert!(!emu.in_sync_update());
+
+        let rest = emu.process(&stream[first.consumed..]);
+        assert!(!rest.frame_complete);
+        assert!(emu.snapshot().contains("frame1next"));
+    }
+
+    #[test]
+    fn in_sync_update_is_true_between_bsu_and_esu() {
+        let mut emu = Vt100Emulator::new(4, 10);
+        feed_all(&mut emu, b"\x1b[?2026hpartial");
+        assert!(emu.in_sync_update());
+        assert!(!emu.mid_sequence()); // the escape itself is finished
+        feed_all(&mut emu, b"\x1b[?2026l");
+        assert!(!emu.in_sync_update());
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -110,6 +110,10 @@ struct EmuState {
     /// The last snapshot built, valid while `generation` is unchanged.
     /// `Screen` is Arc-backed, so serving the cache is a cheap clone.
     snapshot_cache: Option<(u64, Screen)>,
+    /// Completed synchronized updates (DEC 2026) observed so far.
+    frames_seen: u64,
+    /// The screen exactly as of the most recent completed frame.
+    last_frame: Option<Screen>,
 }
 
 impl EmuState {
@@ -120,6 +124,8 @@ impl EmuState {
             eof: false,
             generation: 0,
             snapshot_cache: None,
+            frames_seen: 0,
+            last_frame: None,
         }
     }
 
@@ -355,7 +361,19 @@ fn reader_loop(mut reader: Box<dyn Read + Send>, shared: &Monitor<EmuState>) {
         match reader.read(&mut buf) {
             Ok(0) => break,
             Ok(n) => shared.mutate(|state| {
-                state.emu.process(&buf[..n]);
+                // The emulator stops at each DEC 2026 frame end, so the
+                // snapshot taken there is exactly the completed frame —
+                // even when the same chunk already carries the next
+                // frame's opening bytes.
+                let mut offset = 0;
+                while offset < n {
+                    let processed = state.emu.process(&buf[offset..n]);
+                    offset += processed.consumed;
+                    if processed.frame_complete {
+                        state.frames_seen += 1;
+                        state.last_frame = Some(state.emu.snapshot());
+                    }
+                }
                 state.touch();
             }),
             Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
@@ -478,6 +496,88 @@ impl Terminal {
         }
     }
 
+    /// Block until a **complete frame** satisfies `predicate`.
+    ///
+    /// For applications that bracket repaints in DEC 2026 synchronized
+    /// updates (`BeginSynchronizedUpdate` / `EndSynchronizedUpdate` in
+    /// crossterm), the predicate is evaluated only on screens exactly as
+    /// they stood when an update ended — never on a torn, half-painted
+    /// frame. This removes the discipline [`wait_until`](Self::wait_until)
+    /// demands (single predicate, wait on the last-painted region; see
+    /// `docs/DESIGN.md` §2).
+    ///
+    /// The frame completed most recently *before* the call is evaluated
+    /// first, so a fast application cannot slip a frame past you. Each
+    /// frame is evaluated at most once; if several frames complete within
+    /// one read burst, only the newest is seen — `wait_frame` guarantees
+    /// frame-consistent screens, not observation of every transient frame.
+    ///
+    /// ```
+    /// # fn main() -> termlens::Result<()> {
+    /// let mut t = termlens::Terminal::builder()
+    ///     .timeout(std::time::Duration::from_secs(10))
+    ///     .args(["-c", r"printf '\033[?2026hFrame ready\033[?2026l'; read quit"])
+    ///     .spawn("sh")?;
+    /// t.wait_frame(|screen| screen.contains("Frame ready"))?;
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Timeout`] at the deadline — with a pointed message when the
+    /// application never emitted a single synchronized update, since
+    /// `wait_frame` can then never succeed; use `wait_until` for such apps.
+    /// [`Error::Eof`] as soon as the PTY closes with no matching frame.
+    pub fn wait_frame(&mut self, mut predicate: impl FnMut(&Screen) -> bool) -> Result<()> {
+        const WHAT: &str = "a complete frame matching the predicate";
+        let deadline = Instant::now() + self.default_timeout;
+        let mut seen_frame = None;
+        let outcome = self.shared.wait_until(deadline, |state| {
+            if state.frames_seen > 0 && seen_frame != Some(state.frames_seen) {
+                seen_frame = Some(state.frames_seen);
+                let frame = state
+                    .last_frame
+                    .clone()
+                    .expect("frames_seen > 0 implies a stored frame");
+                if predicate(&frame) {
+                    return Some(Ok(()));
+                }
+            }
+            if state.eof {
+                return Some(Err(Error::Eof {
+                    waiting_for: WHAT.into(),
+                    screen: state.peek_snapshot(),
+                }));
+            }
+            None
+        });
+        match outcome {
+            Ok(inner) => inner,
+            Err(Expired) => {
+                let (frames, screen) = {
+                    let mut guard = self.shared.lock();
+                    let screen = guard.last_frame.clone().unwrap_or_else(|| guard.snapshot());
+                    (guard.frames_seen, screen)
+                };
+                let waiting_for = if frames == 0 {
+                    "a complete frame — but the application never emitted a \
+                     DEC 2026 synchronized update. wait_frame needs repaints \
+                     bracketed in BeginSynchronizedUpdate/EndSynchronizedUpdate; \
+                     for other apps use wait_until (docs/DESIGN.md §2)"
+                        .to_owned()
+                } else {
+                    format!("{WHAT} ({frames} complete frames observed)")
+                };
+                Err(Error::Timeout {
+                    waiting_for,
+                    timeout: self.default_timeout,
+                    screen,
+                })
+            }
+        }
+    }
+
     /// Block until the terminal has been quiet — no bytes for `quiet` and
     /// the stream not ending mid-escape-sequence. EOF counts as idle
     /// (nothing more can arrive).
@@ -501,7 +601,7 @@ impl Terminal {
                 return Ok(());
             }
             let elapsed = guard.last_activity.elapsed();
-            if elapsed >= quiet && !guard.emu.mid_sequence() {
+            if elapsed >= quiet && !guard.emu.mid_sequence() && !guard.emu.in_sync_update() {
                 return Ok(());
             }
 

--- a/crates/termlens/tests/common/mod.rs
+++ b/crates/termlens/tests/common/mod.rs
@@ -1,0 +1,49 @@
+//! Shared helpers for integration tests (not a test binary itself).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Mutex;
+
+/// Fixture names already rebuilt by this test process.
+static BUILT: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// Path to a fixture binary (a sibling workspace member, so
+/// `CARGO_BIN_EXE_*` is unavailable). Always runs `cargo build -p`
+/// once per fixture per test process: `cargo test` links test
+/// harnesses into `deps/` but does not refresh the plain bin artifact,
+/// so an existing `target/<profile>/<name>` can be stale and would
+/// silently test old fixture code. The build no-ops in milliseconds
+/// when everything is fresh (and stress.yml prebuilds --all-targets).
+pub(crate) fn fixture_bin(name: &str) -> PathBuf {
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR").map_or_else(
+        || {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../..")
+                .join("target")
+        },
+        PathBuf::from,
+    );
+    let bin = target_dir.join(profile).join(name);
+
+    let mut built = BUILT.lock().unwrap();
+    if !built.iter().any(|b| b == name) {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let mut cmd = Command::new(cargo);
+        cmd.args(["build", "-p", name]);
+        if profile == "release" {
+            cmd.arg("--release");
+        }
+        let status = cmd.status().expect("failed to run cargo build");
+        assert!(status.success(), "cargo build -p {name} failed");
+        built.push(name.to_owned());
+    }
+    drop(built);
+
+    assert!(bin.exists(), "fixture binary missing at {}", bin.display());
+    bin
+}

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -6,55 +6,8 @@ use std::time::Duration;
 
 use termlens::{Key, Terminal};
 
-mod util {
-    use std::path::PathBuf;
-    use std::process::Command;
-    use std::sync::Mutex;
-
-    /// Fixture names already rebuilt by this test process.
-    static BUILT: Mutex<Vec<String>> = Mutex::new(Vec::new());
-
-    /// Path to a fixture binary (a sibling workspace member, so
-    /// `CARGO_BIN_EXE_*` is unavailable). Always runs `cargo build -p`
-    /// once per fixture per test process: `cargo test` links test
-    /// harnesses into `deps/` but does not refresh the plain bin artifact,
-    /// so an existing `target/<profile>/<name>` can be stale and would
-    /// silently test old fixture code. The build no-ops in milliseconds
-    /// when everything is fresh (and stress.yml prebuilds --all-targets).
-    pub(crate) fn fixture_bin(name: &str) -> PathBuf {
-        let profile = if cfg!(debug_assertions) {
-            "debug"
-        } else {
-            "release"
-        };
-        let target_dir = std::env::var_os("CARGO_TARGET_DIR").map_or_else(
-            || {
-                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                    .join("../..")
-                    .join("target")
-            },
-            PathBuf::from,
-        );
-        let bin = target_dir.join(profile).join(name);
-
-        let mut built = BUILT.lock().unwrap();
-        if !built.iter().any(|b| b == name) {
-            let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-            let mut cmd = Command::new(cargo);
-            cmd.args(["build", "-p", name]);
-            if profile == "release" {
-                cmd.arg("--release");
-            }
-            let status = cmd.status().expect("failed to run cargo build");
-            assert!(status.success(), "cargo build -p {name} failed");
-            built.push(name.to_owned());
-        }
-        drop(built);
-
-        assert!(bin.exists(), "fixture binary missing at {}", bin.display());
-        bin
-    }
-}
+mod common;
+use common as util;
 
 fn spawn_fixture(name: &str) -> termlens::Result<Terminal> {
     Terminal::builder()

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -1,0 +1,147 @@
+//! `wait_frame` (DEC 2026 synchronized output): predicates run only on
+//! complete frames, torn repaints are never observable, and apps that
+//! don't speak synchronized output fail with guidance instead of silence.
+
+use std::time::{Duration, Instant};
+
+use termlens::{Error, Key, Terminal};
+
+mod common;
+use common as util;
+
+fn spawn_form_echo() -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_secs(10))
+        .env_clear()
+        .spawn(util::fixture_bin("form-echo"))
+}
+
+#[test]
+fn the_frame_completed_before_the_call_is_evaluated() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    // The fixture's first synchronized frame has long completed by the time
+    // this wait starts; entry evaluation must still see it.
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+    t.send(Key::Esc);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn a_frame_is_internally_consistent() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    t.send_str("hi");
+    // Both the input line and the last-key line are painted in the same
+    // synchronized update; a frame satisfying one must satisfy the other.
+    t.wait_frame(|s| s.contains("input: hi"))?;
+    let frame_ok = std::cell::Cell::new(false);
+    t.wait_frame(|s| {
+        if s.contains("input: hi") {
+            frame_ok.set(s.contains("last: char:i"));
+            true
+        } else {
+            false
+        }
+    })?;
+    assert!(
+        frame_ok.get(),
+        "frame satisfied one row but not its sibling"
+    );
+
+    t.send(Key::Esc);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn a_torn_repaint_is_never_observed() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    // F2 paints "torn: left", flushes, sleeps 150ms, then paints " right"
+    // and ends the synchronized update. The bytes arrive in two bursts;
+    // the frame completes only with the second.
+    t.send(Key::F(2));
+    let mut observed = None;
+    t.wait_frame(|s| {
+        if s.contains("torn: left") {
+            observed = Some(s.row_text(5));
+            true
+        } else {
+            false
+        }
+    })?;
+    let row = observed.expect("predicate matched");
+    assert!(
+        row.contains("torn: left right"),
+        "wait_frame observed a torn frame: {row:?}"
+    );
+
+    t.send(Key::Esc);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn apps_without_synchronized_output_time_out_with_guidance() {
+    // hello-tui never emits DEC 2026.
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_millis(500))
+        .env_clear()
+        .spawn(util::fixture_bin("hello-tui"))
+        .unwrap();
+    t.wait_until(|s| s.contains("╯")).unwrap();
+
+    let start = Instant::now();
+    let err = t.wait_frame(|_| true).unwrap_err();
+    assert!(start.elapsed() >= Duration::from_millis(500));
+
+    let msg = err.to_string();
+    assert!(msg.contains("2026"), "no guidance in: {msg}");
+    assert!(msg.contains("wait_until"), "no alternative named in: {msg}");
+    assert!(err.screen().is_some(), "timeout must still embed a screen");
+
+    t.send(Key::Char('q'));
+    assert!(t.wait_exit().unwrap().success());
+}
+
+#[test]
+fn wait_frame_fails_fast_on_eof() {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(30))
+        .args(["-c", r"printf '\033[?2026hdone\033[?2026l'; read guard"])
+        .spawn("sh")
+        .unwrap();
+    t.wait_frame(|s| s.contains("done")).unwrap();
+    t.send(Key::Enter);
+
+    let start = Instant::now();
+    let err = t.wait_frame(|s| s.contains("never painted")).unwrap_err();
+    assert!(matches!(err, Error::Eof { .. }), "expected Eof, got: {err}");
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "EOF should fail fast"
+    );
+}
+
+#[test]
+fn wait_idle_does_not_resolve_inside_an_open_synchronized_update() {
+    // The frame never ends: BSU, content, then the app parks on `read`.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(600))
+        .args(["-c", r"printf '\033[?2026hhalf a frame'; read guard"])
+        .spawn("sh")
+        .unwrap();
+    t.wait_until(|s| s.contains("half a frame")).unwrap();
+
+    let err = t.wait_idle(Duration::from_millis(100)).unwrap_err();
+    assert!(
+        matches!(err, Error::Timeout { .. }),
+        "an open synchronized update must not count as idle: {err}"
+    );
+    // Drop kills the parked child.
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -51,14 +51,27 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
   reader delivers bytes (condvar notification), with a 50ms poll cap as a
   missed-wakeup backstop. Fails fast with `Error::Eof` the moment the PTY
   closes while `pred` is false: more waiting can never succeed.
+- `wait_frame(pred)` — evaluates `pred` **only on complete frames**. The
+  sequence tracker recognizes DEC private mode 2026 (`CSI ?2026 h/l`,
+  including multi-mode lists); the reader splits each chunk at every
+  frame end and snapshots the screen *at that instant*, so the predicate
+  sees exactly the frame as the app finished it — even when the same read
+  already carries the next frame's opening bytes. The frame completed
+  most recently before the call is evaluated first (fast apps can't slip
+  a frame past the wait). Honest caveat: frames that complete within one
+  read burst supersede each other — `wait_frame` guarantees
+  frame-consistent screens, not observation of every transient frame. An
+  app that never emits a synchronized update makes the timeout error say
+  so and point at `wait_until`.
 - `wait_idle(quiet)` — resolves when **no bytes for `quiet`** AND the
-  stream does not end mid-escape-sequence (or mid-UTF-8-character). The
-  second condition comes from a minimal sequence tracker (`emu/seq.rs`) —
-  not a VT parser, just enough state to answer "did the stream stop inside
-  an update?". EOF counts as idle. **This is a heuristic**: silence is
-  evidence of a finished render, not proof. Prefer `wait_until` on visible
-  content. Roadmap: DEC private mode 2026 (synchronized output) gives true
-  frame boundaries — a future `wait_frame` will use it where apps opt in.
+  stream does not end mid-escape-sequence (or mid-UTF-8-character) AND no
+  synchronized update is open (a begun-but-unfinished DEC 2026 repaint is
+  by definition mid-update). The sequence conditions come from a minimal
+  tracker (`emu/seq.rs`) — not a VT parser, just enough state to answer
+  "did the stream stop inside an update?". EOF counts as idle. **This is
+  a heuristic**: silence is evidence of a finished render, not proof.
+  Prefer `wait_until` on visible content, or `wait_frame` where the app
+  uses synchronized output.
 - `wait_exit()` — polls `try_wait` on a capped backoff ladder (1→20ms),
   then grace-drains the PTY (≤500ms) so the final screen is complete
   before returning. Idempotent via a cached status.

--- a/docs/announce-r-rust.md
+++ b/docs/announce-r-rust.md
@@ -1,0 +1,60 @@
+# Announcement draft — users.rust-lang.org
+
+Post at https://users.rust-lang.org → log in with GitHub → **New Topic** →
+category **announcements** → paste title and body below. Delete this file
+after posting (it is deliberately untracked and not linked from anywhere).
+
+The same text also works verbatim on the ratatui forum
+(https://forum.ratatui.rs) and as a #rustlang post elsewhere.
+
+---
+
+**Title:**
+
+termlens: test what your TUI actually renders — real PTY, emulated screen, insta snapshots
+
+**Body:**
+
+I kept wanting Playwright-style tests for terminal apps: spawn the real
+binary, look at what a user would *see*, assert on that. Stream matchers
+(rexpect/expectrl) can't answer "is the cursor on the third menu item?",
+and in-process backends like ratatui's `TestBackend` skip your real
+binary and the PTY layer entirely. So I built termlens:
+
+```rust
+let mut t = Terminal::builder()
+    .size(80, 24)
+    .env_clear()                      // hermetic: no host env leaks in
+    .spawn(env!("CARGO_BIN_EXE_myapp"))?;
+
+t.wait_until(|screen| screen.contains("Ready"))?;
+insta::assert_snapshot!(t.screen()); // snapshot the rendered grid
+
+t.send(Key::Char('q'));
+assert!(t.wait_exit()?.success());
+```
+
+How it works: your app runs in a real kernel PTY; a reader thread drains
+it continuously through a vt100 emulator into an immutable screen grid;
+waits are all deadline-bounded, and a timeout error embeds the full
+screen dump — so a CI log alone shows what the app was displaying.
+
+The part I'm proudest of is the flake story. CI runs the whole suite 100
+times on Linux **and** macOS before anything merges to the wait paths.
+That gate caught, among other things, a genuine macOS kernel race where
+pty teardown (`revoke()`) can hang up a *sibling thread's freshly opened
+pty* because device numbers recycle instantly — termlens serializes pty
+lifecycle edges behind a process-wide lock so your parallel tests don't
+hit it.
+
+Honest limitations (v0.1): Unix only for now (portable-pty supports
+ConPTY, so Windows is planned), no scrollback assertions, and styles are
+captured per-cell but not yet part of the text snapshot format.
+
+- crates.io: https://crates.io/crates/termlens (`cargo add termlens --dev`)
+- GitHub: https://github.com/vyncint/termlens
+- Design notes (wait semantics, snapshot format spec, the macOS pty war
+  stories): https://github.com/vyncint/termlens/blob/main/docs/DESIGN.md
+
+Feedback very welcome — especially from anyone testing ratatui apps in
+CI today.

--- a/fixtures/form-echo/src/main.rs
+++ b/fixtures/form-echo/src/main.rs
@@ -5,6 +5,13 @@
 //!
 //! Exit codes: 0 on Esc, 42 on Ctrl-X (exercises exit-status plumbing).
 //!
+//! Every redraw is bracketed in a DEC 2026 synchronized update, so this
+//! fixture also exercises `wait_frame`. F2 triggers a deliberately *torn*
+//! draw — half a row, a real 150ms pause, then the rest, all inside one
+//! synchronized update — to prove `wait_frame` never observes the tear.
+//! That sleep is the only nondeterminism in any fixture, and it affects
+//! timing only, never content.
+//!
 //! Fixture rules: deterministic — redraws only in response to input.
 
 use std::io::{self, Write};
@@ -13,7 +20,8 @@ use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::style::Print;
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen,
+    disable_raw_mode, enable_raw_mode, BeginSynchronizedUpdate, Clear, ClearType,
+    EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
 };
 use crossterm::{execute, queue};
 
@@ -56,6 +64,7 @@ fn describe(key: &KeyEvent) -> String {
 }
 
 fn draw(out: &mut impl Write, app: &App) -> io::Result<()> {
+    queue!(out, BeginSynchronizedUpdate)?;
     let lines = [
         "form-echo ready".to_string(),
         format!("input: {}", app.input),
@@ -70,6 +79,23 @@ fn draw(out: &mut impl Write, app: &App) -> io::Result<()> {
             Print(line)
         )?;
     }
+    queue!(out, EndSynchronizedUpdate)?;
+    out.flush()
+}
+
+/// Half a frame, a real pause, then the rest — inside ONE synchronized
+/// update. An unsynchronized observer sees the tear; `wait_frame` must not.
+fn draw_torn(out: &mut impl Write) -> io::Result<()> {
+    queue!(
+        out,
+        BeginSynchronizedUpdate,
+        MoveTo(0, 5),
+        Clear(ClearType::CurrentLine),
+        Print("torn: left")
+    )?;
+    out.flush()?;
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    queue!(out, MoveTo(10, 5), Print(" right"), EndSynchronizedUpdate)?;
     out.flush()
 }
 
@@ -97,6 +123,11 @@ fn main() -> io::Result<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('x') {
             cleanup(&mut out)?;
             std::process::exit(42);
+        }
+
+        if key.code == KeyCode::F(2) {
+            draw_torn(&mut out)?;
+            continue;
         }
 
         match key.code {


### PR DESCRIPTION
Closes #24.

DEC 2026 synchronized-output support with exact semantics: the tracker recognizes `?2026 h/l` (O(1) incremental param parsing, multi-mode lists included), `Emulator::process` stops at each frame end, and the reader snapshots the screen at that exact instant — a predicate can never observe a torn repaint, even when one chunk carries a frame end plus the next frame's start.

Per the milestone's design bar: one method, no options; the frame completed before the call is evaluated first; an app that never syncs gets a timeout that says so and points at `wait_until`; the superseded-transient-frames caveat is documented rather than papered over. `wait_idle` tightened for free (open sync update ≠ idle).

Proof: form-echo gains an F2 torn-draw mode (half a row → 150ms pause → rest, inside one update); the new test asserts the frame is whole when observed. 35 unit + 6 integration tests; throughput A/B vs main is a wash; local stress 15/15. CI stress on this branch to follow before merge.