### PR TITLE
feat(queries): answer DECRQM, and name DECRQSS, OSC 4 and OSC 52

### DIFF
--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -61,6 +61,31 @@ pub(crate) enum MouseEncoding {
     Utf8,
 }
 
+/// What a `DECRQM` request can be told about a private mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModeState {
+    /// The mode is implemented and currently set.
+    Set,
+    /// The mode is implemented and currently reset.
+    Reset,
+    /// Not implemented, or implemented but not tracked precisely enough
+    /// to answer honestly. Reported as "not recognized", never guessed:
+    /// an application told a mode is reset when it may be set is worse
+    /// off than one told nothing.
+    NotRecognized,
+}
+
+impl ModeState {
+    /// The `Ps` value of the `DECRPM` reply.
+    pub(crate) fn report_value(self) -> u32 {
+        match self {
+            ModeState::Set => 1,
+            ModeState::Reset => 2,
+            ModeState::NotRecognized => 0,
+        }
+    }
+}
+
 /// A VT emulator: consumes raw PTY bytes, maintains a screen grid.
 pub(crate) trait Emulator: Send {
     /// Feed raw bytes from the PTY into the emulator. Stops early — with
@@ -83,6 +108,9 @@ pub(crate) trait Emulator: Send {
 
     /// The input-affecting modes the application has currently set.
     fn input_modes(&self) -> InputModes;
+
+    /// Whether DEC private mode `mode` is set, for answering `DECRQM`.
+    fn mode_state(&self, mode: u32) -> ModeState;
 
     /// Resize the emulated grid to `rows` × `cols`.
     fn set_size(&mut self, rows: u16, cols: u16);

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -82,9 +82,14 @@ pub(crate) enum Query {
         /// True when the query used ST; the reply must mirror it.
         st_terminated: bool,
     },
+    /// DECRQM: "is private mode `n` set?" — `CSI ? n $ p`. Answering
+    /// this truthfully lets an application that *probes* before using a
+    /// mode (synchronized output above all) turn it on against termlens.
+    RequestMode(u32),
     /// Recognized as a question, but one termlens has no answer for
-    /// (XTGETTCAP, kitty `CSI ? u`, other DSR/DA/XTWINOPS reports, …).
-    /// Carries a printable rendering for diagnostics.
+    /// (XTGETTCAP, kitty `CSI ? u`, DECRQSS, `OSC 4`/`OSC 52`, other
+    /// DSR/DA/XTWINOPS reports, …). Carries a printable rendering for
+    /// diagnostics.
     Unanswerable(String),
 }
 
@@ -112,6 +117,8 @@ pub(crate) struct SeqTracker {
     // Incremental CSI scanner: enough to recognize mode 2026 and the
     // handful of query shapes, in O(1) space.
     csi_prefix: u8,
+    /// Intermediate byte seen in the current CSI (only `$` matters).
+    csi_intermediate: u8,
     csi_invalid: bool,
     csi_first: bool,
     csi_param: u32,
@@ -138,6 +145,7 @@ impl SeqTracker {
             utf8_remaining: 0,
             sync_update: false,
             csi_prefix: 0,
+            csi_intermediate: 0,
             csi_invalid: false,
             csi_first: true,
             csi_param: 0,
@@ -176,6 +184,7 @@ impl SeqTracker {
 
     fn reset_csi_scanner(&mut self) {
         self.csi_prefix = 0;
+        self.csi_intermediate = 0;
         self.csi_invalid = false;
         self.csi_first = true;
         self.csi_param = 0;
@@ -227,8 +236,12 @@ impl SeqTracker {
                 self.csi_has_digits = true;
             }
             b';' => self.end_csi_param(),
-            // Sub-parameters or intermediates: none of the sequences we
-            // recognize use them.
+            // `$` is the intermediate of the DECRQM request (`CSI ? n $ p`);
+            // recording it keeps the sequence classifiable instead of
+            // discarding it as unrecognized.
+            b'$' => self.csi_intermediate = b'$',
+            // Sub-parameters or other intermediates: none of the sequences
+            // we recognize use them.
             _ => self.csi_invalid = true,
         }
         self.csi_first = false;
@@ -244,6 +257,20 @@ impl SeqTracker {
         }
         let params_empty = self.csi_param_count == 0;
         let single = |v: u32| self.csi_param_count == 1 && self.csi_first_param == v;
+
+        // DECRQM (`CSI ? n $ p`) and DECRQSS-adjacent `$`-intermediate
+        // requests. Handled before the plain-CSI table below, which
+        // assumes no intermediate.
+        if self.csi_intermediate == b'$' {
+            return match (self.csi_prefix, b) {
+                (b'?', b'p') if self.csi_param_count == 1 => {
+                    SeqEvent::Query(Query::RequestMode(self.csi_first_param))
+                }
+                // ANSI-mode DECRQM and mode *reports* we cannot answer.
+                (_, b'p' | b'y') => SeqEvent::Query(Query::Unanswerable(self.seq_printable())),
+                _ => SeqEvent::None,
+            };
+        }
 
         // DEC private mode 2026 (synchronized output).
         if self.csi_prefix == b'?' && self.csi_saw_2026 {
@@ -307,6 +334,18 @@ impl SeqTracker {
                     })
                 }
                 b"12;?" => return SeqEvent::Query(Query::Unanswerable(self.seq_printable())),
+                content
+                    if content.ends_with(b"?")
+                        && (content.starts_with(b"4;") || content.starts_with(b"52;")) =>
+                {
+                    // Palette queries (`OSC 4;n;?`) and clipboard reads
+                    // (`OSC 52;…;?`), recognized so a blocked application
+                    // is diagnosed rather than left silently hanging. The
+                    // `?` matters: both codes also *set* — a palette
+                    // colour, or the clipboard from base64 — and a set is
+                    // not a question.
+                    return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
+                }
                 content => {
                     // OSC 0 (icon + title) / OSC 2 (title) set the window
                     // title — state the vt100 backend does not track.
@@ -321,9 +360,10 @@ impl SeqTracker {
                 }
             }
         }
-        // DCS: XTGETTCAP is `ESC P + q … ST` — a capability question.
+        // DCS questions: XTGETTCAP (`ESC P + q … ST`) and DECRQSS
+        // (`ESC P $ q … ST`, "what is the current setting of …?").
         let body = &self.seq_buf[..usize::from(self.seq_len)];
-        if body.get(2..4) == Some(b"+q") {
+        if matches!(body.get(2..4), Some(b"+q" | b"$q")) {
             return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
         }
         SeqEvent::None
@@ -621,6 +661,44 @@ mod tests {
         // Any CSI …n is a DSR-family status request by definition.
         let q = queries_of(b"\x1b[6;1n");
         assert_eq!(q, vec![Query::Unanswerable("^[[6;1n".into())]);
+    }
+
+    #[test]
+    fn recognizes_decrqm_mode_requests() {
+        assert_eq!(queries_of(b"\x1b[?2026$p"), vec![Query::RequestMode(2026)]);
+        assert_eq!(queries_of(b"\x1b[?2004$p"), vec![Query::RequestMode(2004)]);
+        assert_eq!(queries_of(b"\x1b[?1$p"), vec![Query::RequestMode(1)]);
+        // ANSI-mode DECRQM (no `?`) is recognized but not answerable.
+        assert_eq!(
+            queries_of(b"\x1b[4$p"),
+            vec![Query::Unanswerable("^[[4$p".into())]
+        );
+    }
+
+    #[test]
+    fn recognizes_the_remaining_unanswerable_families() {
+        // DECRQSS: "what is the current setting of ...?"
+        assert_eq!(
+            queries_of(b"\x1bP$qm\x1b\\"),
+            vec![Query::Unanswerable("^[P$qm^[\\".into())]
+        );
+        // Palette query and clipboard read.
+        assert_eq!(
+            queries_of(b"\x1b]4;1;?\x07"),
+            vec![Query::Unanswerable("^[]4;1;?^G".into())]
+        );
+        assert_eq!(
+            queries_of(b"\x1b]52;c;?\x07"),
+            vec![Query::Unanswerable("^[]52;c;?^G".into())]
+        );
+    }
+
+    #[test]
+    fn setting_a_palette_colour_is_not_a_query() {
+        // `OSC 4;1;rgb:...` sets rather than asks — only the `?` form is
+        // a question.
+        assert!(queries_of(b"\x1b]4;1;rgb:ff/00/00\x07").is_empty());
+        assert!(queries_of(b"\x1b]52;c;aGVsbG8=\x07").is_empty());
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -2,7 +2,7 @@
 //! snapshot converts vt100's grid into termlens's own [`Screen`].
 
 use super::seq::{SeqEvent, SeqTracker};
-use super::{Emulator, InputModes, MouseEncoding, Processed, Stop};
+use super::{Emulator, InputModes, ModeState, MouseEncoding, Processed, Stop};
 use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
 
 pub(crate) struct Vt100Emulator {
@@ -95,6 +95,58 @@ impl Emulator for Vt100Emulator {
             },
             bracketed_paste: screen.bracketed_paste(),
             application_cursor: screen.application_cursor(),
+        }
+    }
+
+    fn mode_state(&self, mode: u32) -> ModeState {
+        let screen = self.parser.screen();
+        let on = |set: bool| {
+            if set {
+                ModeState::Set
+            } else {
+                ModeState::Reset
+            }
+        };
+        // Only modes whose state we hold exactly. The mouse tracking
+        // modes are the interesting exclusion: vt100 collapses 9/1000/
+        // 1002/1003 into one mutually exclusive value, so an application
+        // that enabled several (crossterm's EnableMouseCapture sends
+        // 1000, 1002 and 1003 together) would be told the others are
+        // *reset* — a guess dressed up as an answer. Reporting the exact
+        // match and nothing else keeps every reply true.
+        match mode {
+            // Synchronized output. Answering at all is the point: an
+            // application that probes before bracketing its repaints can
+            // then use it, which is what makes wait_frame work against
+            // programs we haven't modified.
+            2026 => on(self.tracker.in_sync_update()),
+            1 => on(screen.application_cursor()),
+            25 => on(!screen.hide_cursor()),
+            47 | 1047 | 1049 => on(screen.alternate_screen()),
+            2004 => on(screen.bracketed_paste()),
+            1006 => on(matches!(
+                screen.mouse_protocol_encoding(),
+                ::vt100::MouseProtocolEncoding::Sgr
+            )),
+            1005 => on(matches!(
+                screen.mouse_protocol_encoding(),
+                ::vt100::MouseProtocolEncoding::Utf8
+            )),
+            9 | 1000 | 1002 | 1003 => {
+                let current = match screen.mouse_protocol_mode() {
+                    ::vt100::MouseProtocolMode::None => 0,
+                    ::vt100::MouseProtocolMode::Press => 9,
+                    ::vt100::MouseProtocolMode::PressRelease => 1000,
+                    ::vt100::MouseProtocolMode::ButtonMotion => 1002,
+                    ::vt100::MouseProtocolMode::AnyMotion => 1003,
+                };
+                if current == mode {
+                    ModeState::Set
+                } else {
+                    ModeState::NotRecognized
+                }
+            }
+            _ => ModeState::NotRecognized,
         }
     }
 

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -331,6 +331,13 @@ impl EmuState {
                 code,
                 st_terminated,
             } => osc_color(*code, (0xff, 0xff, 0xff), *st_terminated),
+            Query::RequestMode(mode) => {
+                // DECRPM. Reporting 0 ("not recognized") for anything we
+                // do not track exactly is deliberate — see
+                // `Emulator::mode_state`.
+                let value = self.emu.mode_state(*mode).report_value();
+                format!("\x1b[?{mode};{value}$y").into_bytes()
+            }
             Query::Unanswerable(shape) => {
                 self.note_unanswered(shape.clone());
                 return None;
@@ -792,6 +799,7 @@ fn query_shape(query: &Query) -> String {
         Query::SecondaryDa => "^[[>c".into(),
         Query::TextAreaSize => "^[[18t".into(),
         Query::OscColor { code, .. } => format!("^[]{code};?"),
+        Query::RequestMode(mode) => format!("^[[?{mode}$p"),
         Query::Unanswerable(shape) => shape.clone(),
     }
 }

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -186,6 +186,79 @@ fn wait_frame_timeouts_carry_the_query_note() {
     );
 }
 
+/// The payoff of answering DECRQM: an application that *probes* before
+/// using synchronized output can turn it on against termlens — so
+/// `wait_frame` works against a program nobody modified for us.
+#[test]
+fn an_app_that_probes_for_synchronized_output_gets_it() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        // Ask "is mode 2026 supported?" and read the DECRPM reply.
+        r"stty -icanon -echo; printf '\033[?2026$p'; ",
+        r#"reply=$(head -c 10 | tr '\033' 'E'); "#,
+        // A terminal that does not recognize the mode answers `;0$y`.
+        r#"case "$reply" in *';0$y') printf 'unsupported'; read guard; exit 0 ;; esac; "#,
+        // Recognized: bracket the repaint, exactly as a real app would.
+        r"printf '\033[?2026h\033[HPROBED FRAME\033[?2026l'; read guard"
+    ))?;
+
+    t.wait_frame(|s| s.contains("PROBED FRAME"))?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The reply must be truthful, not merely present: a mode we do not
+/// track exactly is reported as "not recognized" rather than guessed.
+#[test]
+fn mode_reports_are_truthful() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"stty -icanon -echo; printf '\033[?2004h'; ",
+        // 2004 was just set -> `;1$y`; 1 (DECCKM) is untouched -> `;2$y`;
+        // 12 (cursor blink) is not tracked at all -> `;0$y`.
+        r"printf '\033[?2004$p\033[?1$p\033[?12$p'; ",
+        // The three replies are 11 + 8 + 9 = 28 bytes:
+        // ESC[?2004;1$y  ESC[?1;2$y  ESC[?12;0$y
+        r#"reply=$(head -c 28 | tr '\033' 'E'); "#,
+        r#"printf 'got:%s' "$reply"; read guard"#
+    ))?;
+    t.wait_until(|s| s.contains("got:"))?;
+    let row = t.screen().row_text(0);
+    assert!(row.contains("E[?2004;1$y"), "2004 should be set: {row}");
+    assert!(row.contains("E[?1;2$y"), "DECCKM should be reset: {row}");
+    assert!(row.contains("E[?12;0$y"), "12 is not tracked: {row}");
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The families we recognize but cannot answer are now named in the
+/// timeout instead of hanging silently.
+#[test]
+fn decrqss_and_palette_queries_are_named() {
+    for (label, script, shape) in [
+        (
+            "DECRQSS",
+            r#"printf '\033P$qm\033\\'; head -c 4 >/dev/null; echo never"#,
+            "^[P$qm",
+        ),
+        (
+            "OSC 4",
+            r#"printf '\033]4;1;?\007'; head -c 4 >/dev/null; echo never"#,
+            "^[]4;1;?",
+        ),
+    ] {
+        let mut t = Terminal::builder()
+            .timeout(Duration::from_millis(400))
+            .args(["-c", script])
+            .spawn("/bin/sh")
+            .unwrap();
+        let err = t.wait_until(|s| s.contains("never")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(shape), "{label} not named in: {msg}");
+    }
+}
+
 #[test]
 fn replies_are_not_echoed_into_the_screen() -> termlens::Result<()> {
     // The reply travels the input path; unless the app prints it, it must


### PR DESCRIPTION
Three families of question slipped past the recognizer entirely, so an application blocked on one got a **bare timeout** — the silent hang v0.2 claimed to have eliminated:

```
CSI ? 2026 $ p     DECRQM   — "do you support synchronized output?"
DCS $ q … ST       DECRQSS  — "what is the current setting of …?"
OSC 4;n;?  OSC 52;…;?        palette / clipboard reads
```

Root cause in `emu/seq.rs`: the CSI scanner marked the `$` intermediate invalid, so DECRQM never reached classification; the DCS branch knew only `+q`; OSC classification knew only 10/11/12.

### DECRQM is answered, not merely named

That's the valuable half. An application that **probes before using** synchronized output can now turn it on against termlens — so `wait_frame` works against a program nobody modified for us, which is the study's §2.2 limitation. Proven end to end: `an_app_that_probes_for_synchronized_output_gets_it` runs a script that emits `2026h`/`2026l` *only* after a successful probe, and `wait_frame` catches the frame.

### Answers are truthful or absent

Modes whose state we hold exactly (2026, DECCKM, 25, alt screen, 2004, 1006, 1005) report set/reset. The mouse tracking modes report set **only on an exact match**: vt100 collapses 9/1000/1002/1003 into one mutually exclusive value, and crossterm's `EnableMouseCapture` sends 1000, 1002 and 1003 together — telling such an app that 1000 is *reset* would be a guess dressed as an answer. Everything else reports `0`, not recognized. `mode_reports_are_truthful` pins all three outcomes in one script.

### Scope note

The issue framed step 2 as retiring the study's §2.2 limitation outright. It doesn't, and the body now shouldn't claim it: crossterm emits `?2026h` unconditionally with no capability check ([crossterm#934](https://github.com/crossterm-rs/crossterm/issues/934)) and ratatui has no synchronized-output support at all, so the benefiting class is real but presently small. The self-inflicted hang it removes is the certain win.

Closes #56