### PR TITLE
fix(terminal): reject an empty program name with a one-line error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- `spawn("")` now fails with a one-line `Error::Spawn` naming the problem
+  instead of surfacing the PTY layer's entire `PATH` search. Genuine
+  "program not found" failures keep their underlying diagnosis.
+
 ## [0.2.0] - 2026-08-11
 
 ### Added

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -435,6 +435,25 @@ impl TerminalBuilder {
         self
     }
 
+    /// Reject configurations that cannot produce a working terminal.
+    ///
+    /// These are all programming errors in the test, and each has a
+    /// failure mode elsewhere that is far harder to read than a typed
+    /// error here: an empty program name becomes a page of PATH search
+    /// output from the PTY layer.
+    fn validate(&self, command_desc: &str, program: &OsStr) -> Result<()> {
+        let spawn_err = |reason: String| {
+            Err(Error::Spawn {
+                command: command_desc.to_owned(),
+                reason,
+            })
+        };
+        if program.is_empty() {
+            return spawn_err("no program name given (the program argument was empty)".into());
+        }
+        Ok(())
+    }
+
     /// Spawn `program` inside a fresh PTY and start draining its output.
     ///
     /// Unless a `TERM` variable was set explicitly, the child gets
@@ -443,8 +462,9 @@ impl TerminalBuilder {
     ///
     /// # Errors
     ///
-    /// [`Error::Pty`] when the PTY cannot be opened and [`Error::Spawn`]
-    /// when the program cannot be executed.
+    /// [`Error::Spawn`] when the configuration cannot produce a runnable
+    /// command (empty program name) or the program cannot be executed;
+    /// [`Error::Pty`] when the PTY cannot be opened.
     pub fn spawn(self, program: impl AsRef<OsStr>) -> Result<Terminal> {
         let program = program.as_ref();
         let command_desc = std::iter::once(program)
@@ -452,6 +472,11 @@ impl TerminalBuilder {
             .map(|s| s.to_string_lossy().into_owned())
             .collect::<Vec<_>>()
             .join(" ");
+
+        // Validate the configuration before opening anything: a bad
+        // builder should fail on its own terms, not as a PTY-layer
+        // diagnostic about something else.
+        self.validate(&command_desc, program)?;
 
         // Hold the lifecycle lock across openpty → spawn → slave close, so
         // no concurrent Terminal teardown can revoke our fresh PTY device.

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -1,0 +1,49 @@
+//! The builder rejects configurations that cannot produce a working
+//! terminal, on its own terms — before the PTY layer turns them into
+//! something much harder to read.
+
+use std::time::Duration;
+
+use termlens::{Error, Terminal};
+
+#[test]
+fn an_empty_program_name_is_a_short_typed_error() {
+    let err = Terminal::builder()
+        .timeout(Duration::from_secs(2))
+        .spawn("")
+        .expect_err("an empty program name cannot run");
+
+    assert!(matches!(err, Error::Spawn { .. }), "got: {err}");
+    let message = err.to_string();
+    assert!(
+        message.contains("no program name given"),
+        "unhelpful message: {message}"
+    );
+    // The point of the guard: the failure is one line, not the PTY
+    // layer's entire PATH search.
+    assert!(
+        message.lines().count() == 1,
+        "expected a one-line error, got {} lines:\n{message}",
+        message.lines().count()
+    );
+}
+
+#[test]
+fn a_missing_program_still_reports_the_underlying_search_failure() {
+    let err = Terminal::builder()
+        .timeout(Duration::from_secs(2))
+        .spawn("termlens-definitely-not-installed-xyz")
+        .expect_err("no such program");
+
+    assert!(matches!(err, Error::Spawn { .. }), "got: {err}");
+    let message = err.to_string();
+    assert!(
+        message.contains("termlens-definitely-not-installed-xyz"),
+        "the program name belongs in the message: {message}"
+    );
+    // The underlying diagnosis is genuinely useful here — keep it.
+    assert!(
+        !message.contains("no program name given"),
+        "the empty-name guard must not swallow real search failures: {message}"
+    );
+}


### PR DESCRIPTION
`spawn("")` surfaced portable-pty's whole PATH search — one "exists but is a directory" line per existing PATH directory, then the PATH again — to say the program name was empty.

Adds a `validate()` guard that runs **before** anything is opened, so a bad builder fails on its own terms rather than as a PTY-layer diagnostic about something else. A genuinely missing program keeps the underlying search failure, which is the case where that detail earns its length — pinned by the second test.

This is the first of the v0.2.1 correctness patch, and deliberately first of the three `spawn`-prologue issues: it establishes the `validate()` shape that #48 (current_dir) and #49 (zero size) extend, so they don't each invent their own.

Closes #52