### PR TITLE
feat(terminal): answer terminal queries; diagnose the unanswerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- termlens now **answers terminal queries** (on by default): DSR cursor
+  position — exact as of the query byte — operating status, DA1/DA2
+  device attributes, `CSI 18 t` text-area size, and `OSC 10/11` color
+  queries (`TerminalBuilder::background_rgb` configures the reported
+  background). Capability-probing applications run instead of hanging.
+  Recognized-but-unanswerable questions (XTGETTCAP, kitty `CSI ? u`,
+  pixel-size reports, …) are named inside the next wait timeout error,
+  turning a silent hang into a diagnosis; `answer_queries(false)` mutes
+  the responder while keeping the diagnosis.
 - `Terminal::wait_frame(pred)`: evaluates the predicate only on **complete
   frames** for applications that bracket repaints in DEC 2026 synchronized
   updates — a torn, half-painted repaint is never observable. Apps that

--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ flowchart TB
 
 The reader thread drains the PTY into the emulator *continuously* — the
 kernel buffer can't fill up and stall your app, and no output is lost
-between assertions. Screens are immutable snapshots taken under the same
+between assertions. It also **answers the queries real terminals
+answer** (cursor position, device attributes, window size, background
+color), so capability-probing apps run instead of hanging — and anything
+left unanswered is named inside the next timeout error. Screens are immutable snapshots taken under the same
 lock the reader writes through, so every assertion sees a consistent
 instant. Four layers, one small internal trait between emulator and screen
 so the backend can be swapped; details in [docs/DESIGN.md](docs/DESIGN.md).

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -8,25 +8,37 @@
 mod seq;
 mod vt100;
 
+pub(crate) use self::seq::Query;
 pub(crate) use self::vt100::Vt100Emulator;
 
 use crate::Screen;
 
+/// Why the emulator stopped consuming mid-segment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Stop {
+    /// A synchronized update ended (DEC 2026 ESU): the screen at this
+    /// instant is a complete frame.
+    FrameComplete,
+    /// The application asked the terminal a question; the screen state
+    /// (cursor, size) is exactly as of the query.
+    Query(Query),
+}
+
 /// Outcome of feeding one segment of PTY bytes into the emulator.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct Processed {
     /// How many input bytes were consumed (> 0 for non-empty input).
     pub(crate) consumed: usize,
-    /// True when consumption stopped because a synchronized update ended
-    /// (DEC 2026 ESU): the screen at this instant is a complete frame.
-    pub(crate) frame_complete: bool,
+    /// Set when consumption stopped before the end of the input.
+    pub(crate) stop: Option<Stop>,
 }
 
 /// A VT emulator: consumes raw PTY bytes, maintains a screen grid.
 pub(crate) trait Emulator: Send {
     /// Feed raw bytes from the PTY into the emulator. Stops early — with
-    /// `consumed < bytes.len()` — when a synchronized update ends, so the
-    /// caller can observe the completed frame before feeding the rest.
+    /// `consumed < bytes.len()` — when a synchronized update ends or the
+    /// application issues a query, so the caller can act on the exact
+    /// screen state at that instant before feeding the rest.
     fn process(&mut self, bytes: &[u8]) -> Processed;
 
     /// Snapshot the current screen as an owned value.

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -33,15 +33,61 @@ enum State {
     DcsEsc,
 }
 
-/// What one byte did to the synchronized-update state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SyncEvent {
-    /// No change.
+/// What one byte completed, if anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SeqEvent {
+    /// Nothing actionable.
     None,
-    /// The byte completed a `CSI ? 2026 … h`: a synchronized update began.
-    Begin,
-    /// The byte completed a `CSI ? 2026 … l`: a frame is now complete.
-    End,
+    /// A `CSI ? 2026 … h` completed: a synchronized update began.
+    SyncBegin,
+    /// A `CSI ? 2026 … l` completed: a frame is now complete.
+    SyncEnd,
+    /// The application asked the terminal a question.
+    Query(Query),
+}
+
+/// A terminal query the application issued. The tracker classifies;
+/// policy (answer vs record) lives with the caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Query {
+    /// DSR cursor position: `CSI 6 n` (or the DEC `CSI ? 6 n` form).
+    CursorPosition {
+        /// True for the `?`-prefixed DECXCPR form.
+        private: bool,
+    },
+    /// DSR operating status: `CSI 5 n`.
+    OperatingStatus,
+    /// Primary device attributes: `CSI c` / `CSI 0 c`.
+    PrimaryDa,
+    /// Secondary device attributes: `CSI > c` / `CSI > 0 c`.
+    SecondaryDa,
+    /// Text-area size in characters: `CSI 18 t`.
+    TextAreaSize,
+    /// OSC color query (`OSC 10;?` foreground / `OSC 11;?` background).
+    OscColor {
+        /// 10 = foreground, 11 = background.
+        code: u8,
+        /// True when the query used ST; the reply must mirror it.
+        st_terminated: bool,
+    },
+    /// Recognized as a question, but one termlens has no answer for
+    /// (XTGETTCAP, kitty `CSI ? u`, other DSR/DA/XTWINOPS reports, …).
+    /// Carries a printable rendering for diagnostics.
+    Unanswerable(String),
+}
+
+/// Render a captured escape sequence printably (`ESC` becomes `^[`).
+fn printable(bytes: &[u8]) -> String {
+    let mut out = String::new();
+    for &b in bytes {
+        match b {
+            0x1b => out.push_str("^["),
+            0x07 => out.push_str("^G"),
+            0x20..=0x7e => out.push(b as char),
+            _ => out.push_str(&format!("\\x{b:02x}")),
+        }
+    }
+    out
 }
 
 #[derive(Debug)]
