### PR TITLE
feat(terminal): per-call timeouts on every wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- Every wait now takes a per-call deadline: `wait_frame_for`,
+  `wait_idle_for` and `wait_exit_for` join `wait_until_for`. One
+  known-slow step no longer forces the builder timeout up for every
+  other wait in the suite — which is what made a genuinely stuck
+  application burn the long timeout on its first failure. Timeout errors
+  report the deadline that actually applied.
 - `wait_frame` retains the **last 8 completed frames** and evaluates
   them oldest first, so a burst of frames arriving in a single read is
   observable step by step — a progress counter ticking `1`, `2`, `3` in

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1214,9 +1214,32 @@ impl Terminal {
     /// application never emitted a single synchronized update, since
     /// `wait_frame` can then never succeed; use `wait_until` for such apps.
     /// [`Error::Eof`] as soon as the PTY closes with no matching frame.
-    pub fn wait_frame(&mut self, mut predicate: impl FnMut(&Screen) -> bool) -> Result<()> {
+    pub fn wait_frame(&mut self, predicate: impl FnMut(&Screen) -> bool) -> Result<()> {
+        self.wait_frame_deadline(predicate, self.default_timeout)
+    }
+
+    /// [`wait_frame`](Self::wait_frame) with a per-call timeout, for the
+    /// one known-slow repaint that shouldn't drag every other wait in the
+    /// suite up to its deadline.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`wait_frame`](Self::wait_frame).
+    pub fn wait_frame_for(
+        &mut self,
+        predicate: impl FnMut(&Screen) -> bool,
+        timeout: Duration,
+    ) -> Result<()> {
+        self.wait_frame_deadline(predicate, timeout)
+    }
+
+    fn wait_frame_deadline(
+        &mut self,
+        mut predicate: impl FnMut(&Screen) -> bool,
+        timeout: Duration,
+    ) -> Result<()> {
         const WHAT: &str = "a complete frame matching the predicate";
-        let deadline = Instant::now() + self.default_timeout;
+        let deadline = Instant::now() + timeout;
         let mut seen_frame = None;
         let outcome = self.shared.wait_until(deadline, |state| {
             if state.frames_seen > 0 && seen_frame != Some(state.frames_seen) {
@@ -1268,7 +1291,7 @@ impl Terminal {
                 };
                 Err(Error::Timeout {
                     waiting_for,
-                    timeout: self.default_timeout,
+                    timeout,
                     screen,
                 })
             }
@@ -1292,7 +1315,35 @@ impl Terminal {
     /// expires first — e.g. when `quiet` exceeds the timeout, or the child
     /// keeps chattering.
     pub fn wait_idle(&mut self, quiet: Duration) -> Result<()> {
-        let deadline = Instant::now() + self.default_timeout;
+        self.wait_idle_deadline(quiet, self.default_timeout)
+    }
+
+    /// [`wait_idle`](Self::wait_idle) with a per-call timeout.
+    ///
+    /// Both arguments are durations and the order matters: `quiet` is the
+    /// silence being waited *for*, `timeout` is how long to wait for it.
+    /// `quiet` must be the smaller of the two, or the wait can only ever
+    /// time out.
+    ///
+    /// ```no_run
+    /// # use std::time::Duration;
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// // 100ms of silence, waited for up to 30s.
+    /// t.wait_idle_for(Duration::from_millis(100), Duration::from_secs(30))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Same as [`wait_idle`](Self::wait_idle), against `timeout`.
+    pub fn wait_idle_for(&mut self, quiet: Duration, timeout: Duration) -> Result<()> {
+        self.wait_idle_deadline(quiet, timeout)
+    }
+
+    fn wait_idle_deadline(&mut self, quiet: Duration, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
         let mut guard = self.shared.lock();
         loop {
             if guard.eof {
@@ -1310,7 +1361,7 @@ impl Terminal {
                 drop(guard);
                 return Err(Error::Timeout {
                     waiting_for: format!("{quiet:?} of output silence{note}"),
-                    timeout: self.default_timeout,
+                    timeout,
                     screen,
                 });
             }
@@ -1404,10 +1455,25 @@ impl Terminal {
     /// [`Error::Timeout`] (with screen) if the child is still running at the
     /// deadline; [`Error::Io`] if the OS wait itself fails.
     pub fn wait_exit(&mut self) -> Result<ExitStatus> {
+        self.wait_exit_deadline(self.default_timeout)
+    }
+
+    /// [`wait_exit`](Self::wait_exit) with a per-call timeout — for the
+    /// application whose shutdown is slower than everything else the
+    /// suite waits on.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`wait_exit`](Self::wait_exit), against `timeout`.
+    pub fn wait_exit_for(&mut self, timeout: Duration) -> Result<ExitStatus> {
+        self.wait_exit_deadline(timeout)
+    }
+
+    fn wait_exit_deadline(&mut self, timeout: Duration) -> Result<ExitStatus> {
         if let Some(status) = self.exit_status.clone() {
             return Ok(status);
         }
-        let deadline = Instant::now() + self.default_timeout;
+        let deadline = Instant::now() + timeout;
         let mut backoff = INITIAL_BACKOFF;
         loop {
             if let Some(status) = self.child.try_wait().map_err(Error::Io)? {
@@ -1428,7 +1494,7 @@ impl Terminal {
                         self.command_desc,
                         self.shared.lock().query_note()
                     ),
-                    timeout: self.default_timeout,
+                    timeout,
                     screen: self.screen(),
                 });
             }

--- a/crates/termlens/tests/timeouts.rs
+++ b/crates/termlens/tests/timeouts.rs
@@ -1,0 +1,116 @@
+//! Every wait takes a per-call deadline, and the error reports the
+//! deadline that actually applied.
+
+use std::time::{Duration, Instant};
+
+use termlens::{Error, Key, Terminal};
+
+/// The builder default is deliberately far too short for the app; only
+/// the per-call override can see each wait through.
+fn slow_app(script: &str) -> Terminal {
+    Terminal::builder()
+        .size(80, 24)
+        .env_clear()
+        .timeout(Duration::from_millis(150))
+        .args(["-c", script])
+        .spawn("/bin/sh")
+        .expect("spawn")
+}
+
+#[test]
+fn wait_frame_for_overrides_the_builder_default() -> termlens::Result<()> {
+    let mut t = slow_app(r"sleep 1; printf '\033[?2026hlate frame\033[?2026l'; read guard");
+    t.wait_frame_for(|s| s.contains("late frame"), Duration::from_secs(30))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit_for(Duration::from_secs(30))?.success());
+    Ok(())
+}
+
+#[test]
+fn wait_idle_for_overrides_the_builder_default() -> termlens::Result<()> {
+    let mut t = slow_app(r"printf busy; read guard");
+    // A 200ms quiet period cannot be observed under the 150ms builder
+    // deadline at all — the wait would expire before the silence does.
+    let start = Instant::now();
+    t.wait_idle_for(Duration::from_millis(200), Duration::from_secs(30))?;
+    assert!(
+        start.elapsed() >= Duration::from_millis(200),
+        "resolved before the quiet period elapsed: {:?}",
+        start.elapsed()
+    );
+    assert!(t.screen().contains("busy"), "{}", t.screen());
+    // (Asserting that the unqualified `wait_idle` still fails here would
+    // be wrong: the terminal has now been silent for longer than the
+    // quiet period, so it resolves immediately without consulting any
+    // deadline. `per_call_timeouts_report_their_own_deadline` covers the
+    // deadline behaviour against a still-chattering child.)
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit_for(Duration::from_secs(30))?.success());
+    Ok(())
+}
+
+#[test]
+fn wait_exit_for_overrides_the_builder_default() -> termlens::Result<()> {
+    let mut t = slow_app("sleep 1; exit 3");
+    let status = t.wait_exit_for(Duration::from_secs(30))?;
+    assert_eq!(status.code(), 3, "status: {status}");
+    Ok(())
+}
+
+/// A per-call timeout also cuts a generous default short, and the error
+/// reports the deadline that actually applied — not the builder's.
+#[test]
+fn per_call_timeouts_report_their_own_deadline() {
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .env_clear()
+        .timeout(Duration::from_secs(30))
+        .args(["-c", "read guard"])
+        .spawn("/bin/sh")
+        .expect("spawn");
+
+    for (label, err) in [
+        (
+            "wait_frame_for",
+            t.wait_frame_for(|s| s.contains("never"), Duration::from_millis(120))
+                .unwrap_err(),
+        ),
+        (
+            "wait_idle_for",
+            t.wait_idle_for(Duration::from_secs(5), Duration::from_millis(120))
+                .unwrap_err(),
+        ),
+        (
+            "wait_exit_for",
+            t.wait_exit_for(Duration::from_millis(120)).unwrap_err(),
+        ),
+    ] {
+        match err {
+            Error::Timeout { timeout, .. } => assert_eq!(
+                timeout,
+                Duration::from_millis(120),
+                "{label} reported the wrong deadline"
+            ),
+            other => panic!("{label}: expected a timeout, got {other}"),
+        }
+    }
+}
+
+/// The overrides must not cost wall-clock when they are not needed.
+#[test]
+fn a_short_per_call_timeout_fails_fast() {
+    let mut t = Terminal::builder()
+        .env_clear()
+        .timeout(Duration::from_secs(60))
+        .args(["-c", "read guard"])
+        .spawn("/bin/sh")
+        .expect("spawn");
+    let start = Instant::now();
+    let _ = t.wait_frame_for(|s| s.contains("never"), Duration::from_millis(100));
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "the per-call deadline did not cut the 60s default short: {:?}",
+        start.elapsed()
+    );
+}


### PR DESCRIPTION
`wait_until_for` existed; `wait_frame`, `wait_idle` and `wait_exit` were stuck with the builder deadline. Since `wait_frame` is now the recommended primitive for applications with synchronized output, a frame-driven suite with one slow step had to raise the builder timeout for *every* wait — which is precisely what makes a genuinely stuck application burn the long timeout on its first failure, the thing the default deadline exists to prevent.

Ranked #1 by the coverage study (§2.8): "the gap most likely to be felt next".

Each wait now has a single internal implementation taking an explicit deadline, with the public method and its `_for` variant as thin wrappers — so behaviour (generation gating, EOF fast-fail, query notes) stays identical and the timeout reported in the error is always the one that applied.

**`wait_exit_for` is included**, which the issue did not ask for: `docs/DESIGN.md` §2 counts `wait_exit` among the waits, so "every wait takes a per-call deadline" is not true without it. `wait_idle_for(quiet, timeout)` takes two durations whose order matters, so the rustdoc shows the call with both values named and states which must be smaller.

Five tests: each override seeing a slow app through under a deliberately-too-short builder default, each reporting its own deadline rather than the builder's, and a short override cutting a 60s default fast.

Closes #53