### PR TITLE
docs: the three rules for race-free waits, and the resize stale-frame trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- The three rules for race-free waits — one predicate, wait on the last
+  thing painted, settle before whole-screen snapshots — and the resize
+  **stale-frame trap** are now documented where you'll meet them: on
+  `wait_until` and `resize` in the rustdoc, and in `docs/DESIGN.md` §2
+  with the first real user's before/after failures.
 - Process ergonomics: `TerminalBuilder::current_dir(dir)` runs the child
   in a chosen working directory (no more `cd … && …` through a shell);
   `Terminal::pid()` exposes the child's process id;

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -793,6 +793,29 @@ impl Terminal {
     /// [`Error::Eof`] as soon as the PTY closes with the predicate still
     /// false — both embed the screen for debugging.
     ///
+    /// # Race-free waiting
+    ///
+    /// The guarantee is precise: every byte up to and including the ones
+    /// that made the predicate true has been processed — and nothing more.
+    /// No byte marks where a repaint ends, so a predicate can fire on a
+    /// half-painted screen, including half a row. Three rules (with the
+    /// field stories behind them: `docs/DESIGN.md` §2):
+    ///
+    /// 1. **Put everything you assert into this one predicate.** A
+    ///    [`Screen`] is one consistent instant; `wait_until(a)` followed by
+    ///    `assert!(screen().b)` is a race between two instants.
+    /// 2. **Wait on the last thing your app paints** (the rightmost text
+    ///    of the bottom row, the cursor's resting position) before
+    ///    snapshotting a whole screen — not on a line drawn midway.
+    /// 3. **Settle before whole-screen snapshots**: a snapshot asserts on
+    ///    cells no predicate named, so [`wait_idle`](Self::wait_idle)
+    ///    first.
+    ///
+    /// Applications that emit DEC 2026 synchronized updates need none of
+    /// this — [`wait_frame`](Self::wait_frame) sees only complete frames.
+    /// After a [`resize`](Self::resize), also see the stale-frame trap
+    /// documented there.
+    ///
     /// # Errors
     ///
     /// [`Error::Timeout`] / [`Error::Eof`], each carrying the screen.
@@ -1098,6 +1121,28 @@ impl Terminal {
 
     /// Resize the PTY (TIOCSWINSZ — the kernel delivers SIGWINCH to the
     /// child) and the emulated grid, atomically from the observer's side.
+    ///
+    /// # The stale-frame trap
+    ///
+    /// The grid resizes immediately — `s.cols()` reports the new width on
+    /// the very next snapshot — but its **content** is still the old
+    /// frame, clipped to the new geometry, until the child handles
+    /// SIGWINCH and repaints. This wait can therefore resolve on entirely
+    /// stale content:
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.resize(50, 20)?;
+    /// t.wait_until(|s| s.cols() == 50 && s.contains("tasks (10)"))?; // ← both true BEFORE the repaint
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Wait for something only the post-SIGWINCH frame can show — content
+    /// that needs the new width, a complete status bar on the new bottom
+    /// row — or use [`wait_frame`](Self::wait_frame) where the app emits
+    /// synchronized updates. `docs/DESIGN.md` §2 shows the trap in full.
     ///
     /// # Errors
     ///

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -103,16 +103,69 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
 `Drop` kills + reaps the child unconditionally (unless already reaped):
 tests never leak zombies, including on panic.
 
-### Snapshot after waiting on the *last* drawn byte
+### The three rules for race-free waits
 
-`wait_until(pred)` guarantees exactly this: every byte up to and including
-the ones that made `pred` true has been processed. Bytes the application
-wrote *after* your marker may still be in flight. So before snapshotting a
-whole screen, wait on the **final** thing the app draws — the bottom-right
-corner of a frame, or the cursor's resting position
-(`s.cursor() == (row, 0, true)`) — not on a line drawn midway. Waiting on
-an early marker and snapshotting is a race at chunk boundaries; the stress
-workflow found exactly that in our own suite.
+`wait_until(pred)` guarantees exactly one thing: every byte up to and
+including the ones that made `pred` true has been processed. Nothing in
+the byte stream marks where a repaint ends, so the predicate can fire on
+a half-painted screen — **including half a row**. The first real user hit
+exactly that (the [termlens-demo coverage
+study](https://github.com/vyncint/termlens-demo/blob/main/docs/TERMLENS-COVERAGE.md),
+§2):
+
+```rust
+t.wait_until(|s| s.contains("NORMAL"))?;      // status bar, last row
+assert!(t.screen().contains("Tasks 1/10"));   // the SAME row — still in flight
+```
+
+This failed roughly 2 runs in 15 under parallel load: `NORMAL` had
+landed; ` Tasks 1/10 …`, the rest of the same row, was still crossing
+the PTY. Three rules make such waits deterministic:
+
+1. **Put everything you assert into one predicate.** A `Screen` is one
+   consistent instant; two waits are two instants with a race between
+   them. The fix for the failure above is race-free by construction:
+
+   ```rust
+   t.wait_until(|s| s.contains("NORMAL") && s.contains("Tasks 1/10"))?;
+   ```
+
+2. **Wait on the last thing painted.** Before snapshotting a whole
+   screen, wait on the **final** thing the app draws — the rightmost
+   text of the bottom row, or the cursor's resting position
+   (`s.cursor() == (row, 0, true)`) — never a line drawn midway. Which
+   text is "last" is a property of *your app's* render order; termlens
+   cannot tell you. Waiting on an early marker and snapshotting is a
+   race at chunk boundaries; the stress workflow found exactly that in
+   our own suite.
+3. **Settle before whole-screen snapshots.** A snapshot asserts on cells
+   the test never named, so no targeted predicate can cover it; call
+   `wait_idle` first. That is a heuristic (silence ≠ proof of a finished
+   render — see above), and it is the honest tool for the job.
+
+Applications that bracket repaints in DEC 2026 synchronized updates need
+none of this discipline: `wait_frame` evaluates predicates only on
+complete frames.
+
+### The resize stale-frame trap
+
+Rule 1 has one non-obvious failure mode after `resize`. The emulated
+grid resizes immediately — but its *content* is still the old frame,
+merely clipped (or reflowed) to the new geometry, until the application
+handles SIGWINCH and repaints. Both halves of this predicate are true of
+the **stale** frame:
+
+```rust
+t.resize(50, 20)?;
+t.wait_until(|s| s.cols() == 50 && s.contains("tasks (10)"))?;   // ← matches old content
+```
+
+`s.cols() == 50` holds from the moment `resize` returns, and the
+clipped old frame still says `tasks (10)` — the wait resolves before
+the app has repainted at all. Wait for something only the
+post-SIGWINCH frame can show — content that needs the new width, a
+complete status bar on the new bottom row — or use `wait_frame` where
+the app emits synchronized updates.
 
 ### The instant-exit caveat (macOS PTY teardown)
 


### PR DESCRIPTION
Folds the first real user's hard-won field notes ([coverage study §2](https://github.com/vyncint/termlens-demo/blob/main/docs/TERMLENS-COVERAGE.md)) into the places a user will actually meet them, so the study can link here instead of teaching them:

- **DESIGN.md §2 → "The three rules for race-free waits"** — (1) everything you assert goes in one predicate, (2) wait on the last thing painted, (3) settle before whole-screen snapshots — told with the study's real failure (a status-bar predicate matching half a row, ~2 in 15 runs under parallel load) and its race-free fix. Notes the `wait_frame` escape hatch: apps with DEC 2026 synchronized output need none of this discipline.
- **DESIGN.md §2 → "The resize stale-frame trap"** — after `resize`, `s.cols() == 50` holds immediately while the content is still the **old** frame clipped to the new geometry, so `cols() == 50 && contains(…)` can resolve entirely on stale content. Fix: wait on something only the post-SIGWINCH frame can show.
- The same rules ride along condensed on the **rustdoc of `wait_until` and `resize`** (a "Race-free waiting" section and a "The stale-frame trap" section), each pointing back to DESIGN.md §2.

Pure writing, no code. (Filed as a good-first-issue; folding it in now so v0.2.0 ships with its docs complete.)

Closes #34