### PR TITLE
feat(terminal): retain a short frame history so burst frames stay observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Added
+
+- `wait_frame` retains the **last 8 completed frames** and evaluates
+  them oldest first, so a burst of frames arriving in a single read is
+  observable step by step — a progress counter ticking `1`, `2`, `3` in
+  one write used to be visible only at `3`. The retention bound and its
+  two consequences (a longer burst drops its oldest frames; a retained
+  frame stays matchable, so a predicate satisfied earlier resolves at
+  once) are documented on `wait_frame` and in `docs/DESIGN.md` §2.
+
 ## [0.2.1] - 2026-08-12
 
 Correctness patch. Every entry below was found by probing the published

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -6,6 +6,7 @@
 //! the test thread. Screens are immutable snapshots taken under that lock,
 //! so no output is ever lost between two waits.
 
+use std::collections::VecDeque;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::{self, Read, Write};
@@ -33,6 +34,17 @@ const DRAIN_GRACE: Duration = Duration::from_millis(500);
 /// distinct `CSI … n` is its own shape — so it is bounded; anything
 /// beyond this is counted rather than kept.
 const MAX_UNANSWERED: usize = 8;
+
+/// How many completed frames a terminal retains for [`wait_frame`].
+///
+/// Several frames can complete inside a single read, and only retained
+/// frames are observable — so the bound is the bound on how much of a
+/// burst a test can assert on. Eight covers realistic bursts (a repaint
+/// is rarely under a hundred bytes, and a read is 8 KiB) while keeping
+/// the worst case small: a retained frame is a full grid snapshot, about
+/// 75 KB at 80×24 and 470 KB at 200×60, so eight of them cost roughly
+/// 0.6 MB and 3.8 MB respectively.
+const FRAME_HISTORY: usize = 8;
 
 /// Query replies that may be queued for the responder thread before the
 /// drain starts discarding them. Reached only when the application has
