### PR TITLE
feat(terminal): process ergonomics — current_dir, pid, signal, wait_until_for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- Process ergonomics: `TerminalBuilder::current_dir(dir)` runs the child
+  in a chosen working directory (no more `cd … && …` through a shell);
+  `Terminal::pid()` exposes the child's process id;
+  `Terminal::signal(Signal::Term)` (Unix) delivers real signals so
+  graceful-shutdown paths are testable — with a guard that refuses to
+  signal an already-reaped pid, which the OS may have reused; and
+  `wait_until_for(pred, timeout)` gives the one known-slow wait its own
+  deadline instead of dragging the builder default up for every wait.
 - Three `Screen` query helpers, each earned by a documented pain in the
   first real user's test suite: `rect_text(cols, rows)` — the text
   inside a rectangle (any range expression, clamped to the screen), for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "insta",
+ "libc",
  "portable-pty",
  "thiserror 2.0.20",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ portable-pty = "0.9"
 vt100 = "0.16"
 thiserror = "2"
 unicode-width = "0.2"
+# Already in the tree transitively (portable-pty); used directly for one
+# kill(2) call behind Terminal::signal.
+libc = "0.2"
 
 # Dev / fixture dependencies.
 insta = "1.48"

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -26,6 +26,9 @@ vt100.workspace = true
 thiserror.workspace = true
 insta = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 # vt100 reports wide cells itself; unicode-width is only needed by our own
 # tests to construct wide-character fixtures.

--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -61,10 +61,11 @@ pub enum Error {
     #[error("i/o error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// Typed input that the application's terminal configuration cannot
-    /// receive — e.g. a mouse click while the application never enabled
-    /// mouse tracking. Sending it anyway would feed the app bytes it
-    /// would misparse as garbage keys.
+    /// Typed input or control the child cannot receive — e.g. a mouse
+    /// click while the application never enabled mouse tracking (sending
+    /// it anyway would feed the app bytes it would misparse as garbage
+    /// keys), or a signal to a child that has already been reaped (its
+    /// pid may belong to someone else by now).
     #[error("input not receivable: {0}")]
     Input(String),
 }

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -63,6 +63,8 @@ mod wait;
 pub use error::{Error, Result};
 pub use keys::{Chord, Input, Key};
 pub use screen::{Cell, Color, MouseMode, Screen, Style};
+#[cfg(unix)]
+pub use terminal::Signal;
 pub use terminal::{ExitStatus, Scroll, Terminal, TerminalBuilder};
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -9,6 +9,7 @@
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -57,6 +58,48 @@ pub enum Scroll {
     Up,
     /// Wheel down (toward the user).
     Down,
+}
+
+/// A POSIX signal for [`Terminal::signal`]: the graceful-shutdown set.
+///
+/// Note the difference from typing: `send(Key::Ctrl('c'))` writes the
+/// `0x03` byte *through the PTY* (an app in raw mode reads it; in cooked
+/// mode the line discipline turns it into `SIGINT`), while
+/// `signal(Signal::Int)` delivers the signal directly via `kill(2)`,
+/// bypassing the terminal entirely.
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Signal {
+    /// `SIGINT` — interactive interrupt (what Ctrl-C means).
+    Int,
+    /// `SIGTERM` — the polite termination request.
+    Term,
+    /// `SIGHUP` — the controlling terminal hung up.
+    Hup,
+    /// `SIGQUIT` — quit (often with a core dump).
+    Quit,
+    /// `SIGUSR1` — user-defined; commonly "reload" or "toggle".
+    Usr1,
+    /// `SIGUSR2` — user-defined.
+    Usr2,
+    /// `SIGKILL` — uncatchable. Prefer letting `Drop` clean up; send this
+    /// only to test how your supervisor reacts to a hard kill.
+    Kill,
+}
+
+#[cfg(unix)]
+impl Signal {
+    fn raw(self) -> libc::c_int {
+        match self {
+            Signal::Int => libc::SIGINT,
+            Signal::Term => libc::SIGTERM,
+            Signal::Hup => libc::SIGHUP,
+            Signal::Quit => libc::SIGQUIT,
+            Signal::Usr1 => libc::SIGUSR1,
+            Signal::Usr2 => libc::SIGUSR2,
+            Signal::Kill => libc::SIGKILL,
+        }
+    }
 }
 
 /// Exit status of the child process.
