### PR TITLE
fix(terminal): fail the spawn when current_dir does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ listed under a **Changed** or **Removed** heading.
 
 ### Fixed
 
+- `current_dir` pointing at a path that is not an existing directory now
+  fails the spawn instead of being **silently ignored**: the PTY layer
+  falls back to the home directory, so a directory-sensitive test could
+  pass against the wrong tree with no error anywhere.
 - `spawn("")` now fails with a one-line `Error::Spawn` naming the problem
   instead of surfacing the PTY layer's entire `PATH` search. Genuine
   "program not found" failures keep their underlying diagnosis.

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -407,6 +407,10 @@ impl TerminalBuilder {
     /// Run the program with `dir` as its working directory instead of
     /// inheriting the test runner's. Directory-sensitive programs no
     /// longer need a `cd … && …` through a shell.
+    ///
+    /// [`spawn`](Self::spawn) fails with [`Error::Spawn`] if `dir` is not
+    /// an existing directory — running somewhere else instead would make
+    /// a directory-sensitive test pass against the wrong tree.
     #[must_use]
     pub fn current_dir(mut self, dir: impl AsRef<Path>) -> Self {
         self.cwd = Some(dir.as_ref().to_path_buf());
@@ -440,7 +444,8 @@ impl TerminalBuilder {
     /// These are all programming errors in the test, and each has a
     /// failure mode elsewhere that is far harder to read than a typed
     /// error here: an empty program name becomes a page of PATH search
-    /// output from the PTY layer.
+    /// output from the PTY layer, and a missing working directory becomes
+    /// no error at all — the child just runs somewhere else.
     fn validate(&self, command_desc: &str, program: &OsStr) -> Result<()> {
         let spawn_err = |reason: String| {
             Err(Error::Spawn {
@@ -450,6 +455,18 @@ impl TerminalBuilder {
         };
         if program.is_empty() {
             return spawn_err("no program name given (the program argument was empty)".into());
+        }
+        // portable-pty filters the cwd through is_dir() and silently falls
+        // back to the home directory. Sensible for a terminal emulator,
+        // which must always open somewhere; wrong for a test harness,
+        // where "run it there" is part of the assertion.
+        if let Some(dir) = &self.cwd {
+            if !dir.is_dir() {
+                return spawn_err(format!(
+                    "current_dir({}) is not an existing directory",
+                    dir.display()
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -29,6 +29,44 @@ fn an_empty_program_name_is_a_short_typed_error() {
 }
 
 #[test]
+fn a_missing_working_directory_fails_instead_of_running_elsewhere() {
+    let missing = std::env::temp_dir().join("termlens-no-such-dir-xyz");
+    assert!(!missing.is_dir(), "test precondition");
+
+    let err = Terminal::builder()
+        .timeout(Duration::from_secs(2))
+        .current_dir(&missing)
+        .args(["-c", "pwd"])
+        .spawn("/bin/sh")
+        .expect_err("the requested directory does not exist");
+
+    assert!(matches!(err, Error::Spawn { .. }), "got: {err}");
+    let message = err.to_string();
+    assert!(
+        message.contains(missing.to_str().expect("utf-8 path")),
+        "the path belongs in the message: {message}"
+    );
+}
+
+#[test]
+fn a_file_is_not_a_working_directory() {
+    // An existing non-directory must be rejected too — portable-pty's
+    // is_dir() fallback treats it exactly like a missing path.
+    let file = std::env::temp_dir().join("termlens-cwd-probe-file");
+    std::fs::write(&file, b"x").expect("write probe file");
+
+    let err = Terminal::builder()
+        .timeout(Duration::from_secs(2))
+        .current_dir(&file)
+        .args(["-c", "pwd"])
+        .spawn("/bin/sh")
+        .expect_err("a file is not a directory");
+    assert!(matches!(err, Error::Spawn { .. }), "got: {err}");
+
+    let _ = std::fs::remove_file(&file);
+}
+
+#[test]
 fn a_missing_program_still_reports_the_underlying_search_failure() {
     let err = Terminal::builder()
         .timeout(Duration::from_secs(2))


### PR DESCRIPTION
portable-pty filters the cwd through `is_dir()` and silently falls back to the home directory (`cmdbuilder.rs`: `.filter(|dir| Path::new(dir).is_dir()).unwrap_or(home)`). So a builder configured with a nonexistent `current_dir` returned `Ok`, ran the child in `$HOME`, and exited 0 — no error anywhere, and a directory-sensitive test passing against the wrong tree.

That's reasonable for a terminal emulator, which must always open *somewhere*. It's wrong for a test harness, where "run it there" is part of the assertion.

Validated in the `validate()` guard #52 established, covering both a missing path and an existing non-directory (portable-pty's `is_dir()` treats them identically). The existing `current_dir_runs_the_child_where_asked` test still passes unchanged.

Closes #48