@@ -51,12 +97,20 @@ pub(crate) struct SeqTracker {
     utf8_remaining: u8,
     /// True between a 2026 `h` and the matching `l`.
     sync_update: bool,
-    // Incremental CSI parameter scanner (only what mode 2026 needs).
-    csi_private: bool,
+    // Incremental CSI scanner: enough to recognize mode 2026 and the
+    // handful of query shapes, in O(1) space.
+    csi_prefix: u8,
     csi_invalid: bool,
     csi_first: bool,
     csi_param: u32,
+    csi_has_digits: bool,
+    csi_first_param: u32,
+    csi_param_count: u8,
     csi_saw_2026: bool,
+    /// Raw capture of the current sequence (from ESC), for diagnostics
+    /// and OSC/DCS query recognition. Bounded; long sequences truncate.
+    seq_buf: [u8; 24],
+    seq_len: u8,
 }
 
 impl SeqTracker {
@@ -65,11 +119,16 @@ impl SeqTracker {
             state: State::Ground,
             utf8_remaining: 0,
             sync_update: false,
-            csi_private: false,
+            csi_prefix: 0,
             csi_invalid: false,
             csi_first: true,
             csi_param: 0,
+            csi_has_digits: false,
+            csi_first_param: 0,
+            csi_param_count: 0,
             csi_saw_2026: false,
+            seq_buf: [0; 24],
+            seq_len: 0,
         }
     }
 
@@ -90,64 +149,169 @@ impl SeqTracker {
     }
 
     fn reset_csi_scanner(&mut self) {
-        self.csi_private = false;
+        self.csi_prefix = 0;
         self.csi_invalid = false;
         self.csi_first = true;
         self.csi_param = 0;
+        self.csi_has_digits = false;
+        self.csi_first_param = 0;
+        self.csi_param_count = 0;
         self.csi_saw_2026 = false;
+    }
+
+    fn push_seq(&mut self, b: u8) {
+        if usize::from(self.seq_len) < self.seq_buf.len() {
+            self.seq_buf[usize::from(self.seq_len)] = b;
+            self.seq_len += 1;
+        }
+    }
+
+    fn seq_printable(&self) -> String {
+        printable(&self.seq_buf[..usize::from(self.seq_len)])
+    }
+
+    /// Close the parameter currently being accumulated.
+    fn end_csi_param(&mut self) {
+        if self.csi_param == 2026 {
+            self.csi_saw_2026 = true;
+        }
+        if self.csi_param_count == 0 {
+            self.csi_first_param = self.csi_param;
+        }
+        self.csi_param_count = self.csi_param_count.saturating_add(1);
+        self.csi_param = 0;
+        self.csi_has_digits = false;
     }
 
     /// Track one CSI parameter/intermediate byte.
     fn scan_csi_byte(&mut self, b: u8) {
         match b {
-            b'?' if self.csi_first => self.csi_private = true,
+            b'?' | b'>' | b'=' if self.csi_first => self.csi_prefix = b,
             b'0'..=b'9' => {
                 self.csi_param = self
                     .csi_param
                     .saturating_mul(10)
                     .saturating_add(u32::from(b - b'0'));
+                self.csi_has_digits = true;
             }
-            b';' => {
-                if self.csi_param == 2026 {
-                    self.csi_saw_2026 = true;
-                }
-                self.csi_param = 0;
-            }
-            // Sub-parameters, intermediates, or other private markers:
-            // whatever this sequence is, it is not a plain mode 2026 set.
+            b';' => self.end_csi_param(),
+            // Sub-parameters or intermediates: none of the sequences we
+            // recognize use them.
             _ => self.csi_invalid = true,
         }
         self.csi_first = false;
     }
 