@@ -213,8 +225,11 @@ struct EmuState {
     snapshot_cache: Option<(u64, Screen)>,
     /// Completed synchronized updates (DEC 2026) observed so far.
     frames_seen: u64,
-    /// The screen exactly as of the most recent completed frame.
-    last_frame: Option<Screen>,
+    /// The most recent completed frames, oldest first, capped at
+    /// [`FRAME_HISTORY`]. Several frames can complete inside one read, so
+    /// keeping only the newest made rapid intermediate states — a
+    /// progress counter ticking 1, 2, 3 in one write — unobservable.
+    frames: VecDeque<Screen>,
     /// Whether to answer recognized terminal queries (builder-configured).
     respond: bool,
     /// Background color reported to OSC 11 queries.
@@ -243,7 +258,7 @@ impl EmuState {
             generation: 0,
             snapshot_cache: None,
             frames_seen: 0,
-            last_frame: None,
+            frames: VecDeque::with_capacity(FRAME_HISTORY),
             respond,
             background,
             unanswered: Vec::new(),
@@ -813,7 +828,11 @@ fn reader_loop(
                         match processed.stop {
                             Some(Stop::FrameComplete) => {
                                 state.frames_seen += 1;
-                                state.last_frame = Some(state.emu.snapshot());
+                                let frame = state.emu.snapshot();
+                                if state.frames.len() == FRAME_HISTORY {
+                                    state.frames.pop_front();
+                                }
+                                state.frames.push_back(frame);
                             }
                             Some(Stop::Query(query)) => {
                                 if let Some(reply) = state.answer(&query) {
@@ -1165,11 +1184,18 @@ impl Terminal {
     /// demands (single predicate, wait on the last-painted region; see
     /// `docs/DESIGN.md` §2).
     ///
-    /// The frame completed most recently *before* the call is evaluated
-    /// first, so a fast application cannot slip a frame past you. Each
-    /// frame is evaluated at most once; if several frames complete within
-    /// one read burst, only the newest is seen — `wait_frame` guarantees
-    /// frame-consistent screens, not observation of every transient frame.
+    /// Frames completed *before* the call are evaluated too, so a fast
+    /// application cannot slip one past you — including when several
+    /// complete inside a single read. The terminal retains the last
+    /// **8** completed frames and each call scans them oldest first, so
+    /// a burst like a progress counter ticking `1`, `2`, `3` in one
+    /// write is observable step by step by three successive calls.
+    ///
+    /// Two honest limits follow from the retention bound: a burst longer
+    /// than 8 frames drops its oldest, and because retained frames stay
+    /// matchable, a predicate that was true of an earlier frame resolves
+    /// immediately rather than waiting for a new one. Where that matters,
+    /// assert on something only the newer frame can show.
     ///
     /// ```
     /// # fn main() -> termlens::Result<()> {
@@ -1195,11 +1221,11 @@ impl Terminal {
         let outcome = self.shared.wait_until(deadline, |state| {
             if state.frames_seen > 0 && seen_frame != Some(state.frames_seen) {
                 seen_frame = Some(state.frames_seen);
-                let frame = state
-                    .last_frame
-                    .clone()
-                    .expect("frames_seen > 0 implies a stored frame");
-                if predicate(&frame) {
+                // Oldest retained frame first: several frames can
+                // complete inside one read, and a test asserting on a
+                // sequence must be able to see them in the order the
+                // application drew them.
+                if state.frames.iter().any(&mut predicate) {
                     return Some(Ok(()));
                 }
             }

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -141,6 +141,63 @@ fn wait_frame_timeouts_embed_the_live_screen_not_the_last_frame() {
     );
 }
 
+/// Several frames can complete inside one read. Each must stay
+/// observable, in the order the application drew them — a progress
+/// counter ticking 1, 2, 3 in a single write used to be visible only
+/// at 3.
+#[test]
+fn every_frame_of_a_burst_is_observable_in_order() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            // Three complete frames in ONE write, then park.
+            concat!(
+                r"printf '\033[?2026h\033[HSTEP 1\033[?2026l",
+                r"\033[?2026h\033[HSTEP 2\033[?2026l",
+                r"\033[?2026h\033[HSTEP 3\033[?2026l'; read guard"
+            ),
+        ])
+        .spawn("sh")?;
+
+    // Wait for the last one first, so all three have certainly arrived
+    // (and been coalesced into as few reads as the OS chose).
+    t.wait_frame(|s| s.contains("STEP 3"))?;
+    // Every intermediate frame is still there.
+    t.wait_frame(|s| s.contains("STEP 1"))?;
+    t.wait_frame(|s| s.contains("STEP 2"))?;
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The retention bound is real and documented: beyond it, the oldest
+/// frames are dropped.
+#[test]
+fn a_burst_longer_than_the_retention_bound_drops_its_oldest_frames() -> termlens::Result<()> {
+    // 12 frames in one write, against a retention bound of 8.
+    let mut script = String::new();
+    for n in 1..=12 {
+        script.push_str(&format!(r"\033[?2026h\033[HFRAME {n:02}\033[?2026l"));
+    }
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(600))
+        .args(["-c", &format!("printf '{script}'; read guard")])
+        .spawn("sh")?;
+
+    t.wait_frame(|s| s.contains("FRAME 12"))?;
+    // The most recent 8 are retained: 05..=12.
+    t.wait_frame(|s| s.contains("FRAME 05"))?;
+    // The first four are gone, and the error says how many were seen.
+    let err = t.wait_frame(|s| s.contains("FRAME 01")).unwrap_err();
+    assert!(
+        err.to_string().contains("12 complete frames observed"),
+        "the frame count belongs in the message: {err}"
+    );
+    Ok(())
+}
+
 #[test]
 fn wait_frame_fails_fast_on_eof() {
     let mut t = Terminal::builder()

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -90,13 +90,16 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
   including multi-mode lists); the reader splits each chunk at every
   frame end and snapshots the screen *at that instant*, so the predicate
   sees exactly the frame as the app finished it — even when the same read
-  already carries the next frame's opening bytes. The frame completed
-  most recently before the call is evaluated first (fast apps can't slip
-  a frame past the wait). Honest caveat: frames that complete within one
-  read burst supersede each other — `wait_frame` guarantees
-  frame-consistent screens, not observation of every transient frame. An
-  app that never emits a synchronized update makes the timeout error say
-  so and point at `wait_until`.
+  already carries the next frame's opening bytes. The last **8**
+  completed frames are retained and each call scans them oldest first, so
+  frames completed before the call are still observable (fast apps can't
+  slip one past the wait) and a burst of frames arriving in one read can
+  be asserted on step by step. Honest caveats: a burst longer than the
+  retention bound drops its oldest frames, and a retained frame stays
+  matchable, so a predicate satisfied by an earlier frame resolves at
+  once rather than waiting for a new one. An app that never emits a
+  synchronized update makes the timeout error say so and point at
+  `wait_until`.
 - `wait_idle(quiet)` — resolves when **no bytes for `quiet`** AND the
   stream does not end mid-escape-sequence (or mid-UTF-8-character) AND no
   synchronized update is open (a begun-but-unfinished DEC 2026 repaint is


### PR DESCRIPTION
Only the newest completed frame was kept, so when several completed inside one read the earlier ones were unreachable — a progress counter ticking `1`, `2`, `3` in a single write was only ever observable at `3`. Ranked #3 by the coverage study (§2.1), pinned there by `only_the_newest_frame_of_a_burst_survives`, which this flips.

The terminal now retains the last **8** completed frames, and each `wait_frame` call scans them oldest first.

### Correcting the fix as filed

The issue proposed a queue plus "evaluate pending frames oldest-first", with a Done-when of *"three frames observable in order by three successive `wait_frame` calls"*. Those two cannot both hold with the existing per-call cursor — satisfying the Done-when literally requires a **shared, consuming** cursor, which silently removes behaviour a shipped test depends on: `a_frame_is_internally_consistent` calls `wait_frame` twice on the same frame with no input in between, against a fixture that repaints only on input. It would burn the full 10s deadline.

So: **keep the per-call cursor, widen what each call scans.** Three successive calls each find their frame, the re-match behaviour survives untouched, and because the match set only grows, no passing test can start failing. (Recorded on #55 before implementing.)

### Documented consequences

The guarantee changes from "the most recently completed frame is evaluated first" to "every retained frame is evaluated, oldest first", and both honest limits are now stated in the rustdoc and DESIGN.md §2: a burst longer than 8 drops its oldest frames, and a retained frame stays matchable, so a predicate satisfied by an earlier frame resolves immediately rather than waiting for a new one.

The issue's memory justification was also wrong and is corrected in the code comment: `Screen::from_parts` allocates a fresh `Arc<[Cell]>` per snapshot, so `Arc`-backing makes *cloning* cheap and says nothing about retaining N frames. The cap is justified by real cost — ~0.6 MB at 80×24, ~3.8 MB at 200×60.

Two new tests (three frames from one write observed in order; a 12-frame burst dropping its oldest), and the existing frames suite passes unchanged — including the internally-consistent test above. Ran the suite 8× locally for flake safety.

Closes #55