### PR TITLE
fix(terminal): reject zero terminal dimensions instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ listed under a **Changed** or **Removed** heading.
 
 ### Fixed
 
+- A zero terminal dimension is now a typed `Error::Input` from `spawn`
+  and `resize` instead of a panic inside the emulator. In release builds
+  — the profile the stress workflow uses — it was worse than a panic:
+  the arithmetic wrapped, both calls returned `Ok`, and the emulator
+  panicked on the reader thread, silently killing the drain so every
+  later snapshot was blank and a careless test went green.
 - `current_dir` pointing at a path that is not an existing directory now
   fails the spawn instead of being **silently ignored**: the PTY layer
   falls back to the home directory, so a directory-sensitive test could

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -347,6 +347,10 @@ impl Default for TerminalBuilder {
 
 impl TerminalBuilder {
     /// Terminal size as columns × rows. Defaults to 80×24.
+    ///
+    /// Both dimensions must be non-zero; [`spawn`](Self::spawn) rejects a
+    /// zero with [`Error::Input`] rather than letting the emulator meet a
+    /// size no terminal can have.
     #[must_use]
     pub fn size(mut self, cols: u16, rows: u16) -> Self {
         self.cols = cols;
@@ -456,6 +460,7 @@ impl TerminalBuilder {
         if program.is_empty() {
             return spawn_err("no program name given (the program argument was empty)".into());
         }
+        check_size(self.cols, self.rows)?;
         // portable-pty filters the cwd through is_dir() and silently falls
         // back to the home directory. Sensible for a terminal emulator,
         // which must always open somewhere; wrong for a test harness,
@@ -480,8 +485,11 @@ impl TerminalBuilder {
     /// # Errors
     ///
     /// [`Error::Spawn`] when the configuration cannot produce a runnable
-    /// command (empty program name) or the program cannot be executed;
-    /// [`Error::Pty`] when the PTY cannot be opened.
+    /// command (empty program name, missing
+    /// [`current_dir`](Self::current_dir)) or the program cannot be
+    /// executed; [`Error::Input`] when the configured
+    /// [`size`](Self::size) has a zero dimension; [`Error::Pty`] when the
+    /// PTY cannot be opened.
     pub fn spawn(self, program: impl AsRef<OsStr>) -> Result<Terminal> {
         let program = program.as_ref();
         let command_desc = std::iter::once(program)
@@ -572,6 +580,28 @@ impl TerminalBuilder {
             command_desc,
         })
     }
+}
+
+/// Reject a zero terminal dimension.
+///
+/// A terminal has at least one row and one column. Letting a zero reach
+/// the emulator is not a graceful degradation: in debug builds vt100
+/// panics on an overflowing subtraction, and in release builds (the
+/// stress workflow runs `--release`) the arithmetic wraps, `spawn` and
+/// `resize` return `Ok`, and vt100 panics on the first printable byte —
+/// on the reader thread, where nothing propagates it. The drain dies
+/// silently, every later snapshot is blank, and a careless test goes
+/// green. Zeroes arrive from ordinary arithmetic (`resize(cols - 1, …)`
+/// in a loop), so this must be a typed error, not a panic in a
+/// dependency.
+fn check_size(cols: u16, rows: u16) -> Result<()> {
+    if cols == 0 || rows == 0 {
+        return Err(Error::Input(format!(
+            "a terminal needs at least one column and one row, got {cols}x{rows} \
+             (columns x rows)"
+        )));
+    }
+    Ok(())
 }
 
 /// Canonical printable shape of a known query (for diagnostics when the
@@ -1189,8 +1219,11 @@ impl Terminal {
     ///
     /// # Errors
     ///
-    /// [`Error::Pty`] if the ioctl fails.
+    /// [`Error::Input`] if either dimension is zero (a terminal has at
+    /// least one row and one column), before the PTY or the grid is
+    /// touched; [`Error::Pty`] if the ioctl fails.
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<()> {
+        check_size(cols, rows)?;
         self.master
             .as_ref()
             .expect("master lives until drop")

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -66,6 +66,51 @@ fn a_file_is_not_a_working_directory() {
     let _ = std::fs::remove_file(&file);
 }
 
+/// A zero dimension used to reach vt100, which panicked on an
+/// overflowing subtraction in debug builds and — worse — panicked on the
+/// *reader thread* in release builds, killing the drain silently.
+#[test]
+fn a_zero_dimension_is_rejected_before_it_reaches_the_emulator() {
+    for (cols, rows) in [(0u16, 24u16), (80, 0), (0, 0)] {
+        let err = Terminal::builder()
+            .size(cols, rows)
+            .timeout(Duration::from_secs(2))
+            .args(["-c", "read x"])
+            .spawn("/bin/sh")
+            .expect_err("a terminal cannot have a zero dimension");
+        assert!(matches!(err, Error::Input(_)), "{cols}x{rows}: got {err}");
+        assert!(
+            err.to_string().contains(&format!("{cols}x{rows}")),
+            "the offending size belongs in the message: {err}"
+        );
+    }
+}
+
+#[test]
+fn resize_to_zero_is_refused_without_touching_the_pty_or_the_grid() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_secs(5))
+        .args(["-c", "printf ready; read x"])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("ready"))?;
+
+    for (cols, rows) in [(0u16, 24u16), (80, 0), (0, 0)] {
+        let err = t
+            .resize(cols, rows)
+            .expect_err("a terminal cannot have a zero dimension");
+        assert!(matches!(err, Error::Input(_)), "{cols}x{rows}: got {err}");
+    }
+
+    // The grid is untouched and the terminal still works.
+    assert_eq!(t.screen().size(), (80, 24));
+    t.resize(70, 20)?;
+    assert_eq!(t.screen().size(), (70, 20));
+    t.send(termlens::Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 #[test]
 fn a_missing_program_still_reports_the_underlying_search_failure() {
     let err = Terminal::builder()


### PR DESCRIPTION
A zero column or row count reached vt100, which panicked on an overflowing subtraction (`grid.rs:26:28` from `spawn`, `grid.rs:74:34` from `resize`).

**Release builds were worse than a panic.** With overflow checks off — the profile `stress.yml` runs — the arithmetic wraps, `spawn`/`resize` return `Ok`, and vt100 panics instead on the first printable byte (`Option::unwrap()` on `None`, `screen.rs:827`) **on the reader thread**, where nothing propagates it. The drain dies, every later snapshot is blank, and a careless test goes green. One case didn't even panic visibly in debug: `size(0, 24)` returned `Ok` and failed the same silent way.

Zeroes arrive from ordinary arithmetic — `resize(cols - 1, rows)` walked down in a loop, a computed split layout, a `u16` that underflows — so the panic pointed at vt100 internals, the last place anyone looks for their own bug.

Now a typed `Error::Input` naming the offending size, raised before the PTY or the grid is touched, from both entry points. The `resize` test asserts the grid is untouched and the terminal still works afterwards. Suite runs green in **both profiles**; the release run is the one that matters here.

Third and last of the `spawn`-prologue guards (#52, #48, this).

Closes #49