@@ -281,6 +324,7 @@ pub struct TerminalBuilder {
     args: Vec<OsString>,
     env_clear: bool,
     envs: Vec<(OsString, OsString)>,
+    cwd: Option<PathBuf>,
     answer_queries: bool,
     background: (u8, u8, u8),
 }
@@ -294,6 +338,7 @@ impl Default for TerminalBuilder {
             args: Vec::new(),
             env_clear: false,
             envs: Vec::new(),
+            cwd: None,
             answer_queries: true,
             background: (0, 0, 0),
         }
@@ -359,6 +404,15 @@ impl TerminalBuilder {
         self
     }
 
+    /// Run the program with `dir` as its working directory instead of
+    /// inheriting the test runner's. Directory-sensitive programs no
+    /// longer need a `cd … && …` through a shell.
+    #[must_use]
+    pub fn current_dir(mut self, dir: impl AsRef<Path>) -> Self {
+        self.cwd = Some(dir.as_ref().to_path_buf());
+        self
+    }
+
     /// Answer terminal queries from the application (on by default).
     ///
     /// Real terminals answer questions like `CSI 6 n` (cursor position),
@@ -415,6 +469,9 @@ impl TerminalBuilder {
 
         let mut cmd = CommandBuilder::new(program);
         cmd.args(&self.args);
+        if let Some(dir) = &self.cwd {
+            cmd.cwd(dir);
+        }
         if self.env_clear {
             cmd.env_clear();
         }
@@ -739,9 +796,32 @@ impl Terminal {
     /// # Errors
     ///
     /// [`Error::Timeout`] / [`Error::Eof`], each carrying the screen.
-    pub fn wait_until(&mut self, mut predicate: impl FnMut(&Screen) -> bool) -> Result<()> {
+    pub fn wait_until(&mut self, predicate: impl FnMut(&Screen) -> bool) -> Result<()> {
+        self.wait_until_deadline(predicate, self.default_timeout)
+    }
+
+    /// [`wait_until`](Self::wait_until) with a per-call timeout — for the
+    /// one known-slow moment (a first compile, a large fixture load) that
+    /// shouldn't force every other wait in the suite to the slow value.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Timeout`] / [`Error::Eof`], each carrying the screen.
+    pub fn wait_until_for(
+        &mut self,
+        predicate: impl FnMut(&Screen) -> bool,
+        timeout: Duration,
+    ) -> Result<()> {
+        self.wait_until_deadline(predicate, timeout)
+    }
+
+    fn wait_until_deadline(
+        &mut self,
+        mut predicate: impl FnMut(&Screen) -> bool,
+        timeout: Duration,
+    ) -> Result<()> {
         const WHAT: &str = "the screen predicate to hold";
-        let deadline = Instant::now() + self.default_timeout;
+        let deadline = Instant::now() + timeout;
         let mut seen_generation = None;
         let outcome = self.shared.wait_until(deadline, |state| {
             // Spurious wake (poll-cap tick, unrelated notify): the state is
@@ -767,7 +847,7 @@ impl Terminal {
             Ok(inner) => inner,
             Err(Expired) => Err(Error::Timeout {
                 waiting_for: format!("{WHAT}{}", self.shared.lock().query_note()),
-                timeout: self.default_timeout,
+                timeout,
                 screen: self.screen(),
             }),
         }
@@ -904,6 +984,70 @@ impl Terminal {
             .min(deadline - now)
             .max(Duration::from_millis(1));
             guard = self.shared.wait_timeout(guard, sleep);
+        }
+    }
+
+    /// The child's OS process id, when the platform reports one.
+    ///
+    /// Useful for out-of-band inspection (`/proc`, `ps`, `lsof`). The pid
+    /// belongs to the child until it has been reaped
+    /// ([`wait_exit`](Self::wait_exit) or `Drop`) — after that the OS may
+    /// reuse it, so don't deliver signals to a stored pid yourself;
+    /// [`signal`](Self::signal) has that guard built in.
+    #[must_use]
+    pub fn pid(&self) -> Option<u32> {
+        self.child.process_id()
+    }
+
+    /// Deliver `signal` to the child process (`kill(2)`) — the tool for
+    /// graceful-shutdown paths: send `SIGTERM`, then assert the app saves
+    /// its state and exits cleanly. Unix only.
+    ///
+    /// ```
+    /// # use termlens::Signal;
+    /// # fn main() -> termlens::Result<()> {
+    /// let mut t = termlens::Terminal::builder()
+    ///     .timeout(std::time::Duration::from_secs(10))
+    ///     .args(["-c", "trap 'echo bye; exit 0' TERM; echo up; while :; do sleep 0.05; done"])
+    ///     .spawn("sh")?;
+    /// t.wait_until(|s| s.contains("up"))?;
+    /// t.signal(Signal::Term)?;
+    /// t.wait_until(|s| s.contains("bye"))?;
+    /// assert!(t.wait_exit()?.success());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Input`] when the child has already been reaped (its pid may
+    /// have been reused — signaling it would be misdirected) or reports no
+    /// pid; [`Error::Io`] when `kill(2)` itself fails.
+    #[cfg(unix)]
+    pub fn signal(&mut self, signal: Signal) -> Result<()> {
+        if let Some(status) = &self.exit_status {
+            return Err(Error::Input(format!(
+                "cannot deliver {signal:?} to `{}`: it already exited ({status})",
+                self.command_desc
+            )));
+        }
+        let Some(pid) = self.pid() else {
+            return Err(Error::Input(format!(
+                "cannot deliver {signal:?} to `{}`: the platform reports no pid",
+                self.command_desc
+            )));
+        };
+        let pid = libc::pid_t::try_from(pid)
+            .map_err(|_| Error::Input(format!("pid {pid} exceeds the platform's pid range")))?;
+        // SAFETY: kill(2) touches no memory. The pid is our own un-reaped
+        // child (guarded above): worst case it is a zombie, for which kill
+        // is defined and harmless — never an unrelated, recycled pid.
+        #[allow(unsafe_code)]
+        let rc = unsafe { libc::kill(pid, signal.raw()) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(Error::Io(io::Error::last_os_error()))
         }
     }
 

--- a/crates/termlens/tests/process.rs
+++ b/crates/termlens/tests/process.rs
@@ -1,0 +1,108 @@
+//! Process ergonomics: working directory, pid, signals, and the per-call
+//! wait timeout.
+
+use std::time::{Duration, Instant};
+
+use termlens::{Error, Key, Signal, Terminal};
+
+#[test]
+fn current_dir_runs_the_child_where_asked() -> termlens::Result<()> {
+    // Canonicalize: /tmp is a symlink on macOS and `pwd` reports the real
+    // path the kernel put the process in.
+    let dir = std::env::temp_dir().canonicalize()?;
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .current_dir(&dir)
+        .args(["-c", "pwd; read _"])
+        .spawn("sh")?;
+    t.wait_until(|s| s.contains(dir.to_str().expect("utf-8 temp dir")))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn pid_reports_the_direct_child() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", r#"printf 'pid:%s;' "$$"; read _"#])
+        .spawn("sh")?;
+    let pid = t.pid().expect("unix reports pids");
+    // The shell's $$ is the exact process the harness spawned.
+    t.wait_until(|s| s.contains(&format!("pid:{pid};")))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn signal_term_exercises_the_graceful_shutdown_path() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            "trap 'printf got-term; exit 7' TERM; printf ready; while :; do sleep 0.05; done",
+        ])
+        .spawn("sh")?;
+    t.wait_until(|s| s.contains("ready"))?;
+
+    t.signal(Signal::Term)?;
+    t.wait_until(|s| s.contains("got-term"))?;
+    let status = t.wait_exit()?;
+    assert_eq!(status.code(), 7, "status: {status}");
+    assert_eq!(status.signal(), None, "trapped, not killed: {status}");
+    Ok(())
+}
+
+#[test]
+fn signal_after_reap_is_a_typed_error_not_a_stray_kill() {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", "exit 0"])
+        .spawn("sh")
+        .unwrap();
+    t.wait_exit().unwrap();
+
+    let err = t.signal(Signal::Term).unwrap_err();
+    assert!(matches!(err, Error::Input(_)), "got: {err}");
+    assert!(
+        err.to_string().contains("already exited"),
+        "unhelpful message: {err}"
+    );
+}
+
+#[test]
+fn wait_until_for_overrides_the_default_timeout_upward() -> termlens::Result<()> {
+    // Builder default far below the app's readiness; only the per-call
+    // override can see this through.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(200))
+        .args(["-c", "sleep 1; printf late-bloomer; read _"])
+        .spawn("sh")?;
+    t.wait_until_for(|s| s.contains("late-bloomer"), Duration::from_secs(30))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn wait_until_for_overrides_the_default_timeout_downward() {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(30))
+        .args(["-c", "read _"])
+        .spawn("sh")
+        .unwrap();
+    let start = Instant::now();
+    let err = t
+        .wait_until_for(|s| s.contains("never shown"), Duration::from_millis(100))
+        .unwrap_err();
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "the per-call timeout must cut the 30s default short"
+    );
+    match err {
+        Error::Timeout { timeout, .. } => assert_eq!(timeout, Duration::from_millis(100)),
+        other => panic!("expected a timeout, got: {other}"),
+    }
+    // Drop kills the parked child.
+}


### PR DESCRIPTION
Closes the process-control gaps from the demo study §7, all additive on existing types:

- **`TerminalBuilder::current_dir(dir)`** — run the child in a chosen working directory; portable-pty carries it natively, so directory-sensitive CLIs no longer need `cd … && …` through a shell.
- **`Terminal::pid()`** — the child's process id for out-of-band inspection (`/proc`, `ps`, `lsof`), documented with the reap/reuse caveat.
- **`Terminal::signal(Signal::Term)`** (Unix) — real signal delivery via `kill(2)`, so graceful-shutdown paths (`SIGTERM` → save state → clean exit) are finally testable; `Drop`'s kill is no longer the only lever. Refuses to signal an already-reaped child (typed `Error::Input`) — that pid may belong to someone else by now. This adds the crate's one `unsafe` call (workspace warns on `unsafe_code`), allowed and justified at the call site: `kill(2)` touches no memory and the reap-guard removes the pid-recycling hazard. `libc` was already in the tree transitively.
- **`Terminal::wait_until_for(pred, timeout)`** — per-call deadline for the one known-slow wait; the timeout error reports the deadline that actually applied. `wait_until` is now a thin wrapper over the same internal path, so behavior (generation gating, EOF fast-fail, query notes) is identical.

Per the study's own assessment: `send`'s documented panic stays; no `try_send` until someone actually asks.

Tests: six integration tests — cwd via canonicalized temp dir, `pid()` matched against the shell's own `$$`, a trap-based SIGTERM graceful-shutdown round-trip (exit 7, no signal death), the reap-guard error, and both directions of the per-call timeout override — plus a runnable `signal` doctest.

Closes #33