### PR TITLE
feat(keys): cursor keys follow the app's DECCKM mode; document Esc/Alt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- Cursor keys are **mode-aware**: while the application has DECCKM
+  (application cursor mode) set, `send(Key::Up)` emits the `ESC O A`
+  form a real terminal would — the emulator knows the mode. `Key::encode`
+  still documents the default-mode bytes, and the `Esc`-then-key wire
+  ambiguity (identical to an Alt chord) is now documented on `Key::Esc`
+  with the working idiom.
 - `Terminal::paste(text)`: pastes the way a terminal pastes — wrapped in
   bracketed-paste markers when the application enabled mode 2004 (one
   `Paste` event, not a burst of key presses), plain bytes when it

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -1,11 +1,12 @@
 //! Typed key input and its byte encodings.
 //!
 //! Every [`Key`] maps to the byte sequence an `xterm`-compatible terminal
-//! sends in its default modes (normal keypad, no application cursor keys).
-//! Applications that enable DECCKM application-cursor mode still accept the
-//! CSI forms in every mainstream input parser (crossterm, termion, ncurses),
-//! so v0.1 keeps the mapping static; see `docs/DESIGN.md` for the roadmap
-//! entry on mode-aware encoding.
+//! sends. [`Key::encode`] gives the default-mode form; when sent through
+//! [`Terminal::send`](crate::Terminal::send), cursor keys (arrows,
+//! Home/End) automatically switch to their `ESC O _` application forms
+//! while the application has DECCKM set — the emulator knows the mode, so
+//! the bytes always match what the application configured its terminal to
+//! send.
 
 /// A key press to send to the terminal.
 ///
