### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-08-12
+
+Correctness patch. Every entry below was found by probing the published
+0.2.0 rather than reading the source, and each one is a case where the
+harness quietly did the wrong thing, panicked inside a dependency, or —
+in the worst of them — hung itself.
+
 ### Changed
 
 - `paste` now transforms the text the way a real terminal does, so what

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossterm",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossterm",
 ]
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossterm",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -563,7 +563,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.2.0" }
+termlens = { path = "crates/termlens", version = "0.2.1" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
Version bump and CHANGELOG date for **v0.2.1** — the correctness patch ([milestone](https://github.com/vyncint/termlens/milestone/2), 9 issues, all closed).

Every issue in this release was found by probing the *published* 0.2.0 rather than reading the source, and each is a case where the harness quietly did the wrong thing rather than failing:

| | |
|---|---|
| #60 | **The harness could deadlock itself** — replies written from the drain, default config, no test input. `Drop` never returned |
| #49 | Zero-size panics; in release builds the drain died silently and tests went green |
| #48 | `current_dir` silently ignored — the child ran in `$HOME` |
| #50 #62 | `paste` delivered something other than what was written (embedded markers, LF vs CR) |
| #51 | The query diagnosis blamed unrelated failures, and `wait_frame` withheld it entirely |
| #61 | `wait_frame` timeouts showed a stale screen under a "screen at timeout" header |
| #57 | Mouse reports a 1005 application cannot parse |
| #52 | `spawn("")` buried its cause in a PATH wall |

**Semver**: no public API changes, so `cargo-semver-checks` passes as a patch. The one behaviour change — `paste` transforming text the way a real terminal does — is under `### Changed`, since that heading is the only notice a downstream user gets for a change the tooling cannot see.

Gates: fmt, clippy (all targets/features), 16 test suites green in **both debug and release** (release matters here — it's where the zero-size bug hid), doctests, doc build with `-D warnings`, cargo-deny, and changelog extraction verified. Stress ×100 on both OSes is running against final main.

Closes the v0.2.1 milestone.