### PR TITLE
feat(mouse): buttons, drag, modifiers and horizontal wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Changed
+
+- `Scroll` gained `Left` and `Right` variants and is now
+  `#[non_exhaustive]`. Exhaustive `match` on it needs a wildcard arm;
+  marking it non-exhaustive means later additions won't break code
+  again.
+
 ### Added
+
+- A fuller mouse API: `click_with(button, col, row)` for middle and
+  right buttons, `drag(button, from, to)`, modifier chords
+  (`MouseButton::Left.ctrl()`, mirroring `Key::Right.ctrl()`), and
+  horizontal wheel via `Scroll::Left` / `Scroll::Right`. Everything
+  stays mode-aware: encoded for the tracking mode and encoding the
+  application enabled, and refused with a typed error when the mode
+  cannot express the gesture — a drag under X10, which reports no
+  release, is an error rather than a misleading half-gesture.
 
 - Every wait now takes a per-call deadline: `wait_frame_for`,
   `wait_idle_for` and `wait_exit_for` join `wait_until_for`. One

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -74,7 +74,7 @@ pub use keys::{Chord, Input, Key};
 pub use screen::{Cell, Color, MouseMode, Screen, Style};
 #[cfg(unix)]
 pub use terminal::Signal;
-pub use terminal::{ExitStatus, Scroll, Terminal, TerminalBuilder};
+pub use terminal::{ExitStatus, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder};
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by
 /// default), so [`assert_screen_snapshot!`] always agrees with the `insta`

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -107,12 +107,125 @@ fn dup_writer(_master: &dyn portable_pty::MasterPty) -> Option<std::fs::File> {
 }
 
 /// Scroll-wheel direction for [`Terminal::scroll`].
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scroll {
     /// Wheel up (away from the user).
     Up,
     /// Wheel down (toward the user).
     Down,
+    /// Horizontal wheel left (or a trackpad swipe).
+    Left,
+    /// Horizontal wheel right.
+    Right,
+}
+
+/// A mouse button, for [`Terminal::click_with`] and [`Terminal::drag`].
+///
+/// Add modifiers the same way [`Key`](crate::Key) does:
+/// `MouseButton::Left.ctrl()`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    /// The primary button — what [`Terminal::click`] sends.
+    Left,
+    /// The middle button (wheel click).
+    Middle,
+    /// The secondary button, conventionally a context menu.
+    Right,
+}
+
+impl MouseButton {
+    fn code(self) -> u8 {
+        match self {
+            MouseButton::Left => 0,
+            MouseButton::Middle => 1,
+            MouseButton::Right => 2,
+        }
+    }
+
+    /// This button held with `Ctrl` — the usual multi-select idiom.
+    #[must_use]
+    pub fn ctrl(self) -> MouseChord {
+        MouseChord::from(self).ctrl()
+    }
+
+    /// This button held with `Alt`.
+    #[must_use]
+    pub fn alt(self) -> MouseChord {
+        MouseChord::from(self).alt()
+    }
+
+    /// This button held with `Shift`.
+    #[must_use]
+    pub fn shift(self) -> MouseChord {
+        MouseChord::from(self).shift()
+    }
+}
+
+/// A mouse button plus modifier keys — `MouseButton::Left.ctrl()`.
+///
+/// Mirrors the [`Chord`](crate::Chord) builder for keys; anything taking
+/// `impl Into<MouseChord>` accepts a bare [`MouseButton`] too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MouseChord {
+    button: MouseButton,
+    ctrl: bool,
+    alt: bool,
+    shift: bool,
+}
+
+impl From<MouseButton> for MouseChord {
+    fn from(button: MouseButton) -> Self {
+        Self {
+            button,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        }
+    }
+}
+
+impl MouseChord {
+    /// Add `Ctrl`.
+    #[must_use]
+    pub fn ctrl(mut self) -> Self {
+        self.ctrl = true;
+        self
+    }
+
+    /// Add `Alt`.
+    #[must_use]
+    pub fn alt(mut self) -> Self {
+        self.alt = true;
+        self
+    }
+
+    /// Add `Shift`.
+    #[must_use]
+    pub fn shift(mut self) -> Self {
+        self.shift = true;
+        self
+    }
+
+    /// The xterm button code: the button, plus 4 for shift, 8 for alt
+    /// and 16 for control.
+    fn code(self) -> u8 {
+        self.button.code()
+            + 4 * u8::from(self.shift)
+            + 8 * u8::from(self.alt)
+            + 16 * u8::from(self.ctrl)
+    }
+}
+
+/// The error every mouse action shares: bytes the application never
+/// asked for would be misparsed as keys.
+fn no_mouse_tracking() -> Error {
+    Error::Input(
+        "the application has not enabled mouse tracking \
+         (no CSI ?9/?1000/?1002/?1003 h was seen)"
+            .into(),
+    )
 }
 
 /// A POSIX signal for [`Terminal::signal`]: the graceful-shutdown set.