@@ -18,6 +19,19 @@ pub enum Key {
     /// delivers as end-of-line in both raw and canonical modes.
     Enter,
     /// The Escape key alone (byte `0x1B`).
+    ///
+    /// **Wire ambiguity**: `Esc` immediately followed by another key is
+    /// byte-identical to an [`Alt`](Key::Alt) chord, and every input
+    /// parser resolves it as one — real keyboards are saved only by human
+    /// inter-key delay, which [`send`](crate::Terminal::send) does not
+    /// add. Make the `Esc`'s effect observable and wait for it before
+    /// sending the next key:
+    ///
+    /// ```text
+    /// t.send(Key::Esc);
+    /// t.wait_until(|s| s.contains("NORMAL"))?; // Esc took effect
+    /// t.send(Key::Char('?'));                  // now unambiguous
+    /// ```
     Esc,
     /// Tab (`0x09`).
     Tab,
@@ -54,7 +68,10 @@ pub enum Key {
 }
 
 impl Key {
-    /// The exact bytes this key sends, per xterm defaults.
+    /// The exact bytes this key sends, per xterm defaults (normal cursor
+    /// mode). [`Terminal::send`](crate::Terminal::send) prefers the
+    /// mode-aware encoding, switching cursor keys to `ESC O _` while the
+    /// application has DECCKM set.
     ///
     /// # Panics
     ///
@@ -137,7 +154,22 @@ pub trait Input: sealed::Sealed {
 }
 
 impl Input for Key {
-    fn encode_modal(&self, _application_cursor: bool) -> Vec<u8> {
+    fn encode_modal(&self, application_cursor: bool) -> Vec<u8> {
+        if application_cursor {
+            // DECCKM: cursor keys send SS3 forms.
+            let ss3 = match self {
+                Key::Up => Some(b'A'),
+                Key::Down => Some(b'B'),
+                Key::Right => Some(b'C'),
+                Key::Left => Some(b'D'),
+                Key::Home => Some(b'H'),
+                Key::End => Some(b'F'),
+                _ => None,
+            };
+            if let Some(final_byte) = ss3 {
+                return vec![0x1b, b'O', final_byte];
+            }
+        }
         self.encode()
     }
 }
@@ -336,6 +368,18 @@ mod tests {
         for (key, bytes) in table {
             assert_eq!(key.encode(), *bytes, "wrong encoding for {key:?}");
         }
+    }
+
+    #[test]
+    fn cursor_keys_switch_to_ss3_under_application_cursor_mode() {
+        assert_eq!(Key::Up.encode_modal(true), b"\x1bOA");
+        assert_eq!(Key::End.encode_modal(true), b"\x1bOF");
+        assert_eq!(Key::Up.encode_modal(false), b"\x1b[A");
+        // Only cursor keys switch; everything else is mode-independent.
+        assert_eq!(Key::F(5).encode_modal(true), Key::F(5).encode());
+        assert_eq!(Key::Delete.encode_modal(true), Key::Delete.encode());
+        // Chords stay CSI-modified regardless of mode.
+        assert_eq!(Key::Up.ctrl().encode_modal(true), b"\x1b[1;5A");
     }
 
     #[test]

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -94,6 +94,36 @@ fn paste_falls_back_to_plain_bytes_without_the_mode() -> termlens::Result<()> {
 }
 
 #[test]
+fn arrows_follow_the_apps_cursor_key_mode() -> termlens::Result<()> {
+    // The script enables DECCKM (CSI ?1 h), reads 3 bytes, reports them,
+    // then disables it and reads again — one terminal, both modes.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo; printf '[?1hAPP '; ",
+                r#"a=$(head -c 3 | tr '' 'E'); printf 'got:%s ' "$a"; "#,
+                r"printf '[?1lNORM '; ",
+                r#"b=$(head -c 3 | tr '' 'E'); printf 'got:%s' "$b"; read guard"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+
+    t.wait_until(|s| s.contains("APP"))?;
+    t.send(Key::Up);
+    t.wait_until(|s| s.contains("got:EOA"))?;
+
+    t.wait_until(|s| s.contains("NORM"))?;
+    t.send(Key::Up);
+    t.wait_until(|s| s.contains("got:E[A"))?;
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
 fn clicking_without_mouse_tracking_is_a_typed_error() {
     // hello-tui never enables mouse tracking.
     let mut t = Terminal::builder()

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -223,10 +223,13 @@ encoding the application enabled (`?9/?1000/?1002/?1003`, SGR `?1006`),
 `click`/`scroll` encode to match, and no tracking enabled is a typed
 error — never bytes the application would misparse as keys.
 
-`Key::encode` maps to xterm *default-mode* sequences (CSI arrows, SS3
-F1–F4, CSI-tilde function keys, DEL for Backspace). Applications that
-enable application-cursor mode (DECCKM) still parse the CSI forms in every
-mainstream input stack, so v0.1 does not track terminal modes for output.
-If a real-world app under test needs mode-aware encoding, the emulator
-already knows the mode — the hook exists, the complexity is deferred until
-someone actually needs it.
+`Key::encode` documents the xterm *default-mode* sequences (CSI arrows,
+SS3 F1–F4, CSI-tilde function keys, DEL for Backspace). `send` is
+mode-aware: cursor keys switch to their `ESC O _` application forms while
+DECCKM is set, bracketed paste wraps only when mode 2004 is on, and mouse
+reports match the tracking mode/encoding the application enabled — the
+emulator knows every one of these modes, and the input path consults it,
+so the bytes always match what the application configured its "terminal"
+to send. The one thing no encoding can fix is the wire itself: `Esc`
+immediately followed by another key is byte-identical to an Alt chord;
+the documented idiom is to wait for the Esc's visible effect first.


### PR DESCRIPTION
Closes #30, completing Tier 2. While the application has application
cursor mode set (CSI ?1 h), send(Key::Up) emits ESC O A — the form a
real terminal sends — and switches back when the mode resets; the
end-to-end test drives one shell through both modes. Chords stay
CSI-modified regardless, matching xterm. Key::encode keeps documenting
the default-mode bytes.

The Esc-then-key wire ambiguity (byte-identical to an Alt chord, no
inter-key delay to save you) is now documented on Key::Esc with the
working idiom: make the Esc's effect observable, wait for it, then
send the next key. DESIGN §6 rewritten: the input path is mode-aware
across cursor keys, paste, and mouse.

Signed-off-by: Vyncint Ng <vyncint@icloud.com>
