### PR TITLE
fix(terminal): paste like a real terminal — CR line breaks, no marker injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Changed
+
+- `paste` now transforms the text the way a real terminal does, so what
+  the application receives matches what a user pasting would produce.
+  Line breaks become `\r` (the byte Enter sends; applications in raw
+  mode never see `\n` from a terminal), and while bracketed paste is
+  active, paste markers embedded in the text are removed — previously an
+  `ESC[201~` inside the text ended the paste early and the remainder
+  arrived as ordinary key presses. `send_str` remains the untransformed
+  path.
+
 ### Fixed
 
 - A zero terminal dimension is now a typed `Error::Input` from `spawn`

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -582,6 +582,22 @@ impl TerminalBuilder {
     }
 }
 
+/// Remove bracketed-paste markers from pasted text.
+///
+/// Repeated to a fixed point, because a single pass is trivially
+/// defeated by a marker that reassembles from the remains of another
+/// (`ESC[2ESC[201~01~`) — the same rule kitty applies.
+fn strip_paste_markers(text: &str) -> String {
+    let mut out = text.to_owned();
+    loop {
+        let stripped = out.replace("\x1b[200~", "").replace("\x1b[201~", "");
+        if stripped == out {
+            return out;
+        }
+        out = stripped;
+    }
+}
+
 /// Reject a zero terminal dimension.
 ///
 /// A terminal has at least one row and one column. Letting a zero reach
@@ -739,15 +755,35 @@ impl Terminal {
     /// crossterm's `EnableBracketedPaste`), the text arrives wrapped in
     /// `ESC[200~ … ESC[201~` and the application sees **one paste
     /// event**, not a burst of key presses. When it hasn't, the bytes
-    /// arrive plain — exactly like a real terminal.
+    /// arrive unwrapped — exactly like a real terminal.
+    ///
+    /// Two transformations make the paste behave like a real one, both
+    /// applied to the text itself:
+    ///
+    /// - **Line breaks become `\r`**, the byte the Enter key produces.
+    ///   Applications in raw mode (which clears `ICRNL`) never see `\n`
+    ///   from a terminal, so a pasted `"a\nb"` would otherwise be a line
+    ///   break the application does not recognize.
+    /// - **Paste markers inside the text are removed** while bracketed
+    ///   paste is active, repeatedly until none remain. Otherwise an
+    ///   embedded `ESC[201~` would end the paste early and the remainder
+    ///   would arrive as ordinary key presses — the classic paste
+    ///   injection, and a silent way for a test to exercise something
+    ///   other than what it wrote.
+    ///
+    /// To send bytes with no transformation at all, use
+    /// [`send_str`](Self::send_str) and write the brackets yourself.
     ///
     /// # Panics
     ///
     /// Same contract as [`send`](Self::send).
     pub fn paste(&mut self, text: &str) {
+        // Real terminals send CR for a pasted line break; \r\n collapses
+        // to a single CR rather than two line breaks.
+        let text = text.replace("\r\n", "\r").replace('\n', "\r");
         if self.input_modes().bracketed_paste {
             let mut bytes = b"\x1b[200~".to_vec();
-            bytes.extend_from_slice(text.as_bytes());
+            bytes.extend_from_slice(strip_paste_markers(&text).as_bytes());
             bytes.extend_from_slice(b"\x1b[201~");
             self.write_or_panic(&bytes, "a bracketed paste");
         } else {

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -93,6 +93,61 @@ fn paste_falls_back_to_plain_bytes_without_the_mode() -> termlens::Result<()> {
     Ok(())
 }
 
+/// A paste marker inside the text must not end the paste early: the app
+/// would see the remainder as ordinary key presses (paste injection).
+#[test]
+fn an_embedded_paste_marker_cannot_end_the_paste() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    t.paste("AB\x1b[201~CD");
+    // One paste event carrying all four characters — the markers are
+    // gone, so nothing arrives as key presses.
+    t.wait_frame(|s| s.contains("input: ABCD") && s.contains("last: paste:4"))?;
+
+    t.send(Key::Esc);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Pasted line breaks reach the application as CR, the byte the Enter
+/// key produces — every real terminal converts, and raw mode (which
+/// clears ICRNL) means nothing downstream will.
+#[test]
+fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                // -icrnl is what raw mode does (crossterm's
+                // enable_raw_mode clears it): without it the line
+                // discipline rewrites our CR back to LF before the app
+                // ever sees it. READY marks the settings as applied —
+                // pasting earlier would race them.
+                r"stty -icanon -echo -icrnl; printf READY; ",
+                // Render the three bytes as hex so the wire is visible.
+                r"head -c 3 | od -An -tx1 | tr -d ' \n'; printf ' WIRE-EOF'; read guard"
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+
+    t.paste("a\nb");
+    t.wait_until(|s| s.contains("WIRE-EOF"))?;
+    let row = t.screen().row_text(0);
+    assert!(
+        row.contains("610d62"),
+        "expected 61 0d 62 (a CR b), got: {row}"
+    );
+
+    // ICRNL is off, so the guard `read` needs a literal newline — the
+    // CR that Key::Enter sends is no longer translated for it.
+    t.send_str("\n");
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 #[test]
 fn arrows_follow_the_apps_cursor_key_mode() -> termlens::Result<()> {
     // The script enables DECCKM (CSI ?1 h), reads 3 bytes, reports them,


### PR DESCRIPTION
Two ways `paste` delivered something other than what the test wrote. Both are the same class: the test writes one thing, the application receives another, silently.

**Embedded markers ended the paste early (#50).** Captured off the wire before the fix:

```
t.paste("AB\x1b[201~CD")   →   E[200~ABE[201~CDE[201~
```

The paste event ended at `AB`; `CD` arrived as ordinary key presses — two stray characters in a text field, or two *commands* in a TUI with single-key bindings. Markers are now stripped, repeated to a fixed point (kitty's rule, which also defeats a marker that reassembles from the remains of another, e.g. `ESC[2ESC[201~01~`), and only while bracketed paste is active — same gating kitty uses.

**Line breaks went out as LF (#62).** Every real terminal sends CR: Alacritty ("a single carriage return (\r, which is what the Enter key produces)"), kitty (`.replace(b'\n', b'\r')`), VTE (`case 0x0a: rv.push_back(0x0d)`). And crossterm's `enable_raw_mode` clears `ICRNL`, so nothing downstream fixes it up — an application treating Enter as submit never saw the breaks in a pasted multi-line string, which is the crate's own advertised use for this API.

`send_str` remains the untransformed path, and the rustdoc now documents both transformations instead of promising the bytes "arrive plain".

**CHANGELOG is under `### Changed`, not `Fixed`** — this changes a documented success-path contract with no signature change, so `cargo-semver-checks` cannot see it and the heading is the only notice a downstream user gets. Precedent: 0.2.0's `wait_idle` change.

Both tests capture the actual wire. The CR test clears `ICRNL` (what raw mode does) — without that the line discipline rewrites the CR back to LF before the app sees it, which is exactly why this bug survived until now.

Closes #50, closes #62