### PR TITLE
feat(terminal): typed mouse input, encoded per the app's tracking mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- `Terminal::click(col, row)` and `Terminal::scroll(col, row, Scroll)`:
+  typed mouse input, encoded exactly as the tracking mode and encoding
+  **the application enabled** (SGR 1006 or the legacy byte form), with a
+  press-only form for X10 mode. Clicking while the app never enabled
+  mouse tracking is a typed `Error::Input` instead of bytes the app
+  would misparse.
 - `Screen::with_styles()`: the plain snapshot rendering followed by a
   compact `styles:` block (run-length spans per row, format specified in
   `docs/DESIGN.md` §3) — a highlight moving to another row or a color

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -33,6 +33,33 @@ pub(crate) struct Processed {
     pub(crate) stop: Option<Stop>,
 }
 
+/// Which mouse events the application asked the terminal to report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MouseMode {
+    /// No mouse tracking enabled.
+    None,
+    /// X10: presses only (mode 9).
+    Press,
+    /// Presses and releases (mode 1000), possibly with motion (1002/1003).
+    PressRelease,
+}
+
+/// Input-affecting terminal modes the application has set — the emulator
+/// knows them, and the input path uses them so sent bytes match what the
+/// application configured the "terminal" to send.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InputModes {
+    pub(crate) mouse: MouseMode,
+    /// SGR (1006) mouse encoding active.
+    pub(crate) sgr_mouse: bool,
+    // Read by paste() and cursor-key encoding, which land right after
+    // the mouse work in this tier; the mode snapshot ships whole.
+    #[allow(dead_code)]
+    pub(crate) bracketed_paste: bool,
+    #[allow(dead_code)]
+    pub(crate) application_cursor: bool,
+}
+
 /// A VT emulator: consumes raw PTY bytes, maintains a screen grid.
 pub(crate) trait Emulator: Send {
     /// Feed raw bytes from the PTY into the emulator. Stops early — with
@@ -52,6 +79,9 @@ pub(crate) trait Emulator: Send {
     /// True while the stream is inside a DEC 2026 synchronized update —
     /// the app has begun a repaint and not finished it.
     fn in_sync_update(&self) -> bool;
+
+    /// The input-affecting modes the application has currently set.
+    fn input_modes(&self) -> InputModes;
 
     /// Resize the emulated grid to `rows` × `cols`.
     fn set_size(&mut self, rows: u16, cols: u16);

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -2,7 +2,7 @@
 //! snapshot converts vt100's grid into termlens's own [`Screen`].
 
 use super::seq::{SeqEvent, SeqTracker};
-use super::{Emulator, Processed, Stop};
+use super::{Emulator, InputModes, MouseMode, Processed, Stop};
 use crate::screen::{Cell, Color, Screen, Style};
 
 pub(crate) struct Vt100Emulator {
@@ -74,6 +74,24 @@ impl Emulator for Vt100Emulator {
 
     fn in_sync_update(&self) -> bool {
         self.tracker.in_sync_update()
+    }
+
+    fn input_modes(&self) -> InputModes {
+        let screen = self.parser.screen();
+        let mouse = match screen.mouse_protocol_mode() {
+            ::vt100::MouseProtocolMode::None => MouseMode::None,
+            ::vt100::MouseProtocolMode::Press => MouseMode::Press,
+            _ => MouseMode::PressRelease,
+        };
+        InputModes {
+            mouse,
+            sgr_mouse: matches!(
+                screen.mouse_protocol_encoding(),
+                ::vt100::MouseProtocolEncoding::Sgr
+            ),
+            bracketed_paste: screen.bracketed_paste(),
+            application_cursor: screen.application_cursor(),
+        }
     }
 
     fn set_size(&mut self, rows: u16, cols: u16) {

--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -60,6 +60,13 @@ pub enum Error {
     /// An OS-level I/O error (e.g. while waiting on the child process).
     #[error("i/o error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Typed input that the application's terminal configuration cannot
+    /// receive — e.g. a mouse click while the application never enabled
+    /// mouse tracking. Sending it anyway would feed the app bytes it
+    /// would misparse as garbage keys.
+    #[error("input not receivable: {0}")]
+    Input(String),
 }
 
 impl Error {

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -121,6 +121,22 @@ fn ctrl_byte(c: char) -> u8 {
     }
 }
 
+/// SGR (1006) mouse report. `press = false` is the release form.
+pub(crate) fn mouse_sgr(button: u8, col: u16, row: u16, press: bool) -> Vec<u8> {
+    let suffix = if press { 'M' } else { 'm' };
+    format!("\x1b[<{button};{};{}{suffix}", col + 1, row + 1).into_bytes()
+}
+
+/// Legacy (X10/normal) mouse report: `ESC [ M Cb Cx Cy`, byte-valued.
+/// Coordinates beyond 222 are unrepresentable; the caller validates.
+pub(crate) fn mouse_legacy(button: u8, col: u16, row: u16) -> Vec<u8> {
+    let mut out = b"\x1b[M".to_vec();
+    out.push(32 + button);
+    out.push(32 + 1 + u8::try_from(col).expect("caller validated"));
+    out.push(32 + 1 + u8::try_from(row).expect("caller validated"));
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,6 +175,15 @@ mod tests {
         for (key, bytes) in table {
             assert_eq!(key.encode(), *bytes, "wrong encoding for {key:?}");
         }
+    }
+
+    #[test]
+    fn mouse_encodings() {
+        assert_eq!(mouse_sgr(0, 9, 6, true), b"\x1b[<0;10;7M");
+        assert_eq!(mouse_sgr(0, 9, 6, false), b"\x1b[<0;10;7m");
+        assert_eq!(mouse_sgr(64, 0, 0, true), b"\x1b[<64;1;1M");
+        assert_eq!(mouse_legacy(0, 0, 0), b"\x1b[M\x20\x21\x21");
+        assert_eq!(mouse_legacy(3, 9, 6,), b"\x1b[M\x23\x2a\x27");
     }
 
     #[test]

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -63,7 +63,7 @@ mod wait;
 pub use error::{Error, Result};
 pub use keys::Key;
 pub use screen::{Cell, Color, Screen, Style};
-pub use terminal::{ExitStatus, Terminal, TerminalBuilder};
+pub use terminal::{ExitStatus, Scroll, Terminal, TerminalBuilder};
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by
 /// default), so [`assert_screen_snapshot!`] always agrees with the `insta`

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -15,9 +15,10 @@ use std::time::{Duration, Instant};
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
-use crate::emu::{Emulator, Query, Stop, Vt100Emulator};
+use crate::emu::{Emulator, InputModes, MouseMode, Query, Stop, Vt100Emulator};
 use crate::error::{Error, Result};
 use crate::keys::Key;
+use crate::keys::{mouse_legacy, mouse_sgr};
 use crate::screen::Screen;
 use crate::wait::{next_backoff, Expired, Monitor, INITIAL_BACKOFF, POLL_CAP};
 
@@ -48,6 +49,15 @@ fn pty_lifecycle_guard() -> std::sync::MutexGuard<'static, ()> {
 /// thread (query replies). `None` after teardown. Locked briefly per write;
 /// never while the emulator state lock is held.
 type SharedWriter = Arc<Mutex<Option<Box<dyn Write + Send>>>>;
+
+/// Scroll-wheel direction for [`Terminal::scroll`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scroll {
+    /// Wheel up (away from the user).
+    Up,
+    /// Wheel down (toward the user).
+    Down,
+}
 
 /// Exit status of the child process.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -590,6 +600,89 @@ impl Terminal {
     /// Same contract as [`send`](Self::send).
     pub fn send_str(&mut self, s: &str) {
         self.write_or_panic(s.as_bytes(), "literal text");
+    }
+
+    /// Click the primary button at `(col, row)` (0-based, like
+    /// [`Screen::cell`]). Sends a press — and, when the application's
+    /// tracking mode reports them, a release — encoded exactly as the
+    /// tracking mode and encoding **the application enabled** (SGR 1006
+    /// or the legacy byte form).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Input`] when the application has not enabled mouse
+    /// tracking (feeding it mouse bytes anyway would be misparsed as
+    /// garbage keys), or when the position is unrepresentable in the
+    /// legacy encoding (columns/rows beyond 222).
+    pub fn click(&mut self, col: u16, row: u16) -> Result<()> {
+        let modes = self.input_modes();
+        let press_only = match modes.mouse {
+            MouseMode::None => {
+                return Err(Error::Input(
+                    "the application has not enabled mouse tracking \
+                     (no CSI ?9/?1000/?1002/?1003 h was seen)"
+                        .into(),
+                ))
+            }
+            MouseMode::Press => true,
+            MouseMode::PressRelease => false,
+        };
+        let mut bytes = self.mouse_report(&modes, 0, col, row, true)?;
+        if !press_only {
+            bytes.extend(self.mouse_report(&modes, 0, col, row, false)?);
+        }
+        self.write_or_panic(&bytes, "a mouse click");
+        Ok(())
+    }
+
+    /// Scroll the wheel one notch at `(col, row)` (0-based).
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`click`](Self::click).
+    pub fn scroll(&mut self, col: u16, row: u16, direction: Scroll) -> Result<()> {
+        let modes = self.input_modes();
+        if modes.mouse == MouseMode::None {
+            return Err(Error::Input(
+                "the application has not enabled mouse tracking \
+                 (no CSI ?9/?1000/?1002/?1003 h was seen)"
+                    .into(),
+            ));
+        }
+        let button = match direction {
+            Scroll::Up => 64,
+            Scroll::Down => 65,
+        };
+        // Wheel events are presses only; there is no release.
+        let bytes = self.mouse_report(&modes, button, col, row, true)?;
+        self.write_or_panic(&bytes, "a mouse scroll");
+        Ok(())
+    }
+
+    fn input_modes(&self) -> InputModes {
+        self.shared.lock().emu.input_modes()
+    }
+
+    fn mouse_report(
+        &self,
+        modes: &InputModes,
+        button: u8,
+        col: u16,
+        row: u16,
+        press: bool,
+    ) -> Result<Vec<u8>> {
+        if modes.sgr_mouse {
+            return Ok(mouse_sgr(button, col, row, press));
+        }
+        if col > 222 || row > 222 {
+            return Err(Error::Input(format!(
+                "({col}, {row}) is unrepresentable in the legacy mouse \
+                 encoding the application selected (max 222)"
+            )));
+        }
+        // Legacy encoding: a release is button 3.
+        let button = if press { button } else { 3 };
+        Ok(mouse_legacy(button, col, row))
     }
 
     fn write_or_panic(&mut self, bytes: &[u8], what: &str) {

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -1,0 +1,56 @@
+//! Typed input beyond plain keys: mouse (mode-aware), and — as the tier
+//! progresses — modifier chords, bracketed paste, and cursor-key modes.
+
+use std::time::Duration;
+
+use termlens::{Error, Key, Scroll, Terminal};
+
+mod common;
+use common as util;
+
+fn spawn_form_echo() -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_secs(10))
+        .env_clear()
+        .spawn(util::fixture_bin("form-echo"))
+}
+
+#[test]
+fn clicks_round_trip_through_the_apps_tracking_mode() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    // crossterm enables SGR tracking; the click must arrive as one press
+    // and one release at the exact cell.
+    t.click(10, 5)?;
+    t.wait_frame(|s| s.contains("last: mouse:up:10,5"))?;
+
+    t.scroll(3, 2, Scroll::Up)?;
+    t.wait_frame(|s| s.contains("last: mouse:scrollup:3,2"))?;
+    t.scroll(3, 2, Scroll::Down)?;
+    t.wait_frame(|s| s.contains("last: mouse:scrolldown:3,2"))?;
+
+    t.send(Key::Esc);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn clicking_without_mouse_tracking_is_a_typed_error() {
+    // hello-tui never enables mouse tracking.
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_secs(10))
+        .env_clear()
+        .spawn(util::fixture_bin("hello-tui"))
+        .unwrap();
+    t.wait_until(|s| s.contains("╯")).unwrap();
+
+    let err = t.click(1, 1).unwrap_err();
+    assert!(matches!(err, Error::Input(_)), "got: {err}");
+    assert!(err.to_string().contains("mouse tracking"), "{err}");
+
+    t.send(Key::Char('q'));
+    assert!(t.wait_exit().unwrap().success());
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -218,6 +218,11 @@ call order is a trap.
 
 ## 6. Input encoding
 
+Mouse input is **mode-aware**: the emulator knows which tracking mode and
+encoding the application enabled (`?9/?1000/?1002/?1003`, SGR `?1006`),
+`click`/`scroll` encode to match, and no tracking enabled is a typed
+error — never bytes the application would misparse as keys.
+
 `Key::encode` maps to xterm *default-mode* sequences (CSI arrows, SS3
 F1–F4, CSI-tilde function keys, DEL for Backspace). Applications that
 enable application-cursor mode (DECCKM) still parse the CSI forms in every

--- a/fixtures/form-echo/src/main.rs
+++ b/fixtures/form-echo/src/main.rs
@@ -17,7 +17,10 @@
 use std::io::{self, Write};
 
 use crossterm::cursor::{Hide, MoveTo, Show};
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    KeyModifiers, MouseEvent, MouseEventKind,
+};
 use crossterm::style::Print;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, BeginSynchronizedUpdate, Clear, ClearType,
@@ -33,6 +36,18 @@ struct App {
 }
 
 /// Stable, greppable one-token description of a key event.
+/// Stable one-token description of a mouse event.
+fn describe_mouse(mouse: &MouseEvent) -> Option<String> {
+    let kind = match mouse.kind {
+        MouseEventKind::Down(_) => "down",
+        MouseEventKind::Up(_) => "up",
+        MouseEventKind::ScrollUp => "scrollup",
+        MouseEventKind::ScrollDown => "scrolldown",
+        _ => return None,
+    };
+    Some(format!("mouse:{kind}:{},{}", mouse.column, mouse.row))
+}
+
 fn describe(key: &KeyEvent) -> String {
     if let KeyCode::Char(c) = key.code {
         if key.modifiers.contains(KeyModifiers::CONTROL) {
@@ -100,21 +115,29 @@ fn draw_torn(out: &mut impl Write) -> io::Result<()> {
 }
 
 fn cleanup(out: &mut impl Write) -> io::Result<()> {
-    execute!(out, Show, LeaveAlternateScreen)?;
+    execute!(out, DisableMouseCapture, Show, LeaveAlternateScreen)?;
     disable_raw_mode()
 }
 
 fn main() -> io::Result<()> {
     enable_raw_mode()?;
     let mut out = io::stdout();
-    execute!(out, EnterAlternateScreen, Hide)?;
+    execute!(out, EnterAlternateScreen, Hide, EnableMouseCapture)?;
 
     let mut app = App::default();
     draw(&mut out, &app)?;
 
     loop {
-        let Event::Key(key) = event::read()? else {
-            continue;
+        let key = match event::read()? {
+            Event::Key(key) => key,
+            Event::Mouse(mouse) => {
+                if let Some(description) = describe_mouse(&mouse) {
+                    app.last = description;
+                    draw(&mut out, &app)?;
+                }
+                continue;
+            }
+            _ => continue,
         };
         if key.kind != KeyEventKind::Press {
             continue;


### PR DESCRIPTION
Closes #27. click(col, row) sends press+release (press-only under X10
mode) and scroll(col, row, Scroll) sends wheel events, encoded exactly
as the tracking mode and encoding the application enabled — SGR 1006
or the legacy byte form (with a typed error for coordinates the legacy
form cannot represent). No tracking enabled is Error::Input with a
clear message instead of bytes the app would misparse as garbage keys.

Plumbing shared with the rest of Tier 2: Emulator::input_modes()
surfaces mouse mode/encoding, bracketed paste, and application-cursor
state from the emulator. form-echo enables mouse capture and reports
events in a stable format; the round-trip test proves our encodings
against crossterm's parser at exact cells.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
