### PR TITLE
feat(screen): expose out-of-band terminal state on snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- Out-of-band terminal state is readable from every `Screen` snapshot:
+  `title()` (tracked from `OSC 0`/`OSC 2` by termlens itself — the
+  emulator backend doesn't need to support it), `alternate_screen()`,
+  `bracketed_paste()`, `application_cursor()`, and `mouse_mode()` (the
+  new public `MouseMode` enum, reporting the exact tracking mode the
+  application enabled). State that previously could only be inferred
+  from grid contents is now a plain assertion:
+  `wait_until(|s| s.alternate_screen())`. None of it appears in the
+  snapshot text format — existing snapshot files stay valid.
 - Cursor keys are **mode-aware**: while the application has DECCKM
   (application cursor mode) set, `send(Key::Up)` emits the `ESC O A`
   form a real terminal would — the emulator knows the mode. `Key::encode`

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -11,6 +11,7 @@ mod vt100;
 pub(crate) use self::seq::Query;
 pub(crate) use self::vt100::Vt100Emulator;
 
+use crate::screen::MouseMode;
 use crate::Screen;
 
 /// Why the emulator stopped consuming mid-segment.
@@ -31,17 +32,6 @@ pub(crate) struct Processed {
     pub(crate) consumed: usize,
     /// Set when consumption stopped before the end of the input.
     pub(crate) stop: Option<Stop>,
-}
-
-/// Which mouse events the application asked the terminal to report.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MouseMode {
-    /// No mouse tracking enabled.
-    None,
-    /// X10: presses only (mode 9).
-    Press,
-    /// Presses and releases (mode 1000), possibly with motion (1002/1003).
-    PressRelease,
 }
 
 /// Input-affecting terminal modes the application has set — the emulator

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -12,6 +12,18 @@
 //!    repaint; the byte that ends one marks a complete frame. Parameters
 //!    are parsed incrementally in O(1) space, and `?2026` is recognized
 //!    anywhere in a multi-mode list such as `CSI ? 2026 ; 25 h`.
