### PR TITLE
fix(mouse): honor the UTF-8 mouse encoding (mode 1005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ listed under a **Changed** or **Removed** heading.
   replies are counted and reported ("the application is not reading its
   input") instead of stalling anything. `Drop`'s reap is bounded too —
   teardown must always terminate.
+- Mouse reports now follow the **UTF-8 encoding** (mode 1005) when the
+  application selects it. The encoding was collapsed to "SGR or not", so
+  a 1005 application received the legacy form — identical below column
+  95, and a bare non-UTF-8 byte past it, which such an application
+  cannot decode.
 - The unanswered-query diagnosis no longer misattributes unrelated
   failures. It was recorded once and never cleared, so a single
   deliberately-unanswered probe at startup (kitty's `CSI ? u` is the

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -40,10 +40,25 @@ pub(crate) struct Processed {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct InputModes {
     pub(crate) mouse: MouseMode,
-    /// SGR (1006) mouse encoding active.
-    pub(crate) sgr_mouse: bool,
+    pub(crate) mouse_encoding: MouseEncoding,
     pub(crate) bracketed_paste: bool,
     pub(crate) application_cursor: bool,
+}
+
+/// How the application asked for mouse coordinates to be encoded. The
+/// three schemes agree below column/row 95 and diverge past it, so
+/// sending the wrong one fails only at a position boundary — which is a
+/// miserable thing to debug from a test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MouseEncoding {
+    /// The original byte-valued form: `ESC [ M Cb Cx Cy`, unusable past
+    /// coordinate 222.
+    Legacy,
+    /// SGR (mode 1006): `ESC [ < b ; col ; row M`, unbounded.
+    Sgr,
+    /// UTF-8 (mode 1005): like the legacy form, but coordinates above 95
+    /// are encoded as two-byte UTF-8 rather than a bare byte.
+    Utf8,
 }
 
 /// A VT emulator: consumes raw PTY bytes, maintains a screen grid.

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -2,7 +2,7 @@
 //! snapshot converts vt100's grid into termlens's own [`Screen`].
 
 use super::seq::{SeqEvent, SeqTracker};
-use super::{Emulator, InputModes, Processed, Stop};
+use super::{Emulator, InputModes, MouseEncoding, Processed, Stop};
 use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
 
 pub(crate) struct Vt100Emulator {
@@ -88,10 +88,11 @@ impl Emulator for Vt100Emulator {
         let screen = self.parser.screen();
         InputModes {
             mouse: convert_mouse(screen.mouse_protocol_mode()),
-            sgr_mouse: matches!(
-                screen.mouse_protocol_encoding(),
-                ::vt100::MouseProtocolEncoding::Sgr
-            ),
+            mouse_encoding: match screen.mouse_protocol_encoding() {
+                ::vt100::MouseProtocolEncoding::Sgr => MouseEncoding::Sgr,
+                ::vt100::MouseProtocolEncoding::Utf8 => MouseEncoding::Utf8,
+                ::vt100::MouseProtocolEncoding::Default => MouseEncoding::Legacy,
+            },
             bracketed_paste: screen.bracketed_paste(),
             application_cursor: screen.application_cursor(),
         }

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -330,6 +330,23 @@ pub(crate) fn mouse_legacy(button: u8, col: u16, row: u16) -> Vec<u8> {
     out
 }
 
+/// UTF-8 (mode 1005) mouse report: the legacy layout, but each
+/// coordinate is written as a UTF-8 *character* rather than a raw byte.
+/// Identical to [`mouse_legacy`] up to coordinate 127 (columns and rows
+/// 0..=94); past that the legacy form emits a bare byte no UTF-8 reader
+/// can accept, which is exactly the bug this encoding exists to avoid.
+pub(crate) fn mouse_utf8(button: u8, col: u16, row: u16) -> Vec<u8> {
+    let mut out = b"\x1b[M".to_vec();
+    out.push(32 + button); // the button byte stays a byte
+    let mut buf = [0u8; 4];
+    for coordinate in [col, row] {
+        let value = 32 + 1 + u32::from(coordinate);
+        let ch = char::from_u32(value).expect("32 + 1 + u16 is always a valid scalar value");
+        out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -415,6 +432,25 @@ mod tests {
         assert_eq!(mouse_sgr(64, 0, 0, true), b"\x1b[<64;1;1M");
         assert_eq!(mouse_legacy(0, 0, 0), b"\x1b[M\x20\x21\x21");
         assert_eq!(mouse_legacy(3, 9, 6,), b"\x1b[M\x23\x2a\x27");
+    }
+
+    #[test]
+    fn utf8_mouse_matches_legacy_until_the_encodings_diverge() {
+        // Coordinate byte is 32 + 1 + n, so n = 94 is the last value that
+        // fits in one UTF-8 byte (127) and n = 95 is the first that does
+        // not (128 -> c2 80).
+        for n in [0u16, 10, 94] {
+            assert_eq!(
+                mouse_utf8(0, n, n),
+                mouse_legacy(0, n, n),
+                "encodings must agree at coordinate {n}"
+            );
+        }
+        assert_eq!(mouse_utf8(0, 95, 0), b"\x1b[M\x20\xc2\x80\x21");
+        // The case that motivated this: column 100 is a bare 0x85 in the
+        // legacy form, which a UTF-8 reader cannot accept.
+        assert_eq!(mouse_legacy(0, 100, 3), b"\x1b[M\x20\x85\x24");
+        assert_eq!(mouse_utf8(0, 100, 3), b"\x1b[M\x20\xc2\x85\x24");
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -16,10 +16,10 @@ use std::time::{Duration, Instant};
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
-use crate::emu::{Emulator, InputModes, Query, Stop, Vt100Emulator};
+use crate::emu::{Emulator, InputModes, MouseEncoding, Query, Stop, Vt100Emulator};
 use crate::error::{Error, Result};
 use crate::keys::Input;
-use crate::keys::{mouse_legacy, mouse_sgr};
+use crate::keys::{mouse_legacy, mouse_sgr, mouse_utf8};
 use crate::screen::{MouseMode, Screen};
 use crate::wait::{next_backoff, Expired, Monitor, INITIAL_BACKOFF, POLL_CAP};
 
@@ -1027,7 +1027,7 @@ impl Terminal {
         row: u16,
         press: bool,
     ) -> Result<Vec<u8>> {
-        if modes.sgr_mouse {
+        if modes.mouse_encoding == MouseEncoding::Sgr {
             return Ok(mouse_sgr(button, col, row, press));
         }
         if col > 222 || row > 222 {
@@ -1036,9 +1036,13 @@ impl Terminal {
                  encoding the application selected (max 222)"
             )));
         }
-        // Legacy encoding: a release is button 3.
-        let button = if press { button } else { 3 };
-        Ok(mouse_legacy(button, col, row))
+        // Both remaining forms are `ESC [ M Cb Cx Cy`; they differ only in
+        // how a coordinate byte above 127 is written.
+        let button = if press { button } else { 3 }; // legacy: release is 3
+        Ok(match modes.mouse_encoding {
+            MouseEncoding::Utf8 => mouse_utf8(button, col, row),
+            MouseEncoding::Legacy | MouseEncoding::Sgr => mouse_legacy(button, col, row),
+        })
     }
 
     fn write_or_panic(&mut self, bytes: &[u8], what: &str) {

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -148,6 +148,41 @@ fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
     Ok(())
 }
 
+/// An application that selected the UTF-8 mouse encoding (mode 1005)
+/// must receive coordinates it can decode. The legacy form writes a bare
+/// byte above 127, which is not valid UTF-8 on its own — and because the
+/// two encodings agree below column 95, sending the wrong one fails only
+/// past a position boundary.
+#[test]
+fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(120, 24)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo; printf '\033[?1000h\033[?1005h'; printf READY; ",
+                r"head -c 7 | od -An -tx1 | tr -d ' \n'; printf ' WIRE-EOF'; read guard"
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+
+    // Column 100 is 0x85 as a bare byte; UTF-8 must send c2 85.
+    t.click(100, 3)?;
+    t.send_str("\n\n\n\n\n\n\n");
+    t.wait_until(|s| s.contains("WIRE-EOF"))?;
+
+    let wire = t.screen().row_text(0);
+    assert!(
+        wire.contains("1b5b4d20c28524"),
+        "expected ESC [ M 0x20 c2 85 0x24 (UTF-8 column 100), got: {wire}"
+    );
+    t.send_str("\n");
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 #[test]
 fn arrows_follow_the_apps_cursor_key_mode() -> termlens::Result<()> {
     // The script enables DECCKM (CSI ?1 h), reads 3 bytes, reports them,


### PR DESCRIPTION
`InputModes` reduced the mouse encoding to a single `sgr_mouse: bool`, so an application that enabled `CSI ?1005 h` (UTF-8 coordinates) was sent the **legacy** byte form.

The two encodings agree below column 95 and diverge past it — which is exactly why this survived until now. Captured off the wire for `click(100, 3)` under `?1000h ?1005h`:

```
1b 5b 4d 20 85 24        ← what termlens sent (legacy: bare 0x85)
1b 5b 4d 20 c2 85 24     ← what a 1005 application is parsing
```

`0x85` is not valid UTF-8 on its own, so the application either drops the report or resynchronizes mid-stream — silently, and only past a position boundary, which is a miserable failure to debug from a test.

The encoding now travels as an enum (`Legacy` / `Sgr` / `Utf8`) through `InputModes`, and the report is built to match. `mouse_utf8` writes each coordinate as a UTF-8 *character*; a unit test pins that it is byte-identical to the legacy form up to coordinate 94 and diverges at 95, and an integration test captures the real wire at column 100.

Moved into v0.2.1 during the milestone audit: this is silent wrong behavior with a purely internal, API-compatible fix (`InputModes` and `mouse_report` are private), so it belongs with the correctness patch rather than the feature milestone.

Closes #57