@@ -998,23 +1111,91 @@ impl Terminal {
     /// garbage keys), or when the position is unrepresentable in the
     /// legacy encoding (columns/rows beyond 222).
     pub fn click(&mut self, col: u16, row: u16) -> Result<()> {
+        self.click_with(MouseButton::Left, col, row)
+    }
+
+    /// Click a specific button, optionally with modifiers, at
+    /// `(col, row)`.
+    ///
+    /// Takes a [`MouseButton`] or a [`MouseChord`], the same way
+    /// [`send`](Self::send) takes a [`Key`](crate::Key) or a
+    /// [`Chord`](crate::Chord):
+    ///
+    /// ```no_run
+    /// # use termlens::MouseButton;
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.click_with(MouseButton::Right, 10, 4)?;          // context menu
+    /// t.click_with(MouseButton::Left.ctrl(), 10, 4)?;    // multi-select
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`click`](Self::click).
+    pub fn click_with(&mut self, button: impl Into<MouseChord>, col: u16, row: u16) -> Result<()> {
+        let chord = button.into();
         let modes = self.input_modes();
         let press_only = match modes.mouse {
-            MouseMode::None => {
-                return Err(Error::Input(
-                    "the application has not enabled mouse tracking \
-                     (no CSI ?9/?1000/?1002/?1003 h was seen)"
-                        .into(),
-                ))
-            }
+            MouseMode::None => return Err(no_mouse_tracking()),
             MouseMode::Press => true,
             MouseMode::PressRelease | MouseMode::ButtonMotion | MouseMode::AnyMotion => false,
         };
-        let mut bytes = self.mouse_report(&modes, 0, col, row, true)?;
+        let mut bytes = self.mouse_report(&modes, chord.code(), col, row, true)?;
         if !press_only {
-            bytes.extend(self.mouse_report(&modes, 0, col, row, false)?);
+            bytes.extend(self.mouse_report(&modes, chord.code(), col, row, false)?);
         }
         self.write_or_panic(&bytes, "a mouse click");
+        Ok(())
+    }
+
+    /// Drag from one cell to another: press, motion, release.
+    ///
+    /// What actually reaches the application depends on what it asked
+    /// for, as always. Under button-event or any-event tracking
+    /// (`?1002`/`?1003`) the motion report is included; under plain
+    /// `?1000` the application asked not to hear about motion, so it
+    /// receives the press and release alone — the endpoints, which is
+    /// what selection handling usually needs. Under X10 (`?9`) there is
+    /// no release at all, so a drag cannot be expressed and this is a
+    /// typed error rather than a misleading half-gesture.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Input`] when no mouse tracking is enabled, when the
+    /// tracking mode is X10, or when a position is unrepresentable in
+    /// the encoding the application selected.
+    pub fn drag(
+        &mut self,
+        button: impl Into<MouseChord>,
+        from: (u16, u16),
+        to: (u16, u16),
+    ) -> Result<()> {
+        let chord = button.into();
+        let modes = self.input_modes();
+        let report_motion = match modes.mouse {
+            MouseMode::None => return Err(no_mouse_tracking()),
+            MouseMode::Press => {
+                return Err(Error::Input(
+                    "the application enabled X10 mouse tracking (CSI ?9 h), which \
+                     reports presses only — a drag has no release to report"
+                        .into(),
+                ))
+            }
+            MouseMode::PressRelease => false,
+            MouseMode::ButtonMotion | MouseMode::AnyMotion => true,
+        };
+        let (from_col, from_row) = from;
+        let (to_col, to_row) = to;
+
+        let mut bytes = self.mouse_report(&modes, chord.code(), from_col, from_row, true)?;
+        if report_motion {
+            // A motion report is the button code plus 32.
+            bytes.extend(self.mouse_report(&modes, chord.code() + 32, to_col, to_row, true)?);
+        }
+        bytes.extend(self.mouse_report(&modes, chord.code(), to_col, to_row, false)?);
+        self.write_or_panic(&bytes, "a mouse drag");
         Ok(())
     }
 
