### PR TITLE
fix(terminal): answer queries from a responder thread so the drain never blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ listed under a **Changed** or **Removed** heading.
 
 ### Fixed
 
+- **The harness can no longer deadlock itself.** Query replies were
+  written by the reader thread, so an application that emitted queries
+  faster than it read the answers filled the PTY's input queue, blocked
+  that write, and stopped the drain — after which the child blocked
+  writing and neither side could proceed. Reproduced in the default
+  configuration with no test input at all: the wait timed out with a
+  stale screen and then `Drop` never returned. Replies now go to a
+  dedicated responder thread, so the drain never writes; undeliverable
+  replies are counted and reported ("the application is not reading its
+  input") instead of stalling anything. `Drop`'s reap is bounded too —
+  teardown must always terminate.
 - The unanswered-query diagnosis no longer misattributes unrelated
   failures. It was recorded once and never cleared, so a single
   deliberately-unanswered probe at startup (kitty's `CSI ? u` is the

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -10,7 +10,7 @@ use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{mpsc, Arc, Mutex, PoisonError};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -34,6 +34,17 @@ const DRAIN_GRACE: Duration = Duration::from_millis(500);
 /// beyond this is counted rather than kept.
 const MAX_UNANSWERED: usize = 8;
 
+/// Query replies that may be queued for the responder thread before the
+/// drain starts discarding them. Reached only when the application has
+/// stopped reading its input entirely, in which case it cannot be
+/// waiting on these bytes.
+const REPLY_QUEUE_DEPTH: usize = 64;
+
+/// How long `Drop` will wait for a killed child to be reaped before
+/// giving up. Teardown must terminate: a stuck child is a bad outcome, a
+/// test binary that never exits is a worse one.
+const DROP_REAP_GRACE: Duration = Duration::from_secs(2);
+
 /// Serializes every PTY *lifecycle edge* (open+spawn on one side, kill+reap+
 /// master-close on the other) across all `Terminal`s in this process.
 ///
@@ -56,6 +67,32 @@ fn pty_lifecycle_guard() -> std::sync::MutexGuard<'static, ()> {
 /// thread (query replies). `None` after teardown. Locked briefly per write;
 /// never while the emulator state lock is held.
 type SharedWriter = Arc<Mutex<Option<Box<dyn Write + Send>>>>;
+
+/// Open a second writer onto the same PTY master, for the responder
+/// thread. `take_writer` may only be called once, so duplicate the
+/// descriptor instead: both refer to the same open file description,
+/// which is what we want — same terminal, independent blocking.
+#[cfg(unix)]
+fn dup_writer(master: &dyn portable_pty::MasterPty) -> Option<std::fs::File> {
+    use std::os::unix::io::FromRawFd;
+
+    let fd = master.as_raw_fd()?;
+    // SAFETY: `fd` is the live master descriptor (the caller still owns
+    // the master). dup(2) returns a fresh descriptor we take sole
+    // ownership of; `File` closes it exactly once on drop.
+    #[allow(unsafe_code)]
+    let duped = unsafe { libc::dup(fd) };
+    if duped < 0 {
+        return None;
+    }
+    #[allow(unsafe_code)]
+    Some(unsafe { std::fs::File::from_raw_fd(duped) })
+}
+
+#[cfg(not(unix))]
+fn dup_writer(_master: &dyn portable_pty::MasterPty) -> Option<std::fs::File> {
+    None
+}
 
 /// Scroll-wheel direction for [`Terminal::scroll`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -188,6 +225,9 @@ struct EmuState {
     unanswered: Vec<(String, u64)>,
     /// Distinct unanswered shapes beyond `MAX_UNANSWERED`, counted only.
     unanswered_overflow: usize,
+    /// Query replies the reader could not deliver because the child was
+    /// not reading its input — evidence for the diagnosis, not an error.
+    replies_dropped: usize,
     /// Reads delivered by the PTY so far. A query last seen in an earlier
     /// read than this cannot be what the application is blocked on: it
     /// produced output after asking.
@@ -208,6 +248,7 @@ impl EmuState {
             background,
             unanswered: Vec::new(),
             unanswered_overflow: 0,
+            replies_dropped: 0,
             reads: 0,
         }
     }
@@ -315,8 +356,17 @@ impl EmuState {
     /// rest of the same chunk, so output the application batched into the
     /// same `write` as its probe is not evidence of progress.
     fn query_note(&self) -> String {
+        let backlog = if self.replies_dropped > 0 {
+            format!(
+                " — note: the application is not reading its input \
+                 ({} terminal replies could not be delivered)",
+                self.replies_dropped
+            )
+        } else {
+            String::new()
+        };
         if self.unanswered.is_empty() {
-            return String::new();
+            return backlog;
         }
         let mut blocking: Vec<&str> = Vec::new();
         let mut moved_past: Vec<&str> = Vec::new();
@@ -334,16 +384,16 @@ impl EmuState {
         };
         if blocking.is_empty() {
             format!(
-                " — note: the application queried the terminal ({}{more}) and \
-                 received no answer, but produced output afterwards, so that is \
-                 probably not why this wait failed",
+                "{backlog} — note: the application queried the terminal \
+                 ({}{more}) and received no answer, but produced output \
+                 afterwards, so that is probably not why this wait failed",
                 moved_past.join(", ")
             )
         } else {
             format!(
-                " — note: the application queried the terminal ({}{more}) and \
-                 received no answer; if it is blocked waiting for that reply, \
-                 this is the cause",
+                "{backlog} — note: the application queried the terminal \
+                 ({}{more}) and received no answer; if it is blocked waiting \
+                 for that reply, this is the cause",
                 blocking.join(", ")
             )
         }
@@ -620,11 +670,41 @@ impl TerminalBuilder {
         )));
         let writer: SharedWriter = Arc::new(Mutex::new(Some(writer)));
 
+        // Query replies are written by a thread of their own, never by
+        // the drain. A reply write blocks whenever the application has
+        // stopped reading its input; doing that on the reader thread
+        // stops the drain, the child then blocks writing into a full
+        // output buffer, and the harness deadlocks itself with no test
+        // input involved.
+        let reply_tx = match dup_writer(pair.master.as_ref()) {
+            Some(mut reply_writer) => {
+                let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(REPLY_QUEUE_DEPTH);
+                thread::Builder::new()
+                    .name("termlens-pty-responder".into())
+                    .spawn(move || {
+                        while let Ok(reply) = rx.recv() {
+                            if reply_writer
+                                .write_all(&reply)
+                                .and_then(|()| reply_writer.flush())
+                                .is_err()
+                            {
+                                break; // terminal gone; nothing left to answer
+                            }
+                        }
+                    })
+                    .map_err(Error::Io)?;
+                Some(tx)
+            }
+            // No descriptor to duplicate: fall back to answering from
+            // the reader thread, as before.
+            None => None,
+        };
+
         let reader_shared = Arc::clone(&shared);
         let reader_writer = Arc::clone(&writer);
         thread::Builder::new()
             .name("termlens-pty-reader".into())
-            .spawn(move || reader_loop(reader, &reader_shared, &reader_writer))
+            .spawn(move || reader_loop(reader, &reader_shared, &reader_writer, reply_tx.as_ref()))
             .map_err(Error::Io)?;
 
         let child = pair.slave.spawn_command(cmd).map_err(|e| Error::Spawn {
@@ -706,6 +786,7 @@ fn reader_loop(
     mut reader: Box<dyn Read + Send>,
     shared: &Monitor<EmuState>,
     writer: &SharedWriter,
+    replies_to: Option<&mpsc::SyncSender<Vec<u8>>>,
 ) {
     let mut buf = [0u8; 8192];
     loop {
@@ -746,9 +827,24 @@ fn reader_loop(
                     replies
                 });
                 for reply in replies {
-                    let mut writer = writer.lock().unwrap_or_else(PoisonError::into_inner);
-                    if let Some(writer) = writer.as_mut() {
-                        let _ = writer.write_all(&reply).and_then(|()| writer.flush());
+                    match replies_to {
+                        // Hand off without waiting. A full queue means the
+                        // application has stopped reading its input
+                        // entirely, so it cannot be waiting on these bytes
+                        // — and the drain must keep running regardless.
+                        Some(tx) => {
+                            if let Err(mpsc::TrySendError::Full(_)) = tx.try_send(reply) {
+                                shared.mutate(|state| state.replies_dropped += 1);
+                            }
+                        }
+                        // No responder thread (no descriptor to duplicate):
+                        // write inline, as before.
+                        None => {
+                            let mut writer = writer.lock().unwrap_or_else(PoisonError::into_inner);
+                            if let Some(writer) = writer.as_mut() {
+                                let _ = writer.write_all(&reply).and_then(|()| writer.flush());
+                            }
+                        }
                     }
                 }
             }
@@ -1380,18 +1476,34 @@ impl Drop for Terminal {
     /// under the process-wide PTY lifecycle lock: on macOS, letting a
     /// master close overlap a concurrent `openpty()` can revoke the *other*
     /// terminal's freshly recycled PTY device (see `PTY_LIFECYCLE` in this module).
+    ///
+    /// The reap is bounded (`DROP_REAP_GRACE`). A child that cannot be
+    /// reaped is a bad outcome; a test binary that never exits — which an
+    /// unbounded `wait` here produced whenever the child was wedged — is a
+    /// worse one, and unlike the first it cannot even be diagnosed.
     fn drop(&mut self) {
         let _lifecycle = pty_lifecycle_guard();
         if self.exit_status.is_none() {
             let already_exited = matches!(self.child.try_wait(), Ok(Some(_)));
             if !already_exited {
                 let _ = self.child.kill();
-                let _ = self.child.wait();
+                let deadline = Instant::now() + DROP_REAP_GRACE;
+                let mut backoff = INITIAL_BACKOFF;
+                while !matches!(self.child.try_wait(), Ok(Some(_))) {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        break;
+                    }
+                    thread::sleep(backoff.min(deadline - now));
+                    backoff = next_backoff(backoff);
+                }
             }
         }
-        // Close the PTY fds while still holding the lock. Taking the boxed
-        // writer out of the shared cell closes its fd even though the
-        // reader thread keeps the (now empty) cell alive.
+        // Close the PTY fds while still holding the lock. Taking the writer
+        // out of the shared cell closes its fd even though the reader
+        // thread keeps the (now empty) cell alive — and it must happen
+        // before the master is dropped, since the reader polls the
+        // master's descriptor while holding this lock.
         drop(
             self.writer
                 .lock()

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -1,0 +1,84 @@
+//! The drain must never block on a write it makes itself.
+//!
+//! The reader thread answers terminal queries. If it blocks writing a
+//! reply into a full PTY input queue, it stops draining the master, the
+//! child then blocks writing into a full output buffer, and neither side
+//! can proceed — a permanent hang with no test input involved. This is
+//! the one failure the harness must never produce, since a hung harness
+//! cannot report anything at all.
+
+use std::time::{Duration, Instant};
+
+use termlens::{Error, Terminal};
+
+/// ~1000 cursor-position queries generate ~8 KB of replies — past the
+/// noncanonical tty buffer — from a child that never reads its input.
+const FLOOD: &str = r"stty -icanon -echo; i=0; while [ $i -lt 1000 ]; do printf '\033[6n'; i=$((i+1)); done; printf 'DONE\n'; sleep 3";
+
+#[test]
+fn a_child_that_never_reads_its_replies_cannot_wedge_the_drain() {
+    let start = Instant::now();
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .env_clear()
+        // answer_queries defaults to true: this is the default config.
+        .timeout(Duration::from_secs(10))
+        .args(["-c", FLOOD])
+        .spawn("/bin/sh")
+        .expect("spawn");
+
+    // The child's own output must keep arriving: the drain is alive.
+    t.wait_until(|s| s.contains("DONE"))
+        .expect("the drain kept running, so DONE arrived");
+
+    drop(t);
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "teardown took {:?} — the drain or the reap is blocking",
+        start.elapsed()
+    );
+}
+
+/// Undeliverable replies are evidence, not silence: the diagnosis says
+/// the application is not reading its input.
+#[test]
+fn undelivered_replies_are_named_in_the_diagnosis() {
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .env_clear()
+        .timeout(Duration::from_millis(600))
+        .args(["-c", FLOOD])
+        .spawn("/bin/sh")
+        .expect("spawn");
+
+    let err = t
+        .wait_until(|s| s.contains("never-appears"))
+        .expect_err("the predicate can never hold");
+    let message = err.to_string();
+    assert!(matches!(err, Error::Timeout { .. }), "got: {err}");
+    assert!(
+        message.contains("not reading its input"),
+        "the backlog should be diagnosed: {message}"
+    );
+}
+
+/// The ordinary case must be untouched: an application that reads its
+/// replies still gets every one of them.
+#[test]
+fn replies_still_reach_an_application_that_reads_them() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo; printf 'abc\033[6n'; ",
+                r#"reply=$(head -c 6 | tr '\033' 'E'); "#,
+                r#"printf '\nunblocked:%s' "$reply"; read guard"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("unblocked:E[1;4R"))?;
+    t.send(termlens::Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -58,6 +58,15 @@ cursor *at the query*, not after later output in the same chunk moved
 it. Replies are built under the state lock but written after it is
 released — the state lock and the writer lock are never held together.
 
+**The drain never writes.** Replies are handed to a dedicated responder
+thread over a bounded queue. Writing them from the reader thread would
+block whenever the application stopped reading its input; the drain
+would stop, the child would then block writing into a full output
+buffer, and the harness would deadlock itself with no test input
+involved. A full queue means the application is not reading at all — so
+it cannot be waiting on those bytes — and the replies are counted and
+named in the next wait's error instead.
+
 Whatever remains unanswered (XTGETTCAP, pixel-size reports, …) is
 recorded, and the next wait timeout names it: "the application queried
 the terminal (`^[[14t`) and received no answer" — a hang becomes a


### PR DESCRIPTION
**The harness could deadlock itself, in the default configuration, with no test input at all.**

The reader thread wrote query replies. That write blocks once the PTY input queue fills — which happens whenever the application emits queries faster than it reads the answers — and a blocked reader stops draining the master, so the child then blocks writing into a full output buffer. Neither side can proceed.

Reproduced against 0.2.0 (`answer_queries` is on by default):

| unread replies | result |
|---|---|
| 200 queries (~1.6 KB) | fine — wait resolves in 96 ms, `Drop` in 151 ms |
| **1000 queries (~8 KB)** | **wait times out on a stale screen; `Drop` never returns** |

Live stacks at the hang: main thread in `__wait4` (Drop → `Child::wait`), `termlens-pty-reader` in `write(2)`. The process had to be `kill -9`'d. The same script with `.answer_queries(false)` finished in 18 ms, isolating the cause to the responder.

**Fix.** Replies go over a bounded channel to a dedicated responder thread, writing through a *duplicate* of the master descriptor (`take_writer` may only be called once). The drain never writes, so it cannot be blocked by the application's reading habits. A full queue means the application has stopped reading entirely and therefore cannot be waiting on those bytes; they are counted, and the next wait reports "the application is not reading its input" — the backlog becomes a diagnosis instead of a stall.

**`POLLOUT` was tried first and rejected.** On macOS a pty master reports writable even when the following write blocks (probed directly: poll said writable, the write then blocked until the child died). It cannot be used for flow control here — worth recording, since it's the obvious first idea. `O_NONBLOCK` was rejected too: portable-pty's reader and writer are dups of the same open file description, so it would also hit the read path, which treats any error as EOF.

`Drop`'s `child.wait()` is now bounded as well. A stuck child is a bad outcome; a test binary that never exits is a worse one, and unlike the first it cannot even be diagnosed.

Three regression tests, including the exact reproduction above (now ~1 s), plus one pinning that applications which *do* read still receive every reply. DESIGN.md §1 documents the drain-never-writes rule.

The user-facing write path (`send`/`paste`/`click`) has the same missing deadline and stays scoped to #59 in v0.3.

Closes #60