-    /// The sync-state change (if any) implied by a CSI final byte.
-    fn csi_final(&mut self, b: u8) -> SyncEvent {
-        if !self.csi_private || self.csi_invalid {
-            return SyncEvent::None;
+    /// The event (if any) implied by a CSI final byte.
+    fn csi_final(&mut self, b: u8) -> SeqEvent {
+        if self.csi_invalid {
+            return SeqEvent::None;
         }
-        if !(self.csi_saw_2026 || self.csi_param == 2026) {
-            return SyncEvent::None;
+        if self.csi_has_digits {
+            self.end_csi_param();
         }
-        match b {
-            b'h' => {
-                self.sync_update = true;
-                SyncEvent::Begin
+        let params_empty = self.csi_param_count == 0;
+        let single = |v: u32| self.csi_param_count == 1 && self.csi_first_param == v;
+
+        // DEC private mode 2026 (synchronized output).
+        if self.csi_prefix == b'?' && self.csi_saw_2026 {
+            match b {
+                b'h' => {
+                    self.sync_update = true;
+                    return SeqEvent::SyncBegin;
+                }
+                b'l' => {
+                    self.sync_update = false;
+                    return SeqEvent::SyncEnd;
+                }
+                _ => {}
             }
-            b'l' => {
-                self.sync_update = false;
-                SyncEvent::End
-            }
-            _ => SyncEvent::None,
         }
+
+        // Queries. Classification only — answering policy lives upstream.
+        let query = match (self.csi_prefix, b) {
+            (0, b'n') if single(6) => Some(Query::CursorPosition { private: false }),
+            (b'?', b'n') if single(6) => Some(Query::CursorPosition { private: true }),
+            (0, b'n') if single(5) => Some(Query::OperatingStatus),
+            (0, b'c') if params_empty || single(0) => Some(Query::PrimaryDa),
+            (b'>', b'c') if params_empty || single(0) => Some(Query::SecondaryDa),
+            (0, b't') if single(18) => Some(Query::TextAreaSize),
+            // Questions we can recognize but not answer.
+            (_, b'n') | (b'=', b'c') => Some(Query::Unanswerable(self.seq_printable())),
+            (b'?', b'u') if params_empty => {
+                // kitty keyboard probe. Its protocol pairs this with DA1;
+                // our DA1 answer unblocks the probe like any non-kitty
+                // terminal, but the probe itself is still unanswered.
+                Some(Query::Unanswerable(self.seq_printable()))
+            }
+            (0, b't')
+                if matches!(self.csi_first_param, 11 | 13 | 14 | 16 | 19 | 20 | 21)
+                    && self.csi_param_count == 1 =>
+            {
+                Some(Query::Unanswerable(self.seq_printable()))
+            }
+            _ => None,
+        };
+        query.map_or(SeqEvent::None, SeqEvent::Query)
     }
 
-    pub(crate) fn step(&mut self, b: u8) -> SyncEvent {
+    /// The event (if any) implied by a completed OSC or DCS string.
+    fn string_final(&mut self, was_osc: bool, st_terminated: bool) -> SeqEvent {
+        let body = &self.seq_buf[..usize::from(self.seq_len)];
+        if was_osc {
+            // body is `ESC ] <content> [terminator…]`; a color query is
+            // exactly `10;?` or `11;?` (12 = cursor color: unanswerable).
+            let content_end = if st_terminated {
+                body.len().saturating_sub(2) // strip ESC \
+            } else {
+                body.len().saturating_sub(1) // strip BEL
+            };
+            let content = body.get(2..content_end).unwrap_or(b"");
+            match content {
+                b"10;?" => {
+                    return SeqEvent::Query(Query::OscColor {
+                        code: 10,
+                        st_terminated,
+                    })
+                }
+                b"11;?" => {
+                    return SeqEvent::Query(Query::OscColor {
+                        code: 11,
+                        st_terminated,
+                    })
+                }
+                b"12;?" => return SeqEvent::Query(Query::Unanswerable(self.seq_printable())),
+                _ => return SeqEvent::None,
+            }
+        }
+        // DCS: XTGETTCAP is `ESC P + q … ST` — a capability question.
+        if body.get(2..4) == Some(b"+q") {
+            return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
+        }
+        SeqEvent::None
+    }
+
+    /// Feed one byte: capture it if it belongs to a sequence, then run
+    /// the state machine.
+    pub(crate) fn step(&mut self, b: u8) -> SeqEvent {
+        if self.state == State::Ground {
+            if b == 0x1b {
+                self.seq_len = 0;
+                self.push_seq(b);
+            }
+        } else {
+            self.push_seq(b);
+        }
+        self.transition(b)
+    }
+
+    fn transition(&mut self, b: u8) -> SeqEvent {
         const ESC: u8 = 0x1b;
         const CAN: u8 = 0x18;
         const SUB: u8 = 0x1a;
         const BEL: u8 = 0x07;
 
-        let mut event = SyncEvent::None;
+        let mut event = SeqEvent::None;
         self.state = match self.state {
             State::Ground => {
                 if b == ESC {
@@ -192,7 +356,10 @@ impl SeqTracker {
                 }
             },
             State::Osc => match b {
-                BEL => State::Ground,
+                BEL => {
+                    event = self.string_final(true, false);
+                    State::Ground
+                }
                 ESC => State::OscEsc,
                 CAN | SUB => State::Ground,
                 _ => State::Osc,
@@ -202,14 +369,28 @@ impl SeqTracker {
                 CAN | SUB => State::Ground,
                 _ => State::Dcs, // BEL is data inside DCS-class strings
             },
-            State::OscEsc | State::DcsEsc => match b {
-                b'\\' => State::Ground, // ESC \ = ST
-                ESC => self.state,
-                // Anything else: the ESC aborted the string and starts a new
-                // escape sequence; reprocess this byte in Esc state.
+            State::OscEsc => match b {
+                b'\\' => {
+                    event = self.string_final(true, true); // ESC \ = ST
+                    State::Ground
+                }
+                ESC => State::OscEsc,
+                // The ESC aborted the string and starts a new sequence;
+                // reprocess this byte in Esc state (capture already done).
                 _ => {
                     self.state = State::Esc;
-                    return self.step(b);
+                    return self.transition(b);
+                }
+            },
+            State::DcsEsc => match b {
+                b'\\' => {
+                    event = self.string_final(false, true);
+                    State::Ground
+                }
+                ESC => State::DcsEsc,
+                _ => {
+                    self.state = State::Esc;
+                    return self.transition(b);
                 }
             },
         };
@@ -299,11 +480,11 @@ mod tests {
     #[test]
     fn sync_update_events_fire_on_2026_set_and_reset() {
         let mut t = SeqTracker::new();
-        let events: Vec<SyncEvent> = b"\x1b[?2026h".iter().map(|&b| t.step(b)).collect();
-        assert_eq!(*events.last().unwrap(), SyncEvent::Begin);
+        let events: Vec<SeqEvent> = b"\x1b[?2026h".iter().map(|&b| t.step(b)).collect();
+        assert_eq!(*events.last().unwrap(), SeqEvent::SyncBegin);
         assert!(t.in_sync_update());
-        let events: Vec<SyncEvent> = b"\x1b[?2026l".iter().map(|&b| t.step(b)).collect();
-        assert_eq!(*events.last().unwrap(), SyncEvent::End);
+        let events: Vec<SeqEvent> = b"\x1b[?2026l".iter().map(|&b| t.step(b)).collect();
+        assert_eq!(*events.last().unwrap(), SeqEvent::SyncEnd);
         assert!(!t.in_sync_update());
     }
 
@@ -337,6 +518,75 @@ mod tests {
         assert!(t.in_sync_update());
         t.feed(b"\x1b[?2026l");
         assert!(!t.in_sync_update());
+    }
+
+    fn queries_of(bytes: &[u8]) -> Vec<Query> {
+        let mut t = SeqTracker::new();
+        bytes
+            .iter()
+            .filter_map(|&b| match t.step(b) {
+                SeqEvent::Query(q) => Some(q),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn recognizes_the_answerable_queries() {
+        assert_eq!(
+            queries_of(b"\x1b[6n"),
+            vec![Query::CursorPosition { private: false }]
+        );
+        assert_eq!(
+            queries_of(b"\x1b[?6n"),
+            vec![Query::CursorPosition { private: true }]
+        );
+        assert_eq!(queries_of(b"\x1b[5n"), vec![Query::OperatingStatus]);
+        assert_eq!(queries_of(b"\x1b[c"), vec![Query::PrimaryDa]);
+        assert_eq!(queries_of(b"\x1b[0c"), vec![Query::PrimaryDa]);
+        assert_eq!(queries_of(b"\x1b[>c"), vec![Query::SecondaryDa]);
+        assert_eq!(queries_of(b"\x1b[18t"), vec![Query::TextAreaSize]);
+        assert_eq!(
+            queries_of(b"\x1b]11;?\x07"),
+            vec![Query::OscColor {
+                code: 11,
+                st_terminated: false
+            }]
+        );
+        assert_eq!(
+            queries_of(b"\x1b]10;?\x1b\\"),
+            vec![Query::OscColor {
+                code: 10,
+                st_terminated: true
+            }]
+        );
+    }
+
+    #[test]
+    fn recognizes_unanswerable_questions_with_their_shape() {
+        let q = queries_of(b"\x1b[?u");
+        assert_eq!(q, vec![Query::Unanswerable("^[[?u".into())]);
+        let q = queries_of(b"\x1b[14t");
+        assert_eq!(q, vec![Query::Unanswerable("^[[14t".into())]);
+        let q = queries_of(b"\x1bP+q544e\x1b\\"); // XTGETTCAP
+        assert_eq!(q, vec![Query::Unanswerable("^[P+q544e^[\\".into())]);
+        let q = queries_of(b"\x1b[=c"); // DA3
+        assert_eq!(q, vec![Query::Unanswerable("^[[=c".into())]);
+        let q = queries_of(b"\x1b]12;?\x07"); // cursor color
+        assert_eq!(q, vec![Query::Unanswerable("^[]12;?^G".into())]);
+        // Any CSI …n is a DSR-family status request by definition.
+        let q = queries_of(b"\x1b[6;1n");
+        assert_eq!(q, vec![Query::Unanswerable("^[[6;1n".into())]);
+    }
+
+    #[test]
+    fn ordinary_output_is_not_a_query() {
+        assert!(queries_of(b"\x1b[31m").is_empty()); // SGR
+        assert!(queries_of(b"\x1b[2J\x1b[H").is_empty()); // clear+home
+        assert!(queries_of(b"\x1b[8;30;100t").is_empty()); // resize command
+        assert!(queries_of(b"\x1b]0;title\x07").is_empty()); // set title
+        assert!(queries_of(b"\x1b[1;6H").is_empty()); // cursor move
+        assert!(queries_of(b"plain text").is_empty());
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -1,8 +1,8 @@
 //! The `vt100`-crate backend. Public types never leak from here: every
 //! snapshot converts vt100's grid into termlens's own [`Screen`].
 
-use super::seq::{SeqTracker, SyncEvent};
-use super::{Emulator, Processed};
+use super::seq::{SeqEvent, SeqTracker};
+use super::{Emulator, Processed, Stop};
 use crate::screen::{Cell, Color, Screen, Style};
 
 pub(crate) struct Vt100Emulator {
@@ -23,18 +23,23 @@ impl Vt100Emulator {
 impl Emulator for Vt100Emulator {
     fn process(&mut self, bytes: &[u8]) -> Processed {
         for (i, &byte) in bytes.iter().enumerate() {
-            if self.tracker.step(byte) == SyncEvent::End {
+            let stop = match self.tracker.step(byte) {
+                SeqEvent::SyncEnd => Some(Stop::FrameComplete),
+                SeqEvent::Query(query) => Some(Stop::Query(query)),
+                SeqEvent::None | SeqEvent::SyncBegin => None,
+            };
+            if let Some(stop) = stop {
                 self.parser.process(&bytes[..=i]);
                 return Processed {
                     consumed: i + 1,
-                    frame_complete: true,
+                    stop: Some(stop),
                 };
             }
         }
         self.parser.process(bytes);
         Processed {
             consumed: bytes.len(),
-            frame_complete: false,
+            stop: None,
         }
     }
 
@@ -171,7 +176,7 @@ mod tests {
         let stream = b"\x1b[?2026hframe1\x1b[?2026lnext";
 
         let first = emu.process(stream);
-        assert!(first.frame_complete);
+        assert_eq!(first.stop, Some(Stop::FrameComplete));
         // Everything through the ESU is consumed; "next" is not.
         assert_eq!(
             &stream[..first.consumed],
@@ -182,7 +187,7 @@ mod tests {
         assert!(!emu.in_sync_update());
 
         let rest = emu.process(&stream[first.consumed..]);
-        assert!(!rest.frame_complete);
+        assert!(rest.stop.is_none());
         assert!(emu.snapshot().contains("frame1next"));
     }
 

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
-use crate::emu::{Emulator, Vt100Emulator};
+use crate::emu::{Emulator, Query, Stop, Vt100Emulator};
 use crate::error::{Error, Result};
 use crate::keys::Key;
 use crate::screen::Screen;
@@ -43,6 +43,11 @@ static PTY_LIFECYCLE: Mutex<()> = Mutex::new(());
 fn pty_lifecycle_guard() -> std::sync::MutexGuard<'static, ()> {
     PTY_LIFECYCLE.lock().unwrap_or_else(PoisonError::into_inner)
 }
+
+/// The PTY writer, shared between `Terminal` (typed input) and the reader
+/// thread (query replies). `None` after teardown. Locked briefly per write;
+/// never while the emulator state lock is held.
+type SharedWriter = Arc<Mutex<Option<Box<dyn Write + Send>>>>;
 
 /// Exit status of the child process.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,10 +119,17 @@ struct EmuState {
     frames_seen: u64,
     /// The screen exactly as of the most recent completed frame.
     last_frame: Option<Screen>,
+    /// Whether to answer recognized terminal queries (builder-configured).
+    respond: bool,
+    /// Background color reported to OSC 11 queries.
+    background: (u8, u8, u8),
+    /// The most recent query that got no answer, printable, plus a count —
+    /// timeout errors surface this so a blocked probe is diagnosable.
+    unanswered: Option<String>,
 }
 
 impl EmuState {
-    fn new(emu: Box<dyn Emulator>) -> Self {
+    fn new(emu: Box<dyn Emulator>, respond: bool, background: (u8, u8, u8)) -> Self {
         Self {
             emu,
             last_activity: Instant::now(),
@@ -126,7 +138,63 @@ impl EmuState {
             snapshot_cache: None,
             frames_seen: 0,
             last_frame: None,
+            respond,
+            background,
+            unanswered: None,
         }
+    }
+
+    /// Build the reply for a query, or record it as unanswered. Pure
+    /// computation under the state lock; the caller does the writing.
+    fn answer(&mut self, query: &Query) -> Option<Vec<u8>> {
+        fn osc_color(code: u8, (r, g, b): (u8, u8, u8), st: bool) -> Vec<u8> {
+            let widen = |v: u8| u16::from(v) << 8 | u16::from(v);
+            let terminator = if st { "\x1b\\" } else { "\x07" };
+            format!(
+                "\x1b]{code};rgb:{:04x}/{:04x}/{:04x}{terminator}",
+                widen(r),
+                widen(g),
+                widen(b)
+            )
+            .into_bytes()
+        }
+
+        if !self.respond {
+            self.unanswered = Some(query_shape(query));
+            return None;
+        }
+        let reply = match query {
+            Query::CursorPosition { private } => {
+                // Report exactly the cursor as of the query byte: the
+                // emulator stopped there, so this snapshot cannot include
+                // later output. 1-based on the wire.
+                let (row, col, _) = self.emu.snapshot().cursor();
+                let prefix = if *private { "?" } else { "" };
+                format!("\x1b[{prefix}{};{}R", row + 1, col + 1).into_bytes()
+            }
+            Query::OperatingStatus => b"\x1b[0n".to_vec(),
+            // VT220 with ANSI color: honest — nothing claimed (sixel,
+            // kitty, …) that the emulator cannot render.
+            Query::PrimaryDa => b"\x1b[?62;22c".to_vec(),
+            Query::SecondaryDa => b"\x1b[>1;10;0c".to_vec(),
+            Query::TextAreaSize => {
+                let screen = self.emu.snapshot();
+                format!("\x1b[8;{};{}t", screen.rows(), screen.cols()).into_bytes()
+            }
+            Query::OscColor {
+                code: 11,
+                st_terminated,
+            } => osc_color(11, self.background, *st_terminated),
+            Query::OscColor {
+                code,
+                st_terminated,
+            } => osc_color(*code, (0xff, 0xff, 0xff), *st_terminated),
+            Query::Unanswerable(shape) => {
+                self.unanswered = Some(shape.clone());
+                return None;
+            }
+        };
+        Some(reply)
     }
 
     /// Record a state change: waiters must re-evaluate, snapshots rebuild.
@@ -147,6 +215,19 @@ impl EmuState {
         let screen = self.emu.snapshot();
         self.snapshot_cache = Some((self.generation, screen.clone()));
         screen
+    }
+
+    /// One-line diagnosis when a query went unanswered, appended to
+    /// timeout messages — a probing app blocked on a reply is otherwise
+    /// indistinguishable from a hung one.
+    fn query_note(&self) -> String {
+        self.unanswered.as_ref().map_or_else(String::new, |shape| {
+            format!(
+                " — note: the application queried the terminal ({shape}) \
+                 and received no answer; if it is blocked waiting for that \
+                 reply, this is the cause"
+            )
+        })
     }
 
     /// Cache-aware read that never writes: serve the stored snapshot when
@@ -190,6 +271,8 @@ pub struct TerminalBuilder {
     args: Vec<OsString>,
     env_clear: bool,
     envs: Vec<(OsString, OsString)>,
+    answer_queries: bool,
+    background: (u8, u8, u8),
 }
 
 impl Default for TerminalBuilder {
@@ -201,6 +284,8 @@ impl Default for TerminalBuilder {
             args: Vec::new(),
             env_clear: false,
             envs: Vec::new(),
+            answer_queries: true,
+            background: (0, 0, 0),
         }
     }
 }
@@ -264,6 +349,28 @@ impl TerminalBuilder {
         self
     }
 
+    /// Answer terminal queries from the application (on by default).
+    ///
+    /// Real terminals answer questions like `CSI 6 n` (cursor position),
+    /// `CSI c` (device attributes) and `OSC 11 ; ?` (background color) —
+    /// so does termlens, because an application blocked on a probe reply
+    /// would otherwise hang until the test times out. Disable only to
+    /// test how your app behaves against a mute terminal; unanswered
+    /// queries are then named inside wait-timeout errors.
+    #[must_use]
+    pub fn answer_queries(mut self, answer: bool) -> Self {
+        self.answer_queries = answer;
+        self
+    }
+
+    /// The background color reported to `OSC 11` queries (light/dark
+    /// detection). Defaults to black.
+    #[must_use]
+    pub fn background_rgb(mut self, r: u8, g: u8, b: u8) -> Self {
+        self.background = (r, g, b);
+        self
+    }
+
     /// Spawn `program` inside a fresh PTY and start draining its output.
     ///
     /// Unless a `TERM` variable was set explicitly, the child gets
@@ -323,14 +430,18 @@ impl TerminalBuilder {
             .take_writer()
             .map_err(|e| Error::Pty(format!("taking PTY writer failed: {e}")))?;
 
-        let shared = Arc::new(Monitor::new(EmuState::new(Box::new(Vt100Emulator::new(
-            self.rows, self.cols,
-        )))));
+        let shared = Arc::new(Monitor::new(EmuState::new(
+            Box::new(Vt100Emulator::new(self.rows, self.cols)),
+            self.answer_queries,
+            self.background,
+        )));
+        let writer: SharedWriter = Arc::new(Mutex::new(Some(writer)));
 
         let reader_shared = Arc::clone(&shared);
+        let reader_writer = Arc::clone(&writer);
         thread::Builder::new()
             .name("termlens-pty-reader".into())
-            .spawn(move || reader_loop(reader, &reader_shared))
+            .spawn(move || reader_loop(reader, &reader_shared, &reader_writer))
             .map_err(Error::Io)?;
 
         let child = pair.slave.spawn_command(cmd).map_err(|e| Error::Spawn {
@@ -345,7 +456,7 @@ impl TerminalBuilder {
         Ok(Terminal {
             child,
             master: Some(pair.master),
-            writer: Some(writer),
+            writer,
             shared,
             default_timeout: self.timeout,
             exit_status: None,
@@ -354,28 +465,67 @@ impl TerminalBuilder {
     }
 }
 
+/// Canonical printable shape of a known query (for diagnostics when the
+/// responder is disabled).
+fn query_shape(query: &Query) -> String {
+    match query {
+        Query::CursorPosition { private: false } => "^[[6n".into(),
+        Query::CursorPosition { private: true } => "^[[?6n".into(),
+        Query::OperatingStatus => "^[[5n".into(),
+        Query::PrimaryDa => "^[[c".into(),
+        Query::SecondaryDa => "^[[>c".into(),
+        Query::TextAreaSize => "^[[18t".into(),
+        Query::OscColor { code, .. } => format!("^[]{code};?"),
+        Query::Unanswerable(shape) => shape.clone(),
+    }
+}
+
 /// Drain the PTY into the emulator until EOF. Runs on a dedicated thread.
-fn reader_loop(mut reader: Box<dyn Read + Send>, shared: &Monitor<EmuState>) {
+fn reader_loop(
+    mut reader: Box<dyn Read + Send>,
+    shared: &Monitor<EmuState>,
+    writer: &SharedWriter,
+) {
     let mut buf = [0u8; 8192];
     loop {
         match reader.read(&mut buf) {
             Ok(0) => break,
-            Ok(n) => shared.mutate(|state| {
-                // The emulator stops at each DEC 2026 frame end, so the
-                // snapshot taken there is exactly the completed frame —
-                // even when the same chunk already carries the next
-                // frame's opening bytes.
-                let mut offset = 0;
-                while offset < n {
-                    let processed = state.emu.process(&buf[offset..n]);
-                    offset += processed.consumed;
-                    if processed.frame_complete {
-                        state.frames_seen += 1;
-                        state.last_frame = Some(state.emu.snapshot());
+            Ok(n) => {
+                // The emulator stops at each DEC 2026 frame end and at
+                // each query, so state read there (screen, cursor) is
+                // exact — even when the same chunk already carries the
+                // following bytes. Replies are BUILT under the state
+                // lock but WRITTEN after it is released; the state lock
+                // and the writer lock are never held together.
+                let replies = shared.mutate(|state| {
+                    let mut replies: Vec<Vec<u8>> = Vec::new();
+                    let mut offset = 0;
+                    while offset < n {
+                        let processed = state.emu.process(&buf[offset..n]);
+                        offset += processed.consumed;
+                        match processed.stop {
+                            Some(Stop::FrameComplete) => {
+                                state.frames_seen += 1;
+                                state.last_frame = Some(state.emu.snapshot());
+                            }
+                            Some(Stop::Query(query)) => {
+                                if let Some(reply) = state.answer(&query) {
+                                    replies.push(reply);
+                                }
+                            }
+                            None => {}
+                        }
+                    }
+                    state.touch();
+                    replies
+                });
+                for reply in replies {
+                    let mut writer = writer.lock().unwrap_or_else(PoisonError::into_inner);
+                    if let Some(writer) = writer.as_mut() {
+                        let _ = writer.write_all(&reply).and_then(|()| writer.flush());
                     }
                 }
-                state.touch();
-            }),
+            }
             Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
             // Linux reports EIO on the master once the child side is gone;
             // treat any hard error as end-of-stream.
@@ -394,10 +544,11 @@ fn reader_loop(mut reader: Box<dyn Read + Send>, shared: &Monitor<EmuState>) {
 /// and reaps the child — tests never leak zombies, even on panic.
 pub struct Terminal {
     child: Box<dyn portable_pty::Child + Send + Sync>,
-    // Option only so Drop can close them under the PTY lifecycle lock;
-    // both are Some for the entire life of the value outside Drop.
+    // Option only so Drop can close it under the PTY lifecycle lock;
+    // Some for the entire life of the value outside Drop.
     master: Option<Box<dyn portable_pty::MasterPty + Send>>,
-    writer: Option<Box<dyn Write + Send>>,
+    /// Shared with the reader thread, which writes query replies.
+    writer: SharedWriter,
     shared: Arc<Monitor<EmuState>>,
     default_timeout: Duration,
     exit_status: Option<ExitStatus>,
@@ -442,8 +593,17 @@ impl Terminal {
     }
 
     fn write_or_panic(&mut self, bytes: &[u8], what: &str) {
-        let writer = self.writer.as_mut().expect("writer lives until drop");
-        if let Err(e) = writer.write_all(bytes).and_then(|()| writer.flush()) {
+        // Write under the writer lock only; build the panic message (which
+        // takes the state lock for the screen) strictly after releasing it,
+        // so the two locks are never held together.
+        let result = {
+            let mut writer = self.writer.lock().unwrap_or_else(PoisonError::into_inner);
+            match writer.as_mut() {
+                Some(writer) => writer.write_all(bytes).and_then(|()| writer.flush()),
+                None => Err(io::Error::new(io::ErrorKind::BrokenPipe, "pty closed")),
+            }
+        };
+        if let Err(e) = result {
             panic!(
                 "termlens: failed to send {what} to `{}` ({e})\n--- screen ---\n{}",
                 self.command_desc,
@@ -489,7 +649,7 @@ impl Terminal {
         match outcome {
             Ok(inner) => inner,
             Err(Expired) => Err(Error::Timeout {
-                waiting_for: WHAT.into(),
+                waiting_for: format!("{WHAT}{}", self.shared.lock().query_note()),
                 timeout: self.default_timeout,
                 screen: self.screen(),
             }),
@@ -608,9 +768,10 @@ impl Terminal {
             let now = Instant::now();
             if now >= deadline {
                 let screen = guard.peek_snapshot();
+                let note = guard.query_note();
                 drop(guard);
                 return Err(Error::Timeout {
-                    waiting_for: format!("{quiet:?} of output silence"),
+                    waiting_for: format!("{quiet:?} of output silence{note}"),
                     timeout: self.default_timeout,
                     screen,
                 });
@@ -660,7 +821,11 @@ impl Terminal {
             let now = Instant::now();
             if now >= deadline {
                 return Err(Error::Timeout {
-                    waiting_for: format!("`{}` to exit", self.command_desc),
+                    waiting_for: format!(
+                        "`{}` to exit{}",
+                        self.command_desc,
+                        self.shared.lock().query_note()
+                    ),
                     timeout: self.default_timeout,
                     screen: self.screen(),
                 });
@@ -723,8 +888,15 @@ impl Drop for Terminal {
                 let _ = self.child.wait();
             }
         }
-        // Close the PTY fds while still holding the lock.
-        drop(self.writer.take());
+        // Close the PTY fds while still holding the lock. Taking the boxed
+        // writer out of the shared cell closes its fd even though the
+        // reader thread keeps the (now empty) cell alive.
+        drop(
+            self.writer
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .take(),
+        );
         drop(self.master.take());
     }
 }

--- a/crates/termlens/src/wait.rs
+++ b/crates/termlens/src/wait.rs
@@ -48,13 +48,17 @@ impl<S> Monitor<S> {
         self.state.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
-    /// Mutate under the lock, then wake all waiters.
-    pub(crate) fn mutate(&self, f: impl FnOnce(&mut S)) {
-        {
+    /// Mutate under the lock, then wake all waiters. Returns the closure's
+    /// value so callers can carry work out of the critical section (the
+    /// reader thread uses this to build query replies under the lock but
+    /// write them to the PTY after releasing it).
+    pub(crate) fn mutate<R>(&self, f: impl FnOnce(&mut S) -> R) -> R {
+        let value = {
             let mut guard = self.lock();
-            f(&mut guard);
-        }
+            f(&mut guard)
+        };
         self.cond.notify_all();
+        value
     }
 
     /// One bounded condvar sleep; returns the reacquired guard.

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -1,0 +1,134 @@
+//! The query responder: capability-probing apps get real answers instead
+//! of hanging, and whatever stays unanswered is named in timeout errors.
+//!
+//! Each shell script here genuinely BLOCKS on the terminal's reply
+//! (`head -c N` reads exactly the reply bytes), then prints a marker the
+//! test waits for — the marker appearing proves the app was unblocked.
+
+use std::time::Duration;
+
+use termlens::{Error, Key, Terminal};
+
+fn sh(script: &str) -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", script])
+        .spawn("/bin/sh")
+}
+
+#[test]
+fn cursor_position_reports_the_position_at_the_query() -> termlens::Result<()> {
+    // After printing "abc" the cursor sits at row 1, col 4 (1-based on the
+    // wire); the CPR reply is exactly 6 bytes: ESC [ 1 ; 4 R.
+    let mut t = sh(concat!(
+        r"stty -icanon -echo; printf 'abc\033[6n'; ",
+        r#"reply=$(head -c 6 | tr '\033' 'E'); "#,
+        r#"printf '\nunblocked:%s' "$reply"; read guard"#
+    ))?;
+    t.wait_until(|s| s.contains("unblocked:E[1;4R"))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn device_attribute_probes_are_unblocked() -> termlens::Result<()> {
+    // DA1 reply is ESC [ ? 6 2 ; 2 2 c = 9 bytes. This is also the exact
+    // pattern kitty-protocol probes rely on: the DA1 answer arriving tells
+    // the app "no kitty support", exactly like a real non-kitty terminal.
+    let mut t = sh(concat!(
+        r"stty -icanon -echo; printf '\033[c'; ",
+        r#"reply=$(head -c 9 | tr '\033' 'E'); "#,
+        r#"printf 'unblocked:%s' "$reply"; read guard"#
+    ))?;
+    t.wait_until(|s| s.contains("unblocked:E[?62;22c"))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn background_color_query_gets_the_configured_answer() -> termlens::Result<()> {
+    // OSC 11 reply: ESC ] 1 1 ; rgb:1e1e/1e1e/2e2e BEL = 24 bytes.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .background_rgb(0x1e, 0x1e, 0x2e)
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo; printf '\033]11;?\007'; ",
+                r#"reply=$(head -c 24 | tr '\033\007' 'EG'); "#,
+                r#"printf 'unblocked:%s' "$reply"; read guard"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("unblocked:E]11;rgb:1e1e/1e1e/2e2eG"))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn text_area_size_reports_the_real_grid() -> termlens::Result<()> {
+    // XTWINOPS 18 reply: ESC [ 8 ; 24 ; 80 t = 10 bytes.
+    let mut t = sh(concat!(
+        r"stty -icanon -echo; printf '\033[18t'; ",
+        r#"reply=$(head -c 10 | tr '\033' 'E'); "#,
+        r#"printf 'unblocked:%s' "$reply"; read guard"#
+    ))?;
+    t.wait_until(|s| s.contains("unblocked:E[8;24;80t"))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn unanswerable_queries_turn_timeouts_into_diagnoses() {
+    // CSI 14 t (pixel size) is recognized as a question termlens cannot
+    // answer; the app blocks, and the timeout error names the query.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(500))
+        .args(["-c", r"printf '\033[14t'; head -c 4 >/dev/null; echo never"])
+        .spawn("/bin/sh")
+        .unwrap();
+    let err = t.wait_until(|s| s.contains("never")).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("^[[14t"), "query not named in: {msg}");
+    assert!(msg.contains("received no answer"), "no diagnosis in: {msg}");
+    // Drop kills the blocked child.
+}
+
+#[test]
+fn the_responder_can_be_disabled_and_says_what_went_unanswered() {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(500))
+        .answer_queries(false)
+        .args(["-c", r"printf '\033[6n'; head -c 6 >/dev/null; echo never"])
+        .spawn("/bin/sh")
+        .unwrap();
+    let err = t.wait_until(|s| s.contains("never")).unwrap_err();
+    assert!(matches!(err, Error::Timeout { .. }));
+    let msg = err.to_string();
+    assert!(msg.contains("^[[6n"), "query not named in: {msg}");
+}
+
+#[test]
+fn replies_are_not_echoed_into_the_screen() -> termlens::Result<()> {
+    // The reply travels the input path; unless the app prints it, it must
+    // never appear in the grid. `stty -echo` keeps the line discipline
+    // from echoing what the "terminal" typed back.
+    let mut t = sh(concat!(
+        r"stty -icanon -echo; printf 'before\033[5n'; ",
+        r"head -c 4 >/dev/null; ",
+        r"printf ' after'; read guard"
+    ))?;
+    t.wait_until(|s| s.contains("before after"))?;
+    assert!(
+        !t.screen().text().contains("[0n"),
+        "reply leaked into the grid:\n{}",
+        t.screen()
+    );
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -39,6 +39,30 @@ are notified. On EOF (child exited and released the terminal — reported as
 0-read on macOS, EIO on Linux) it sets the `eof` flag and exits. It is
 never joined: a grandchild holding the PTY open must not hang `Drop`.
 
+### The reader answers queries
+
+Applications ask their terminal questions — DSR `CSI 6 n` (cursor
+position), DA1/DA2 (device attributes), `CSI 18 t` (text-area size),
+`OSC 10/11 ; ?` (colors) — and block on the reply. A mute harness turns
+every capability probe into a hang. termlens therefore answers, by
+default, exactly what a real terminal answers and nothing more: the DA1
+identity is VT220-with-color (`?62;22c`), claiming no feature the
+emulator cannot render, and kitty's `CSI ? u` probe is deliberately left
+unanswered because its protocol resolves via the DA1 reply, exactly as
+on a real non-kitty terminal.
+
+Precision: the emulator stops consuming at each query byte (the same
+mechanism as frame boundaries), so a cursor-position report reflects the
+cursor *at the query*, not after later output in the same chunk moved
+it. Replies are built under the state lock but written after it is
+released — the state lock and the writer lock are never held together.
+
+Whatever remains unanswered (XTGETTCAP, pixel-size reports, …) is
+recorded, and the next wait timeout names it: "the application queried
+the terminal (`^[[14t`) and received no answer" — a hang becomes a
+diagnosis. `answer_queries(false)` mutes the responder for tests that
+need a silent terminal; the diagnosis still works.
+
 ## 2. Wait semantics
 
 Every wait runs under the terminal's **default deadline** (builder


### PR DESCRIPTION
Closes #25 — the Tier-1 flagship: capability-probing apps run instead of hanging.

- Answers what a real conservative terminal answers: DSR cursor position (exact as of the query byte — the emulator stops there, same mechanism as frame boundaries), operating status, DA1 (`?62;22c`, VT220-with-color, claiming nothing we can't render), DA2, XTWINOPS 18 (real rows/cols), OSC 10/11 colors with mirrored terminators and a `background_rgb` builder knob.
- kitty's `?u` probe deliberately unanswered: its protocol resolves via our DA1 reply, exactly like a real non-kitty terminal — covered by a test.
- Whatever stays unanswered (XTGETTCAP, pixel-size, …) is named inside the next wait timeout: a hang becomes a diagnosis. `answer_queries(false)` mutes replies, keeps diagnosis.
- Lock discipline: replies built under the state lock, written after release through the now-shared writer; state and writer locks never held together (also fixes a latent AB-BA hazard in send's panic path).

38 unit + 7 integration tests (each script genuinely blocks on the reply in raw mode; the marker printing proves unblocking). Throughput A/B vs main: wash. Local stress 15/15; branch stress to follow.