@@ -1026,15 +1207,13 @@ impl Terminal {
     pub fn scroll(&mut self, col: u16, row: u16, direction: Scroll) -> Result<()> {
         let modes = self.input_modes();
         if modes.mouse == MouseMode::None {
-            return Err(Error::Input(
-                "the application has not enabled mouse tracking \
-                 (no CSI ?9/?1000/?1002/?1003 h was seen)"
-                    .into(),
-            ));
+            return Err(no_mouse_tracking());
         }
         let button = match direction {
             Scroll::Up => 64,
             Scroll::Down => 65,
+            Scroll::Left => 66,
+            Scroll::Right => 67,
         };
         // Wheel events are presses only; there is no release.
         let bytes = self.mouse_report(&modes, button, col, row, true)?;

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -183,6 +183,71 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
     Ok(())
 }
 
+/// Everything the mouse API can express, captured off the wire under
+/// SGR encoding with full (any-event) tracking.
+#[test]
+fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        // Wide enough that the captured wire stays on one row.
+        .size(200, 24)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo; printf '\033[?1003h\033[?1006h'; printf READY; ",
+                // 78 bytes: 20 (right press+release) + 20 (ctrl+left)
+                // + 10 (wheel left) + 28 (drag press+motion+release).
+                r#"wire=$(head -c 78 | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+
+    // Right-click: SGR button 2. Ctrl-click: 0 + 16. Wheel left: 66.
+    t.click_with(termlens::MouseButton::Right, 10, 4)?;
+    t.click_with(termlens::MouseButton::Left.ctrl(), 3, 1)?;
+    t.scroll(5, 5, termlens::Scroll::Left)?;
+    // Drag left button from (2,2) to (6,3): press, motion (0+32), release.
+    t.drag(termlens::MouseButton::Left, (2, 2), (6, 3))?;
+
+    t.wait_until(|s| s.row_text(0).contains("|"))?;
+    let text = t.screen().row_text(0);
+    for expected in [
+        "[<2;11;5M",
+        "[<2;11;5m", // right press + release
+        "[<16;4;2M",
+        "[<16;4;2m", // ctrl + left
+        "[<66;6;6M", // horizontal wheel
+        "[<0;3;3M",
+        "[<32;7;4M",
+        "[<0;7;4m", // drag: press, motion, release
+    ] {
+        assert!(text.contains(expected), "missing {expected} in:\n{text}");
+    }
+    Ok(())
+}
+
+/// A drag is refused under X10, where there is no release to report —
+/// the same standard `click` applies to "no tracking at all".
+#[test]
+fn drag_is_refused_when_the_mode_cannot_express_it() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", r"printf '\033[?9h'; printf READY; read guard"])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+
+    let err = t
+        .drag(termlens::MouseButton::Left, (1, 1), (4, 4))
+        .expect_err("X10 reports presses only");
+    assert!(matches!(err, Error::Input(_)), "got: {err}");
+    assert!(err.to_string().contains("X10"), "unhelpful: {err}");
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 #[test]
 fn arrows_follow_the_apps_cursor_key_mode() -> termlens::Result<()> {
     // The script enables DECCKM (CSI ?1 h), reads 3 bytes, reports them,


### PR DESCRIPTION
`click` sent button 0 and `Scroll` had only `Up`/`Down`, so right-click, middle-click, drag, modifier+click and horizontal wheel still needed hand-encoded SGR bytes — exactly what *all* mouse input needed before v0.2. Ranked #2 by the coverage study (§2.4), which puts it fairly: "Given how well `click` reads the app's mode, the asymmetry stands out."

### Shape

Mirrors the key API rather than inventing a second vocabulary:

```rust
t.click_with(MouseButton::Right, 10, 4)?;        // context menu
t.click_with(MouseButton::Left.ctrl(), 3, 1)?;   // multi-select
t.drag(MouseButton::Left, (2, 2), (6, 3))?;      // press, motion, release
t.scroll(5, 5, Scroll::Left)?;                   // horizontal wheel
```

`MouseButton::Left.ctrl()` builds a `MouseChord` the way `Key::Right.ctrl()` builds a `Chord`, and `click_with`/`drag` take `impl Into<MouseChord>` so a bare button works too. `click` and `scroll` are unchanged.

### Mode-awareness extends to the new gestures

A drag needs a release to mean anything, so under X10 (`?9`, presses only) it is a **typed error** rather than a misleading half-gesture. Under `?1000`, which reports no motion, the endpoints are sent and the motion report is omitted — that is what the application asked to hear. Under `?1002`/`?1003` the full press-motion-release goes out.

### Breaking, and deliberately the last of its kind

`Scroll` gains `Left`/`Right` and becomes `#[non_exhaustive]`: exhaustive matches need a wildcard arm. Listed under `### Changed`; the non-exhaustive marking means further variants are additive from here.

Wire-level test captures all four gestures under SGR + any-event tracking and asserts every byte (`[<2;11;5M`, `[<16;4;2M`, `[<66;6;6M`, and the drag's `[<0;3;3M` / `[<32;7;4M` / `[<0;7;4m`), plus the X10 refusal. Full suite green: 17 suites.

Closes #54