+//!
+//! It also tracks the one piece of screen state the vt100 backend does not
+//! expose: the **window title** (`OSC 0`/`OSC 2`), kept whole in its own
+//! buffer — the diagnostic capture below truncates at 24 bytes, real titles
+//! don't fit.
+
+use std::sync::Arc;
+
+/// OSC strings are captured whole (titles must not truncate), but bounded:
+/// a buggy or hostile stream must not grow memory without limit. No real
+/// title comes anywhere near this.
+const OSC_CAPTURE_MAX: usize = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum State {
@@ -108,9 +120,15 @@ pub(crate) struct SeqTracker {
     csi_param_count: u8,
     csi_saw_2026: bool,
     /// Raw capture of the current sequence (from ESC), for diagnostics
-    /// and OSC/DCS query recognition. Bounded; long sequences truncate.
+    /// and DCS query recognition. Bounded; long sequences truncate.
     seq_buf: [u8; 24],
     seq_len: u8,
+    /// Content bytes of the current OSC string (no `ESC ]`, no
+    /// terminator), kept whole so titles never truncate.
+    osc_buf: Vec<u8>,
+    /// The window title as most recently set via `OSC 0`/`OSC 2`; empty
+    /// until the application sets one. Shared so snapshots clone for free.
+    title: Arc<str>,
 }
 
 impl SeqTracker {
@@ -129,6 +147,8 @@ impl SeqTracker {
             csi_saw_2026: false,
             seq_buf: [0; 24],
             seq_len: 0,
+            osc_buf: Vec::new(),
+            title: Arc::from(""),
         }
     }
 
@@ -148,6 +168,12 @@ impl SeqTracker {
         self.sync_update
     }
 
+    /// The window title as most recently set via `OSC 0`/`OSC 2` (empty
+    /// until the application sets one).
+    pub(crate) fn title(&self) -> Arc<str> {
+        Arc::clone(&self.title)
+    }
+
     fn reset_csi_scanner(&mut self) {
         self.csi_prefix = 0;
         self.csi_invalid = false;
@@ -163,6 +189,12 @@ impl SeqTracker {
         if usize::from(self.seq_len) < self.seq_buf.len() {
             self.seq_buf[usize::from(self.seq_len)] = b;
             self.seq_len += 1;
+        }
+    }
+
+    fn push_osc(&mut self, b: u8) {
+        if self.osc_buf.len() < OSC_CAPTURE_MAX {
+            self.osc_buf.push(b);
         }
     }
 
@@ -257,17 +289,11 @@ impl SeqTracker {
 
     /// The event (if any) implied by a completed OSC or DCS string.
     fn string_final(&mut self, was_osc: bool, st_terminated: bool) -> SeqEvent {
-        let body = &self.seq_buf[..usize::from(self.seq_len)];
         if was_osc {
-            // body is `ESC ] <content> [terminator…]`; a color query is
-            // exactly `10;?` or `11;?` (12 = cursor color: unanswerable).
-            let content_end = if st_terminated {
-                body.len().saturating_sub(2) // strip ESC \
-            } else {
-                body.len().saturating_sub(1) // strip BEL
-            };
-            let content = body.get(2..content_end).unwrap_or(b"");
-            match content {
+            // `osc_buf` holds exactly the content (`ESC ]` and terminator
+            // stripped). A color query is exactly `10;?` or `11;?`
+            // (12 = cursor color: unanswerable).
+            match self.osc_buf.as_slice() {
                 b"10;?" => {
                     return SeqEvent::Query(Query::OscColor {
                         code: 10,
@@ -281,10 +307,22 @@ impl SeqTracker {
                     })
                 }
                 b"12;?" => return SeqEvent::Query(Query::Unanswerable(self.seq_printable())),
-                _ => return SeqEvent::None,
+                content => {
+                    // OSC 0 (icon + title) / OSC 2 (title) set the window
+                    // title — state the vt100 backend does not track.
+                    // OSC 1 (icon only) is deliberately ignored.
+                    if let Some(title) = content
+                        .strip_prefix(b"0;")
+                        .or_else(|| content.strip_prefix(b"2;"))
+                    {
+                        self.title = Arc::from(String::from_utf8_lossy(title));
+                    }
+                    return SeqEvent::None;
+                }
             }
         }
         // DCS: XTGETTCAP is `ESC P + q … ST` — a capability question.
+        let body = &self.seq_buf[..usize::from(self.seq_len)];
         if body.get(2..4) == Some(b"+q") {
             return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
         }
@@ -327,7 +365,10 @@ impl SeqTracker {
                     self.reset_csi_scanner();
                     State::Csi
                 }
-                b']' => State::Osc,
+                b']' => {
+                    self.osc_buf.clear();
+                    State::Osc
+                }
                 // DCS, SOS, PM, APC — string sequences terminated by ST.
                 b'P' | b'X' | b'^' | b'_' => State::Dcs,
                 0x20..=0x2f => State::EscIntermediate,
@@ -362,7 +403,10 @@ impl SeqTracker {
                 }
                 ESC => State::OscEsc,
                 CAN | SUB => State::Ground,
-                _ => State::Osc,
+                _ => {
+                    self.push_osc(b);
+                    State::Osc
+                }
             },
             State::Dcs => match b {
                 ESC => State::DcsEsc,
@@ -587,6 +631,53 @@ mod tests {
         assert!(queries_of(b"\x1b]0;title\x07").is_empty()); // set title
         assert!(queries_of(b"\x1b[1;6H").is_empty()); // cursor move
         assert!(queries_of(b"plain text").is_empty());
+    }
+
+    #[test]
+    fn osc_0_and_2_set_the_title_via_bel_or_st() {
+        let mut t = SeqTracker::new();
+        assert_eq!(&*t.title(), "");
+        t.feed(b"\x1b]2;hello world\x07");
+        assert_eq!(&*t.title(), "hello world");
+        t.feed("\x1b]0;second ✓\x1b\\".as_bytes());
+        assert_eq!(&*t.title(), "second ✓");
+    }
+
+    #[test]
+    fn titles_longer_than_the_diagnostic_capture_are_kept_whole() {
+        let mut t = SeqTracker::new();
+        let title = "t".repeat(80); // seq_buf truncates at 24; titles must not
+        t.feed(format!("\x1b]2;{title}\x07").as_bytes());
+        assert_eq!(&*t.title(), title.as_str());
+    }
+
+    #[test]
+    fn title_survives_chunked_delivery() {
+        let mut t = SeqTracker::new();
+        t.feed(b"\x1b]2;split");
+        t.feed(b" title\x07");
+        assert_eq!(&*t.title(), "split title");
+    }
+
+    #[test]
+    fn title_keeps_embedded_semicolons() {
+        let mut t = SeqTracker::new();
+        t.feed(b"\x1b]0;a;b;c\x07");
+        assert_eq!(&*t.title(), "a;b;c");
+    }
+
+    #[test]
+    fn icon_only_and_aborted_titles_do_not_change_the_title() {
+        let mut t = SeqTracker::new();
+        t.feed(b"\x1b]2;kept\x07");
+        t.feed(b"\x1b]1;icon only\x07"); // OSC 1: icon name, not the title
+        assert_eq!(&*t.title(), "kept");
+        t.feed(b"\x1b]2;aborted\x18"); // CAN aborts the string
+        assert_eq!(&*t.title(), "kept");
+        t.feed(b"\x1b]2;also aborted\x1b[31m"); // ESC starts a new sequence
+        assert_eq!(&*t.title(), "kept");
+        t.feed(b"\x1b]2;\x07"); // explicitly set empty: cleared
+        assert_eq!(&*t.title(), "");
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -2,8 +2,8 @@
 //! snapshot converts vt100's grid into termlens's own [`Screen`].
 
 use super::seq::{SeqEvent, SeqTracker};
-use super::{Emulator, InputModes, MouseMode, Processed, Stop};
-use crate::screen::{Cell, Color, Screen, Style};
+use super::{Emulator, InputModes, Processed, Stop};
+use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
 
 pub(crate) struct Vt100Emulator {
     parser: ::vt100::Parser,
@@ -58,6 +58,13 @@ impl Emulator for Vt100Emulator {
             }
         }
         let (cursor_row, cursor_col) = screen.cursor_position();
+        let state = TermState {
+            title: self.tracker.title(),
+            alternate_screen: screen.alternate_screen(),
+            bracketed_paste: screen.bracketed_paste(),
+            application_cursor: screen.application_cursor(),
+            mouse: convert_mouse(screen.mouse_protocol_mode()),
+        };
         Screen::from_parts(
             cols,
             rows,
@@ -65,6 +72,7 @@ impl Emulator for Vt100Emulator {
             cursor_col,
             !screen.hide_cursor(),
             cells,
+            state,
         )
     }
 
@@ -78,13 +86,8 @@ impl Emulator for Vt100Emulator {
 
     fn input_modes(&self) -> InputModes {
         let screen = self.parser.screen();
-        let mouse = match screen.mouse_protocol_mode() {
-            ::vt100::MouseProtocolMode::None => MouseMode::None,
-            ::vt100::MouseProtocolMode::Press => MouseMode::Press,
-            _ => MouseMode::PressRelease,
-        };
         InputModes {
-            mouse,
+            mouse: convert_mouse(screen.mouse_protocol_mode()),
             sgr_mouse: matches!(
                 screen.mouse_protocol_encoding(),
                 ::vt100::MouseProtocolEncoding::Sgr
@@ -96,6 +99,16 @@ impl Emulator for Vt100Emulator {
 
     fn set_size(&mut self, rows: u16, cols: u16) {
         self.parser.screen_mut().set_size(rows, cols);
+    }
+}
+
+fn convert_mouse(mode: ::vt100::MouseProtocolMode) -> MouseMode {
+    match mode {
+        ::vt100::MouseProtocolMode::None => MouseMode::None,
+        ::vt100::MouseProtocolMode::Press => MouseMode::Press,
+        ::vt100::MouseProtocolMode::PressRelease => MouseMode::PressRelease,
+        ::vt100::MouseProtocolMode::ButtonMotion => MouseMode::ButtonMotion,
+        ::vt100::MouseProtocolMode::AnyMotion => MouseMode::AnyMotion,
     }
 }
 
@@ -217,6 +230,28 @@ mod tests {
         assert!(!emu.mid_sequence()); // the escape itself is finished
         feed_all(&mut emu, b"\x1b[?2026l");
         assert!(!emu.in_sync_update());
+    }
+
+    #[test]
+    fn snapshot_carries_out_of_band_terminal_state() {
+        let emu = emu_with(b"\x1b]0;my app\x07\x1b[?1049h\x1b[?2004h\x1b[?1h\x1b[?1002h");
+        let s = emu.snapshot();
+        assert_eq!(s.title(), "my app");
+        assert!(s.alternate_screen());
+        assert!(s.bracketed_paste());
+        assert!(s.application_cursor());
+        assert_eq!(s.mouse_mode(), MouseMode::ButtonMotion);
+    }
+
+    #[test]
+    fn snapshot_state_defaults_until_the_app_sets_it() {
+        let emu = emu_with(b"plain");
+        let s = emu.snapshot();
+        assert_eq!(s.title(), "");
+        assert!(!s.alternate_screen());
+        assert!(!s.bracketed_paste());
+        assert!(!s.application_cursor());
+        assert_eq!(s.mouse_mode(), MouseMode::None);
     }
 
     #[test]

--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -83,7 +83,7 @@ impl Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::screen::{Cell, Style};
+    use crate::screen::{Cell, Style, TermState};
 
     fn tiny_screen() -> Screen {
         let mut cells = Vec::new();
@@ -91,7 +91,7 @@ mod tests {
             cells.push(Cell::new(ch.to_string(), Style::default(), false, false));
         }
         cells.push(Cell::new(String::new(), Style::default(), false, false));
-        Screen::from_parts(3, 1, 0, 2, true, cells)
+        Screen::from_parts(3, 1, 0, 2, true, cells, TermState::default())
     }
 
     #[test]

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -62,7 +62,7 @@ mod wait;
 
 pub use error::{Error, Result};
 pub use keys::{Chord, Input, Key};
-pub use screen::{Cell, Color, Screen, Style};
+pub use screen::{Cell, Color, MouseMode, Screen, Style};
 pub use terminal::{ExitStatus, Scroll, Terminal, TerminalBuilder};
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -41,6 +41,54 @@ pub struct Style {
     pub reverse: bool,
 }
 
+/// Which mouse events the application asked its terminal to report.
+///
+/// Read it from a snapshot via [`Screen::mouse_mode`];
+/// [`Terminal::click`](crate::Terminal::click) and
+/// [`Terminal::scroll`](crate::Terminal::scroll) consult the same state to
+/// encode exactly what the application expects.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum MouseMode {
+    /// No mouse tracking enabled.
+    #[default]
+    None,
+    /// X10 mode (`CSI ?9 h`): presses only.
+    Press,
+    /// VT200 mode (`CSI ?1000 h`): presses and releases.
+    PressRelease,
+    /// Button-event tracking (`CSI ?1002 h`): presses, releases, and motion
+    /// while a button is held down.
+    ButtonMotion,
+    /// Any-event tracking (`CSI ?1003 h`): presses, releases, and all
+    /// motion.
+    AnyMotion,
+}
+
+/// Out-of-band terminal state captured with each snapshot. Deliberately
+/// invisible in the text rendering (existing snapshot files stay valid);
+/// exposed through the accessors on [`Screen`].
+#[derive(Debug, Clone)]
+pub(crate) struct TermState {
+    pub(crate) title: Arc<str>,
+    pub(crate) alternate_screen: bool,
+    pub(crate) bracketed_paste: bool,
+    pub(crate) application_cursor: bool,
+    pub(crate) mouse: MouseMode,
+}
+
+impl Default for TermState {
+    fn default() -> Self {
+        Self {
+            title: Arc::from(""),
+            alternate_screen: false,
+            bracketed_paste: false,
+            application_cursor: false,
+            mouse: MouseMode::None,
+        }
+    }
+}
+
 /// One cell of the screen grid.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cell {
@@ -109,6 +157,7 @@ pub struct Screen {
     cursor_col: u16,
     cursor_visible: bool,
     cells: Arc<[Cell]>,
+    state: TermState,
 }
 
 impl Screen {
@@ -119,6 +168,7 @@ impl Screen {
         cursor_col: u16,
         cursor_visible: bool,
         cells: Vec<Cell>,
+        state: TermState,
     ) -> Self {
         debug_assert_eq!(cells.len(), usize::from(cols) * usize::from(rows));
         Self {
@@ -128,6 +178,7 @@ impl Screen {
             cursor_col,
             cursor_visible,
             cells: cells.into(),
+            state,
         }
     }
 
@@ -156,6 +207,53 @@ impl Screen {
     #[must_use]
     pub fn cursor(&self) -> (u16, u16, bool) {
         (self.cursor_row, self.cursor_col, self.cursor_visible)
+    }
+
+    /// The window title, as the application most recently set it (`OSC 0`
+    /// or `OSC 2` — crossterm's `SetTitle`). Empty until the application
+    /// sets one; `OSC 1` (icon name only) is ignored. termlens tracks the
+    /// title itself, so it works regardless of the emulator backend.
+    ///
+    /// Like all out-of-band state, the title is not part of the
+    /// [`Display`](fmt::Display) rendering — assert on it directly:
+    /// `wait_until(|s| s.title() == "editor — draft.txt")`.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.state.title
+    }
+
+    /// True while the application has the alternate screen active (modes
+    /// 47/1049) — the buffer full-screen TUIs switch to on startup and
+    /// leave on exit, restoring the shell's scrollback.
+    #[must_use]
+    pub fn alternate_screen(&self) -> bool {
+        self.state.alternate_screen
+    }
+
+    /// True while bracketed paste (mode 2004) is enabled.
+    /// [`Terminal::paste`](crate::Terminal::paste) consults this: the text
+    /// then arrives as one paste event instead of a burst of key presses.
+    #[must_use]
+    pub fn bracketed_paste(&self) -> bool {
+        self.state.bracketed_paste
+    }
+
+    /// True while application cursor mode (DECCKM) is set.
+    /// [`Terminal::send`](crate::Terminal::send) consults this: arrow keys
+    /// then use their `ESC O` application forms.
+    #[must_use]
+    pub fn application_cursor(&self) -> bool {
+        self.state.application_cursor
+    }
+
+    /// Which mouse events the application asked to be reported —
+    /// [`MouseMode::None`] until it enables a tracking mode.
+    /// [`Terminal::click`](crate::Terminal::click) and
+    /// [`Terminal::scroll`](crate::Terminal::scroll) consult the same
+    /// state, so their reports always match what the application expects.
+    #[must_use]
+    pub fn mouse_mode(&self) -> MouseMode {
+        self.state.mouse
     }
 
     /// The cell at `(row, col)`, or `None` when out of bounds.
@@ -426,7 +524,7 @@ mod tests {
             }
             cells.extend(row_cells);
         }
-        Screen::from_parts(cols, rows, 1, 2, true, cells)
+        Screen::from_parts(cols, rows, 1, 2, true, cells, TermState::default())
     }
 
     #[test]
@@ -506,7 +604,7 @@ mod tests {
             };
             cells.push(Cell::new(String::new(), style, false, false));
         }
-        let screen = Screen::from_parts(6, 3, 0, 0, true, cells);
+        let screen = Screen::from_parts(6, 3, 0, 0, true, cells, TermState::default());
 
         let rendered = screen.with_styles().to_string();
         let styles_block = rendered.split("\n\nstyles:\n").nth(1).unwrap();
@@ -533,7 +631,7 @@ mod tests {
             cells.push(Cell::new(ch.to_string(), style, false, false));
         }
         cells.push(Cell::new(String::new(), Style::default(), false, false));
-        let screen = Screen::from_parts(4, 1, 0, 0, true, cells);
+        let screen = Screen::from_parts(4, 1, 0, 0, true, cells, TermState::default());
         let rendered = screen.with_styles().to_string();
         assert!(
             rendered.ends_with("styles:\n0: 0-2 bg=#1e1e2e"),
@@ -545,5 +643,30 @@ mod tests {
     fn display_format_matches_spec() {
         let s = screen(10, 2, &["hi"]);
         assert_eq!(format!("{s}"), "size: 10x2  cursor: 1,2\nhi\n");
+    }
+
+    #[test]
+    fn state_accessors_report_the_captured_state_and_stay_out_of_display() {
+        let default = screen(4, 1, &["x"]);
+        assert_eq!(default.title(), "");
+        assert!(!default.alternate_screen());
+        assert!(!default.bracketed_paste());
+        assert!(!default.application_cursor());
+        assert_eq!(default.mouse_mode(), MouseMode::None);
+
+        let state = TermState {
+            title: Arc::from("my app"),
+            alternate_screen: true,
+            bracketed_paste: true,
+            application_cursor: true,
+            mouse: MouseMode::AnyMotion,
+        };
+        let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
+        let s = Screen::from_parts(1, 1, 0, 0, true, cells, state);
+        assert_eq!(s.title(), "my app");
+        assert!(s.alternate_screen() && s.bracketed_paste() && s.application_cursor());
+        assert_eq!(s.mouse_mode(), MouseMode::AnyMotion);
+        // Out-of-band state never leaks into the text format.
+        assert_eq!(format!("{s}"), "size: 1x1  cursor: 0,0\nx");
     }
 }

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -15,11 +15,11 @@ use std::time::{Duration, Instant};
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
-use crate::emu::{Emulator, InputModes, MouseMode, Query, Stop, Vt100Emulator};
+use crate::emu::{Emulator, InputModes, Query, Stop, Vt100Emulator};
 use crate::error::{Error, Result};
 use crate::keys::Input;
 use crate::keys::{mouse_legacy, mouse_sgr};
-use crate::screen::Screen;
+use crate::screen::{MouseMode, Screen};
 use crate::wait::{next_backoff, Expired, Monitor, INITIAL_BACKOFF, POLL_CAP};
 
 /// How long `wait_exit` keeps draining PTY output after the child has been
@@ -649,7 +649,7 @@ impl Terminal {
                 ))
             }
             MouseMode::Press => true,
-            MouseMode::PressRelease => false,
+            MouseMode::PressRelease | MouseMode::ButtonMotion | MouseMode::AnyMotion => false,
         };
         let mut bytes = self.mouse_report(&modes, 0, col, row, true)?;
         if !press_only {

--- a/crates/termlens/tests/state.rs
+++ b/crates/termlens/tests/state.rs
@@ -1,0 +1,77 @@
+//! Out-of-band terminal state on `Screen`: title, alternate screen, and
+//! the input modes — asserted directly instead of inferred from the grid.
+
+use std::time::Duration;
+
+use termlens::{Key, MouseMode, Terminal};
+
+/// One script walks the whole state surface: set everything, assert, then
+/// unwind everything and assert the way back.
+#[test]
+fn screen_reports_title_alternate_screen_and_input_modes() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"printf '\033]0;termlens state\007'; ",
+                r"printf '\033[?1049h\033[?2004h\033[?1h\033[?1002h'; ",
+                r"printf 'modes: on'; ",
+                r"read _; ",
+                r"printf '\033]2;phase two\033\\'; ",
+                r"printf '\033[?1002l\033[?1l\033[?2004l\033[?1049l'; ",
+                r"printf 'modes: off'; ",
+                r"read _",
+            ),
+        ])
+        .spawn("sh")?;
+
+    // State assertions are ordinary predicates — waitable like any text.
+    t.wait_until(|s| {
+        s.contains("modes: on")
+            && s.title() == "termlens state"
+            && s.alternate_screen()
+            && s.bracketed_paste()
+            && s.application_cursor()
+            && s.mouse_mode() == MouseMode::ButtonMotion
+    })?;
+
+    t.send(Key::Enter);
+    t.wait_until(|s| {
+        s.contains("modes: off")
+            && s.title() == "phase two" // OSC 2, ST-terminated
+            && !s.alternate_screen()
+            && !s.bracketed_paste()
+            && !s.application_cursor()
+            && s.mouse_mode() == MouseMode::None
+    })?;
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The tracking mode the app enabled is reported by name, not collapsed.
+#[test]
+fn mouse_mode_reports_the_exact_tracking_mode() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"printf '\033[?9h9\n'; read _; ",
+                r"printf '\033[?9l\033[?1000h1000\n'; read _; ",
+                r"printf '\033[?1000l\033[?1003h1003\n'; read _",
+            ),
+        ])
+        .spawn("sh")?;
+
+    t.wait_until(|s| s.contains("9") && s.mouse_mode() == MouseMode::Press)?;
+    t.send(Key::Enter);
+    t.wait_until(|s| s.contains("1000") && s.mouse_mode() == MouseMode::PressRelease)?;
+    t.send(Key::Enter);
+    t.wait_until(|s| s.contains("1003") && s.mouse_mode() == MouseMode::AnyMotion)?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -185,6 +185,17 @@ Rules:
    Wide-character continuation cells participate in spans like any other
    cell.
 
+6. **Out-of-band terminal state is not part of the text format.** The
+   window title (tracked by termlens itself from `OSC 0`/`OSC 2` — the
+   vt100 backend does not expose it), the alternate-screen flag, and the
+   input modes (bracketed paste, application cursor, mouse tracking) are
+   captured with every snapshot and read through plain accessors —
+   `Screen::title`, `Screen::alternate_screen`, `Screen::bracketed_paste`,
+   `Screen::application_cursor`, `Screen::mouse_mode`. Keeping them out of
+   the rendering means existing snapshot files stay valid, and state
+   assertions read as ordinary predicates:
+   `wait_until(|s| s.alternate_screen())`.
+
 The `insta` feature (default) re-exports `insta` and ships
 `assert_screen_snapshot!` so the snapshotting insta version can't drift
 from the one the macro targets.


### PR DESCRIPTION
State that isn't a cell could previously only be inferred from grid contents (demo study §4.3). Every `Screen` now carries it, read through plain accessors:

- `title()` — tracked by termlens itself from `OSC 0`/`OSC 2` in the sequence tracker, kept whole in a dedicated buffer (the 24-byte diagnostic capture truncates; vt100 0.16 does not expose titles). BEL- and ST-terminated forms both work; `OSC 1` (icon-only) is ignored; aborted strings never set a title.
- `alternate_screen()`, `bracketed_paste()`, `application_cursor()` — free from the emulator.
- `mouse_mode()` — `MouseMode` goes public and now reports the **exact** tracking mode: `ButtonMotion` (1002) and `AnyMotion` (1003) are no longer collapsed into `PressRelease`. `click`/`scroll` behavior is unchanged.

Per the minimalism bar: no new concepts — booleans, one small enum, and `&str` on the existing `Screen`. Nothing enters the snapshot text format (DESIGN.md §3 rule 6 added), so existing snapshot files stay valid and state assertions read as ordinary predicates: `wait_until(|s| s.alternate_screen())`.

Tests: seq-tracker unit tests (chunked delivery, long titles, semicolons, aborts, empty-clear), vt100 state-capture tests, screen accessor tests, and a new `tests/state.rs` integration suite walking the full surface up and back down, plus exact-mode reporting for 9/1000/1003.

Closes #31