### PR TITLE
feat(screen): with_styles() — style regressions become snapshot diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- `Screen::with_styles()`: the plain snapshot rendering followed by a
+  compact `styles:` block (run-length spans per row, format specified in
+  `docs/DESIGN.md` §3) — a highlight moving to another row or a color
+  changing is now a visible snapshot diff. Plain snapshots stay
+  text-only; this is the opt-in.
 - termlens now **answers terminal queries** (on by default): DSR cursor
   position — exact as of the query byte — operating status, DA1/DA2
   device attributes, `CSI 18 t` text-area size, and `OSC 10/11` color

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ fn quits_from_the_main_screen() -> termlens::Result<()> {
 
     t.wait_until(|screen| screen.contains("Ready"))?;
     insta::assert_snapshot!(t.screen());   // snapshot the rendered grid
+    // …or t.screen().with_styles() to catch style-only regressions too
 
     t.send(Key::Char('q'));
     assert!(t.wait_exit()?.success());
@@ -138,8 +139,6 @@ design. termlens's position:
   unaffected; for run-and-exit programs, end the script with a `read` and
   release it after asserting — see the "instant-exit caveat" in
   [docs/DESIGN.md](docs/DESIGN.md).
-- Styles (colors/bold/…) are captured per-cell and queryable, but not part
-  of the text snapshot format yet (`with_styles()` planned for v0.2).
 - Exotic grapheme clusters render as the vt100 crate renders them; the
   unicode-torture fixture pins the current behavior.
 

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -21,9 +21,8 @@ pub enum Color {
 
 /// Visual attributes of a [`Cell`].
 ///
-/// Captured for every cell in v0.1; the textual snapshot format does not
-/// render them yet (a `with_styles()` styles block is planned for v0.2 — see
-/// `docs/DESIGN.md`), but assertions can inspect them via [`Cell::style`].
+/// Inspect them per cell via [`Cell::style`], or snapshot them wholesale
+/// with [`Screen::with_styles`] (plain snapshots stay text-only).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Style {
     /// Foreground color.
@@ -256,6 +255,117 @@ impl Screen {
         }
         None
     }
+
+    /// This screen rendered **with its styles**: the normal
+    /// [`Display`](fmt::Display) output followed by a `styles:` block
+    /// listing every non-default span (format specified in
+    /// `docs/DESIGN.md` §3). Style-only regressions — a highlight moving
+    /// to another row, a color changing — become visible snapshot diffs:
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let t = termlens::Terminal::builder().spawn("true")?;
+    /// insta::assert_snapshot!(t.screen().with_styles());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Plain snapshots stay text-only; this is the opt-in.
+    #[must_use]
+    pub fn with_styles(&self) -> ScreenWithStyles<'_> {
+        ScreenWithStyles { screen: self }
+    }
+}
+
+impl Style {
+    /// True when every attribute is at its default.
+    fn is_default(&self) -> bool {
+        *self == Style::default()
+    }
+
+    /// Fixed-order tokens for the `styles:` block (see `docs/DESIGN.md` §3).
+    fn tokens(&self) -> String {
+        fn color(prefix: &str, color: Color, out: &mut Vec<String>) {
+            match color {
+                Color::Default => {}
+                Color::Indexed(i) => out.push(format!("{prefix}={i}")),
+                Color::Rgb(r, g, b) => out.push(format!("{prefix}=#{r:02x}{g:02x}{b:02x}")),
+            }
+        }
+        let mut tokens = Vec::new();
+        color("fg", self.fg, &mut tokens);
+        color("bg", self.bg, &mut tokens);
+        for (on, name) in [
+            (self.bold, "bold"),
+            (self.dim, "dim"),
+            (self.italic, "italic"),
+            (self.underline, "underline"),
+            (self.reverse, "reverse"),
+        ] {
+            if on {
+                tokens.push(name.to_owned());
+            }
+        }
+        tokens.join(" ")
+    }
+}
+
+/// [`Screen`] rendered with its styles — see [`Screen::with_styles`].
+#[derive(Debug, Clone, Copy)]
+pub struct ScreenWithStyles<'a> {
+    screen: &'a Screen,
+}
+
+impl fmt::Display for ScreenWithStyles<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let screen = self.screen;
+        write!(f, "{screen}\n\nstyles:")?;
+        let mut any = false;
+        for row in 0..screen.rows() {
+            let mut spans: Vec<String> = Vec::new();
+            let mut run: Option<(u16, u16, Style)> = None;
+            for col in 0..screen.cols() {
+                let style = screen
+                    .cell(row, col)
+                    .map_or_else(Style::default, |cell| *cell.style());
+                match &mut run {
+                    Some((_, end, current)) if *current == style => *end = col,
+                    _ => {
+                        if let Some(span) = flush(run.take()) {
+                            spans.push(span);
+                        }
+                        run = Some((col, col, style));
+                    }
+                }
+            }
+            if let Some(span) = flush(run) {
+                spans.push(span);
+            }
+            if !spans.is_empty() {
+                any = true;
+                write!(f, "\n{row}: {}", spans.join("; "))?;
+            }
+        }
+        if !any {
+            write!(f, "\n(none)")?;
+        }
+        return Ok(());
+
+        /// Render one run, or `None` for default-styled runs (absence
+        /// means default).
+        fn flush(run: Option<(u16, u16, Style)>) -> Option<String> {
+            let (start, end, style) = run?;
+            if style.is_default() {
+                return None;
+            }
+            let range = if start == end {
+                format!("{start}")
+            } else {
+                format!("{start}-{end}")
+            };
+            Some(format!("{range} {}", style.tokens()))
+        }
+    }
 }
 
 impl fmt::Debug for Screen {
@@ -362,6 +472,73 @@ mod tests {
         assert_eq!(s.cursor(), (1, 2, true));
         assert_eq!(s.size(), (10, 2));
         assert_eq!((s.cols(), s.rows()), (10, 2));
+    }
+
+    #[test]
+    fn with_styles_renders_runs_in_fixed_token_order() {
+        use unicode_width::UnicodeWidthChar as _;
+        let mut cells: Vec<Cell> = Vec::new();
+        let styled = Style {
+            fg: Color::Indexed(4),
+            bold: true,
+            ..Style::default()
+        };
+        // Row 0: "hi" styled, rest default. Row 1: all default text.
+        // Row 2: one reverse blank cell at col 3 (highlight past text).
+        for ch in ['h', 'i'] {
+            assert_eq!(ch.width(), Some(1));
+            cells.push(Cell::new(ch.to_string(), styled, false, false));
+        }
+        for _ in 2..6 {
+            cells.push(Cell::new(String::new(), Style::default(), false, false));
+        }
+        for ch in "plain ".chars() {
+            cells.push(Cell::new(ch.to_string(), Style::default(), false, false));
+        }
+        for col in 0..6 {
+            let style = if col == 3 {
+                Style {
+                    reverse: true,
+                    ..Style::default()
+                }
+            } else {
+                Style::default()
+            };
+            cells.push(Cell::new(String::new(), style, false, false));
+        }
+        let screen = Screen::from_parts(6, 3, 0, 0, true, cells);
+
+        let rendered = screen.with_styles().to_string();
+        let styles_block = rendered.split("\n\nstyles:\n").nth(1).unwrap();
+        assert_eq!(styles_block, "0: 0-1 fg=4 bold\n2: 3 reverse");
+        // The plain rendering is a strict prefix.
+        assert!(rendered.starts_with(&screen.to_string()));
+    }
+
+    #[test]
+    fn with_styles_on_a_default_screen_says_none() {
+        let s = screen(10, 2, &["hello"]);
+        let rendered = s.with_styles().to_string();
+        assert!(rendered.ends_with("\n\nstyles:\n(none)"), "{rendered}");
+    }
+
+    #[test]
+    fn with_styles_renders_rgb_and_merges_adjacent_runs() {
+        let style = Style {
+            bg: Color::Rgb(0x1e, 0x1e, 0x2e),
+            ..Style::default()
+        };
+        let mut cells: Vec<Cell> = Vec::new();
+        for ch in ['a', 'b', 'c'] {
+            cells.push(Cell::new(ch.to_string(), style, false, false));
+        }
+        cells.push(Cell::new(String::new(), Style::default(), false, false));
+        let screen = Screen::from_parts(4, 1, 0, 0, true, cells);
+        let rendered = screen.with_styles().to_string();
+        assert!(
+            rendered.ends_with("styles:\n0: 0-2 bg=#1e1e2e"),
+            "{rendered}"
+        );
     }
 
     #[test]

--- a/crates/termlens/tests/snapshots/styles__styled_screen_snapshot.snap
+++ b/crates/termlens/tests/snapshots/styles__styled_screen_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/termlens/tests/styles.rs
+expression: t.screen().with_styles()
+---
+size: 80x24  cursor: 2,0
+ERROR plain underlined
+second row selected
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+styles:
+0: 0-4 fg=1 bold; 12-21 fg=4 underline
+1: 11-18 reverse

--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -1,0 +1,59 @@
+//! `with_styles()`: style-only regressions become visible snapshot diffs.
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+fn sh(script: &str) -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", script])
+        .spawn("/bin/sh")
+}
+
+/// Print a two-item list with `reverse` on the item given by $1.
+fn list_with_highlight(row: u16) -> String {
+    let (one, two) = match row {
+        0 => (r"\033[7mitem one\033[0m", "item two"),
+        _ => ("item one", r"\033[7mitem two\033[0m"),
+    };
+    format!(r"printf '{one}\n{two}\n'; read guard")
+}
+
+#[test]
+fn moving_a_highlight_changes_the_styled_rendering_only() -> termlens::Result<()> {
+    let mut first = sh(&list_with_highlight(0))?;
+    first.wait_until(|s| s.contains("item two"))?;
+    let a = first.screen();
+    first.send(Key::Enter);
+    first.wait_exit()?;
+
+    let mut second = sh(&list_with_highlight(1))?;
+    second.wait_until(|s| s.contains("item two"))?;
+    let b = second.screen();
+    second.send(Key::Enter);
+    second.wait_exit()?;
+
+    // The pinning scenario from the coverage study: identical text…
+    assert_eq!(a.text(), b.text());
+    // …identical plain snapshots…
+    assert_eq!(a.to_string(), b.to_string());
+    // …but the styled rendering sees the highlight move.
+    assert_ne!(a.with_styles().to_string(), b.with_styles().to_string());
+    assert!(a.with_styles().to_string().contains("0: 0-7 reverse"));
+    assert!(b.with_styles().to_string().contains("1: 0-7 reverse"));
+    Ok(())
+}
+
+#[test]
+fn styled_screen_snapshot() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf '\033[1;31mERROR\033[0m plain \033[4;34munderlined\033[0m\n'; ",
+        r"printf 'second row \033[7mselected\033[0m\n'; read guard"
+    ))?;
+    t.wait_until(|s| s.contains("selected"))?;
+    insta::assert_snapshot!(t.screen().with_styles());
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -163,9 +163,27 @@ Rules:
 4. Wide characters occupy their real columns: the character appears once;
    its continuation cell contributes nothing to the text but does count
    for column arithmetic (`find` returns true terminal columns).
