### PR TITLE
docs: bring README, DESIGN, and rustdoc up to the v0.2 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ flowchart TB
   test["your test<br/>drive · wait · assert"]
   subgraph proc["your test process · cargo test"]
     subgraph tt["termlens"]
-      api["Terminal<br/>send · resize · wait_until / wait_idle / wait_exit"]
+      api["Terminal<br/>send · click · paste · signal · resize · wait_until / wait_frame / wait_idle / wait_exit"]
       reader["reader thread<br/>drains continuously — output is never lost between waits"]
       emu["VT emulator<br/>vt100 behind a small internal trait, swappable"]
       screen["Screen<br/>immutable grid snapshots · cells · cursor · styles"]
@@ -72,7 +72,7 @@ flowchart TB
   end
   app["your app, unmodified<br/>believes it owns a terminal"]
 
-  test -->|"send(Key) · send_str"| api
+  test -->|"send(Key) · click · paste"| api
   api -->|"xterm byte sequences"| PTY
   api -.->|"resize · kernel delivers SIGWINCH"| PTY
   PTY -->|stdin| app
@@ -90,7 +90,17 @@ kernel buffer can't fill up and stall your app, and no output is lost
 between assertions. It also **answers the queries real terminals
 answer** (cursor position, device attributes, window size, background
 color), so capability-probing apps run instead of hanging — and anything
-left unanswered is named inside the next timeout error. Screens are immutable snapshots taken under the same
+left unanswered is named inside the next timeout error.
+
+Input is **mode-aware**: mouse clicks and scrolls, pastes, modifier
+chords, and cursor keys are encoded exactly as the application
+configured its terminal (SGR mouse, bracketed paste, DECCKM) — because
+the emulator knows which modes the app enabled. The same knowledge is
+readable from every `Screen`: the window title, the alternate-screen
+flag, and the input modes are plain accessors, so "did the app enter the
+alt screen?" is an assertion, not an inference.
+
+Screens are immutable snapshots taken under the same
 lock the reader writes through, so every assertion sees a consistent
 instant. Four layers, one small internal trait between emulator and screen
 so the backend can be swapped; details in [docs/DESIGN.md](docs/DESIGN.md).
@@ -112,7 +122,8 @@ design. termlens's position:
 
 - **Prefer `wait_until` on visible content.** It re-checks on every chunk
   of output and is exact: the condition either becomes true or you get a
-  screen-carrying timeout.
+  screen-carrying timeout. The three rules for race-free waits (and the
+  resize stale-frame trap) are in [docs/DESIGN.md](docs/DESIGN.md) §2.
 - **`wait_frame` gives exact frame boundaries** for apps that bracket
   repaints in DEC 2026 synchronized updates (crossterm's
   `BeginSynchronizedUpdate`/`EndSynchronizedUpdate`): the predicate only
@@ -128,7 +139,7 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.1)
+## Known limitations (v0.2)
 
 - No scrollback assertions, and resizing does not reflow scrollback — the
   visible grid is the testable surface.

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -3,7 +3,7 @@
 //! The public types ([`Screen`](crate::Screen) et al.) are termlens's own;
 //! the VT emulator sits behind this small internal trait so the backend can
 //! be swapped (e.g. for `wezterm-term` or `alacritty_terminal`) without any
