### PR TITLE
feat(terminal): paste() — bracketed paste as a first-class input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- `Terminal::paste(text)`: pastes the way a terminal pastes — wrapped in
+  bracketed-paste markers when the application enabled mode 2004 (one
+  `Paste` event, not a burst of key presses), plain bytes when it
+  didn't.
 - Modifier chords over special keys: `Key::Right.ctrl()`,
   `Key::Up.shift()`, `Key::F(5).ctrl().shift()` — the xterm
   CSI-modifier encodings, chainable, accepted by the same

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -52,11 +52,7 @@ pub(crate) struct InputModes {
     pub(crate) mouse: MouseMode,
     /// SGR (1006) mouse encoding active.
     pub(crate) sgr_mouse: bool,
-    // Read by paste() and cursor-key encoding, which land right after
-    // the mouse work in this tier; the mode snapshot ships whole.
-    #[allow(dead_code)]
     pub(crate) bracketed_paste: bool,
-    #[allow(dead_code)]
     pub(crate) application_cursor: bool,
 }
 

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -604,6 +604,28 @@ impl Terminal {
         self.write_or_panic(s.as_bytes(), "literal text");
     }
 
+    /// Paste text, the way a terminal pastes.
+    ///
+    /// When the application has enabled bracketed paste (mode 2004 —
+    /// crossterm's `EnableBracketedPaste`), the text arrives wrapped in
+    /// `ESC[200~ … ESC[201~` and the application sees **one paste
+    /// event**, not a burst of key presses. When it hasn't, the bytes
+    /// arrive plain — exactly like a real terminal.
+    ///
+    /// # Panics
+    ///
+    /// Same contract as [`send`](Self::send).
+    pub fn paste(&mut self, text: &str) {
+        if self.input_modes().bracketed_paste {
+            let mut bytes = b"\x1b[200~".to_vec();
+            bytes.extend_from_slice(text.as_bytes());
+            bytes.extend_from_slice(b"\x1b[201~");
+            self.write_or_panic(&bytes, "a bracketed paste");
+        } else {
+            self.write_or_panic(text.as_bytes(), "a paste");
+        }
+    }
+
     /// Click the primary button at `(col, row)` (0-based, like
     /// [`Screen::cell`]). Sends a press — and, when the application's
     /// tracking mode reports them, a release — encoded exactly as the

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -59,6 +59,41 @@ fn modifier_chords_round_trip_through_crossterms_parser() -> termlens::Result<()
 }
 
 #[test]
+fn paste_is_one_event_under_bracketed_paste() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    // One paste event — not eleven key presses — proves the wrapper.
+    t.paste("hello world");
+    t.wait_frame(|s| s.contains("input: hello world") && s.contains("last: paste:11"))?;
+
+    t.send(Key::Esc);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn paste_falls_back_to_plain_bytes_without_the_mode() -> termlens::Result<()> {
+    // A plain shell never enables mode 2004; the paste must arrive as
+    // raw bytes with no ESC[200~ wrapper.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo; ",
+                r#"reply=$(head -c 5); printf 'got:%s' "$reply"; read guard"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.paste("plain");
+    t.wait_until(|s| s.contains("got:plain"))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
 fn clicking_without_mouse_tracking_is_a_typed_error() {
     // hello-tui never enables mouse tracking.
     let mut t = Terminal::builder()

--- a/fixtures/form-echo/src/main.rs
+++ b/fixtures/form-echo/src/main.rs
@@ -18,8 +18,8 @@ use std::io::{self, Write};
 
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
-    KeyModifiers, MouseEvent, MouseEventKind,
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind,
 };
 use crossterm::style::Print;
 use crossterm::terminal::{
@@ -130,14 +130,26 @@ fn draw_torn(out: &mut impl Write) -> io::Result<()> {
 }
 
 fn cleanup(out: &mut impl Write) -> io::Result<()> {
-    execute!(out, DisableMouseCapture, Show, LeaveAlternateScreen)?;
+    execute!(
+        out,
+        DisableBracketedPaste,
+        DisableMouseCapture,
+        Show,
+        LeaveAlternateScreen
+    )?;
     disable_raw_mode()
 }
 
 fn main() -> io::Result<()> {
     enable_raw_mode()?;
     let mut out = io::stdout();
-    execute!(out, EnterAlternateScreen, Hide, EnableMouseCapture)?;
+    execute!(
+        out,
+        EnterAlternateScreen,
+        Hide,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
 
     let mut app = App::default();
     draw(&mut out, &app)?;
@@ -145,6 +157,12 @@ fn main() -> io::Result<()> {
     loop {
         let key = match event::read()? {
             Event::Key(key) => key,
+            Event::Paste(text) => {
+                app.last = format!("paste:{}", text.chars().count());
+                app.input.push_str(&text);
+                draw(&mut out, &app)?;
+                continue;
+            }
             Event::Mouse(mouse) => {
                 if let Some(description) = describe_mouse(&mouse) {
                     app.last = description;


### PR DESCRIPTION
Closes #29. paste(text) wraps in ESC[200~…ESC[201~ when the
application enabled mode 2004 (the app sees ONE Paste event, not a
burst of key presses — proven by form-echo counting exactly one
event) and sends plain bytes when it did not, exactly like a real
terminal. Same panic contract as send. One method, zero options.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