-5. Styles are captured per-cell (`Cell::style`) but not rendered in v0.1.
-   v0.2 adds `Screen::with_styles()`, appending a styles block after the
-   grid; the format will be specified here before it ships.
+5. Styles are text-invisible by default; `Screen::with_styles()` opts in.
+   Its rendering is the plain `Display` output followed by a blank line
+   and a `styles:` block:
+
+   ```
+   styles:
+   1: 0-8 fg=4 bold; 12 reverse
+   3: 0-79 bg=#1e1e2e
+   ```
+
+   One line per row containing any non-default cell, ascending; each line
+   is `<row>: <spans>` with spans joined by `; `. A span is an inclusive,
+   0-based column range (`start-end`, or just `start` for one column)
+   followed by style tokens in fixed order: `fg=`, `bg=` (indexed colors
+   as decimal, RGB as `#rrggbb`), then `bold`, `dim`, `italic`,
+   `underline`, `reverse`. Default-styled spans are omitted entirely —
+   absence means default — so a highlight moving rows diffs as exactly
+   two lines. A fully default-styled screen renders `styles:` followed by
+   `(none)`, so the snapshot itself records that styles were asserted.
+   Wide-character continuation cells participate in spans like any other
+   cell.
 
 The `insta` feature (default) re-exports `insta` and ships
 `assert_screen_snapshot!` so the snapshotting insta version can't drift


### PR DESCRIPTION
Closes #26, the last Tier-1 item. Screen::with_styles() renders the
plain snapshot followed by a styles: block — one line per row with any
non-default styling, as inclusive 0-based run-length spans with tokens
in fixed order (fg, bg, bold, dim, italic, underline, reverse; indexed
colors decimal, RGB #rrggbb). Default spans are absent, so a highlight
moving rows diffs as exactly two lines; a fully default screen renders
(none), recording that styles were asserted. Format specified in
DESIGN.md §3 before implementation, as that section promised in v0.1.

Plain snapshots stay text-only; this is the opt-in — one method, one
Display wrapper, no configuration.

The integration test reproduces the coverage study's pinning scenario
end-to-end: two screens with identical text and identical plain
snapshots, distinguishable only through with_styles().

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