-//! public API change. v0.1 ships one backend: the `vt100` crate.
+//! public API change. One backend ships today: the `vt100` crate.
 
 mod seq;
 mod vt100;

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -13,7 +13,7 @@ pub(crate) struct Vt100Emulator {
 impl Vt100Emulator {
     pub(crate) fn new(rows: u16, cols: u16) -> Self {
         Self {
-            // No scrollback: v0.1 asserts on the visible screen only.
+            // No scrollback: termlens asserts on the visible screen only.
             parser: ::vt100::Parser::new(rows, cols, 0),
             tracker: SeqTracker::new(),
         }

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -38,7 +38,16 @@
 //! [`timeout`](TerminalBuilder::timeout), default 5s), and a timeout error
 //! [embeds the screen](Error::Timeout) so a CI log alone shows what the
 //! application was displaying. A background reader thread drains the PTY
-//! continuously — no output is lost between waits.
+//! continuously — no output is lost between waits — and answers the
+//! queries a real terminal answers, so capability-probing apps run
+//! instead of hanging.
+//!
+//! Input is mode-aware: [mouse clicks](Terminal::click),
+//! [pastes](Terminal::paste), modifier [chords](Chord), and cursor keys
+//! are encoded exactly as the application configured its terminal. And
+//! the terminal's out-of-band state — the window title, the
+//! alternate-screen flag, the input modes — is readable from every
+//! [`Screen`] as plain accessors.
 //!
 //! With the default `insta` feature, snapshot-test whole screens:
 //!

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -964,9 +964,10 @@ impl Terminal {
     ///
     /// This is a heuristic: "no output for N ms" is evidence, not proof,
     /// that the application finished rendering. Prefer
-    /// [`wait_until`](Self::wait_until) on visible content where possible.
-    /// `docs/DESIGN.md` discusses the trade-off and the planned frame-sync
-    /// alternative.
+    /// [`wait_until`](Self::wait_until) on visible content where possible,
+    /// or [`wait_frame`](Self::wait_frame) where the application emits
+    /// DEC 2026 synchronized updates. `docs/DESIGN.md` §2 discusses the
+    /// trade-off.
     ///
     /// # Errors
     ///

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -9,9 +9,9 @@ change those only with a matching change here.
 ```mermaid
 flowchart TB
   test["test code"]
-  l4["4 · assertions<br/>wait_until / wait_idle / wait_exit · Screen queries · insta snapshots"]
-  l3["3 · Screen<br/>immutable Arc-backed grid snapshots · Cell · Style · cursor — termlens's own types"]
-  l2["2 · emulator<br/>internal trait: process · snapshot · mid_sequence · set_size — v0.1 backend: vt100"]
+  l4["4 · assertions<br/>wait_until / wait_frame / wait_idle / wait_exit · Screen queries · insta snapshots"]
+  l3["3 · Screen<br/>immutable Arc-backed grid snapshots · Cell · Style · cursor · title & modes — termlens's own types"]
+  l2["2 · emulator<br/>internal trait: process · snapshot · mid_sequence · in_sync_update · input_modes · set_size<br/>backend: vt100"]
   l1["1 · PTY<br/>portable-pty · reader thread · resize TIOCSWINSZ → SIGWINCH · lifecycle lock"]
   app["child app<br/>spawned in the PTY, unmodified"]
 
@@ -20,15 +20,16 @@ flowchart TB
   l2 -->|"snapshot on demand"| l3
   l3 -->|"predicates · dumps embedded in every timeout"| l4
   l4 --> test
-  test -.->|"send(Key) → Key::encode · resize"| l1
+  test -.->|"send · click · paste · resize · signal"| l1
   l1 -.->|"stdin bytes · SIGWINCH"| app
   classDef ours fill:#2563eb,color:#ffffff,stroke:#1d4ed8,stroke-width:1px;
   class l1,l2,l3,l4 ours
 ```
 
 Data flows up (solid): child writes → PTY master → reader thread →
-emulator → screen snapshots → assertions. Input flows down (dashed):
-`Key::encode()` → PTY master → child.
+emulator → screen snapshots → assertions. Input flows down (dashed),
+encoded to match the modes the application enabled (§6) → PTY master →
+child.
 
 **The reader thread** is the linchpin. It drains the PTY *continuously*, not
 just inside `wait_*` calls, so a chatty program can never fill the kernel
@@ -255,18 +256,21 @@ from the one the macro targets.
 
 ## 4. Emulator abstraction — why
 
-`vt100` is the v0.1 backend: small, pure, battle-tested by its own suite.
+`vt100` is the first backend: small, pure, battle-tested by its own suite.
 But it is an implementation detail:
 
-- Public types (`Screen`, `Cell`, `Style`, `Color`) are termlens's own.
-  vt100 types never appear in the API, so swapping the backend is a
-  non-breaking change.
-- The `Emulator` trait is four methods (`process`, `snapshot`,
-  `mid_sequence`, `set_size`) — deliberately the *narrowest* surface that
+- Public types (`Screen`, `Cell`, `Style`, `Color`, `MouseMode`) are
+  termlens's own. vt100 types never appear in the API, so swapping the
+  backend is a non-breaking change. The one piece of state vt100 does
+  not track — the window title — termlens tracks itself in the sequence
+  tracker, so it survives a backend swap too.
+- The `Emulator` trait is six methods (`process`, `snapshot`,
+  `mid_sequence`, `in_sync_update`, `input_modes`, `set_size`) —
+  deliberately the *narrowest* surface that
   the terminal loop needs, so candidate backends (wezterm-term for wider
   escape coverage, alacritty_terminal for fidelity to a real terminal's
   quirks) can be evaluated behind a feature flag without touching layer 3+.
-- Known vt100 limits we accept in v0.1: no scrollback assertions (parser
+- Known vt100 limits we accept in v0.2: no scrollback assertions (parser
   runs with scrollback 0), no reflow of scrollback on resize, cluster
   handling for exotic emoji is whatever vt100 does (pinned by the
   unicode-torture snapshot rather than promised).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,8 +45,8 @@ Pushing the tag runs `release.yml`, which:
 2. re-runs the full CI gates (`workflow_call` into ci.yml),
 3. runs `cargo-semver-checks` against the last published release
    (skipped gracefully on the first release),
-4. `cargo publish -p termlens` via Trusted Publishing (OIDC) or the
-   token fallback,
+4. `cargo publish -p termlens` via Trusted Publishing (OIDC) — the
+   repository stores no tokens,
 5. creates the GitHub Release with notes extracted from the CHANGELOG
    section for that version (`.github/scripts/extract-changelog.sh`).
 


### PR DESCRIPTION
Pre-release consistency sweep — no code changes, no behavior changes:

- **README**: the architecture diagram now names the full input/wait surface (`click`, `paste`, `signal`, `wait_frame`); a new paragraph explains mode-aware input and the `Screen` state accessors; the determinism section links the three wait rules in DESIGN §2; "Known limitations" retitled to v0.2 (every listed limitation is still true).
- **DESIGN**: the layer diagram lists all six `Emulator` trait methods (§4 previously said *four* — stale since Tier 1) and the state `Screen` carries; `MouseMode` joins the public-type list; a note that the title tracking lives in the sequence tracker and therefore survives a backend swap; the input edge now says encoded-to-match-modes instead of naming `Key::encode`.
- **rustdoc**: crate-level docs mention query answering, mode-aware input, and the state accessors; `wait_idle` no longer calls `wait_frame` "planned" — it exists.
- **RELEASING**: the token-fallback mention is gone; publishing is OIDC-only and the repository stores no tokens.

Sets up the v0.2.0 release PR, which will only need the version bump and the CHANGELOG header.