### PR TITLE
fix(terminal): wait_frame timeouts embed the live screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ listed under a **Changed** or **Removed** heading.
 
 ### Fixed
 
+- `wait_frame` timeouts embed the **live** screen, like every other
+  wait. They previously embedded the last completed frame — which can be
+  arbitrarily old — under a header saying "screen at timeout", so the
+  one place a CI log is the only evidence showed the wrong screen. The
+  count of observed frames is still in the message.
 - A zero terminal dimension is now a typed `Error::Input` from `spawn`
   and `resize` instead of a panic inside the emulator. In release builds
   — the profile the stress workflow uses — it was worse than a panic:

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1043,9 +1043,15 @@ impl Terminal {
         match outcome {
             Ok(inner) => inner,
             Err(Expired) => {
+                // The live screen, like every other wait: the error's
+                // header says "screen at timeout" and a CI log is often
+                // the only evidence there is. The last completed frame
+                // can be arbitrarily old — it is named in `waiting_for`
+                // instead, where it reads as a count rather than a
+                // picture that claims to be current.
                 let (frames, screen) = {
                     let mut guard = self.shared.lock();
-                    let screen = guard.last_frame.clone().unwrap_or_else(|| guard.snapshot());
+                    let screen = guard.snapshot();
                     (guard.frames_seen, screen)
                 };
                 let waiting_for = if frames == 0 {

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -109,6 +109,38 @@ fn apps_without_synchronized_output_time_out_with_guidance() {
     assert!(t.wait_exit().unwrap().success());
 }
 
+/// The timeout error must show the screen as it is *now*, like every
+/// other wait: its header says so, and in CI the embedded dump is often
+/// the only evidence available. The last completed frame can be
+/// arbitrarily old.
+#[test]
+fn wait_frame_timeouts_embed_the_live_screen_not_the_last_frame() {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(400))
+        .args([
+            "-c",
+            // One synchronized frame, then unbracketed output that will
+            // never complete a frame.
+            r"printf '\033[?2026h\033[HOLD FRAME\033[?2026l'; printf '\r\nLIVE SCREEN'; read quit",
+        ])
+        .spawn("sh")
+        .unwrap();
+    t.wait_frame(|s| s.contains("OLD FRAME")).unwrap();
+    t.wait_until(|s| s.contains("LIVE SCREEN")).unwrap();
+
+    let err = t.wait_frame(|s| s.contains("never painted")).unwrap_err();
+    let screen = err.screen().expect("timeouts embed a screen");
+    assert!(
+        screen.contains("LIVE SCREEN"),
+        "the embedded screen is stale — it must match the header:\n{screen}"
+    );
+    // The frame count still tells you what wait_frame actually saw.
+    assert!(
+        err.to_string().contains("1 complete frames observed"),
+        "the frame count belongs in the message: {err}"
+    );
+}
+
 #[test]
 fn wait_frame_fails_fast_on_eof() {
     let mut t = Terminal::builder()


### PR DESCRIPTION
`wait_frame`'s `Err(Expired)` arm embedded `last_frame` — the last *completed* frame, which can be arbitrarily old — under the header `--- screen at timeout ---`.

Every other wait embeds the live screen, `wait_frame`'s own `Eof` arm already uses `peek_snapshot()`, and both contracts promise live:

- `error.rs`: "The screen at the moment of the timeout is embedded"
- `docs/DESIGN.md` §2: "On expiry the error **embeds the full screen dump** — a CI log alone answers 'what was the app showing?'"

So in the one situation where the embedded dump is the only evidence a maintainer has, it showed the wrong screen — with a header asserting otherwise.

The frame count stays in `waiting_for` ("1 complete frames observed"), where it reads as a count rather than a picture claiming to be current. New test pins which screen the arm carries; nothing in `tests/frames.rs` did before.

Closes #61