### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-11
+
 ### Added
 
 - The three rules for race-free waits — one predicate, wait on the last

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "crossterm",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "crossterm",
 ]
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "crossterm",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -563,7 +563,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.1.1"
+version = "0.2.0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.1.1" }
+termlens = { path = "crates/termlens", version = "0.2.0" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
Version bump + CHANGELOG date for **v0.2.0** — the user-experience milestone ([milestone #1](https://github.com/vyncint/termlens/milestone/1), issues #24–#34, all closed), scoped from the first real user's coverage study in [termlens-demo](https://github.com/vyncint/termlens-demo):

- `wait_frame` — frame-exact waits on DEC 2026 synchronized updates (#24)
- Terminal query answering — DSR/DA1/DA2/XTWINOPS-18/OSC 10/11, unanswered queries named in timeouts (#25)
- `Screen::with_styles()` — style-aware snapshots (#26)
- Mode-aware input: `click`/`scroll` (#27), modifier `Chord`s (#28), `paste` (#29), DECCKM cursor keys (#30)
- Out-of-band state on `Screen`: `title`, `alternate_screen`, input modes (#31)
- Query helpers: `rect_text`, `find_by`, multi-row `find` (#32)
- Process ergonomics: `current_dir`, `pid`, `signal`, `wait_until_for` (#33)
- The three wait rules + resize stale-frame trap, documented (#34)

Release gates before tagging:
- [x] Local: fmt, clippy (all targets, all features), full test suite ×14 green at 0.2.0, doc build with `-D warnings`, cargo-deny clean
- [ ] Stress workflow ×100 on ubuntu + macos against final main ([run 31437291903](https://github.com/vyncint/termlens/actions/runs/31437291903), in flight)

After merge: tag `v0.2.0` on the squash commit → `release.yml` verifies tag==version, re-runs CI, runs cargo-semver-checks against 0.1.1, publishes via Trusted Publishing (OIDC, no tokens), and creates the GitHub Release from this CHANGELOG section.