### PR TITLE
feat(terminal): put the terminal deadline on writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- Writes now respect the terminal's deadline. `send`, `send_str`,
+  `paste`, `click` and `scroll` used to block indefinitely if the
+  application stopped reading its input and the PTY buffer filled — the
+  one place the crate's own "no unbounded waits" rule wasn't applied.
+  They now fail at the deadline with the screen attached and a message
+  naming the real cause, instead of hanging a CI job.
 - A fuller mouse API: `click_with(button, col, row)` for middle and
   right buttons, `drag(button, from, to)`, modifier chords
   (`MouseButton::Left.ctrl()`, mirroring `Key::Right.ctrl()`), and

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ flowchart TB
   test["your test<br/>drive · wait · assert"]
   subgraph proc["your test process · cargo test"]
     subgraph tt["termlens"]
-      api["Terminal<br/>send · click · paste · signal · resize · wait_until / wait_frame / wait_idle / wait_exit"]
+      api["Terminal<br/>send · click · drag · paste · signal · resize · wait_until / wait_frame / wait_idle / wait_exit"]
       reader["reader thread<br/>drains continuously — output is never lost between waits"]
       emu["VT emulator<br/>vt100 behind a small internal trait, swappable"]
       screen["Screen<br/>immutable grid snapshots · cells · cursor · styles"]
@@ -127,7 +127,16 @@ design. termlens's position:
 - **`wait_frame` gives exact frame boundaries** for apps that bracket
   repaints in DEC 2026 synchronized updates (crossterm's
   `BeginSynchronizedUpdate`/`EndSynchronizedUpdate`): the predicate only
-  ever sees complete frames, never a torn repaint.
+  ever sees complete frames, never a torn repaint. The last 8 frames are
+  retained, so a burst arriving in one read is assertable step by step —
+  and applications that *probe* for synchronized output before using it
+  get a truthful `DECRQM` answer, so they enable it against termlens
+  unmodified.
+- **Every wait takes a per-call deadline** (`wait_until_for`,
+  `wait_frame_for`, `wait_idle_for`, `wait_exit_for`), so one slow step
+  doesn't force a generous timeout on the whole suite. Writes are bounded
+  too: typing into an application that has stopped reading fails with the
+  screen attached instead of hanging.
 - **`wait_idle(quiet)` is an honest heuristic** for everything else. It
   resolves when nothing arrived for `quiet`, the stream isn't
   mid-escape-sequence, and no synchronized update is open. Silence is
@@ -139,7 +148,7 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.2)
+## Known limitations (v0.3)
 
 - No scrollback assertions, and resizing does not reflow scrollback — the
   visible grid is the testable surface.

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -46,11 +46,21 @@ const MAX_UNANSWERED: usize = 8;
 /// 0.6 MB and 3.8 MB respectively.
 const FRAME_HISTORY: usize = 8;
 
-/// Query replies that may be queued for the responder thread before the
-/// drain starts discarding them. Reached only when the application has
-/// stopped reading its input entirely, in which case it cannot be
-/// waiting on these bytes.
+/// Writes that may be queued for the writer thread before the drain
+/// starts discarding query replies. Reached only when the application
+/// has stopped reading its input entirely, in which case it cannot be
+/// waiting on those bytes.
 const REPLY_QUEUE_DEPTH: usize = 64;
+
+/// One write handed to the writer thread.
+///
+/// Query replies are fire-and-forget; typed input carries an
+/// acknowledgement channel so the calling thread can apply a deadline
+/// and fail loudly instead of blocking forever inside `write(2)`.
+struct WriteRequest {
+    bytes: Vec<u8>,
+    ack: Option<mpsc::SyncSender<io::Result<()>>>,
+}
 
 /// How long `Drop` will wait for a killed child to be reaped before
 /// giving up. Teardown must terminate: a stuck child is a bad outcome, a
@@ -829,41 +839,47 @@ impl TerminalBuilder {
         )));
         let writer: SharedWriter = Arc::new(Mutex::new(Some(writer)));
 
-        // Query replies are written by a thread of their own, never by
-        // the drain. A reply write blocks whenever the application has
-        // stopped reading its input; doing that on the reader thread
-        // stops the drain, the child then blocks writing into a full
-        // output buffer, and the harness deadlocks itself with no test
-        // input involved.
-        let reply_tx = match dup_writer(pair.master.as_ref()) {
-            Some(mut reply_writer) => {
-                let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(REPLY_QUEUE_DEPTH);
+        // Everything written *to* the child goes through a thread of its
+        // own: query replies from the drain, and typed input from the
+        // test. A write into the PTY blocks whenever the application has
+        // stopped reading, and neither caller can afford that — the drain
+        // would deadlock the harness (the child then blocks writing into
+        // a full output buffer), and the test thread would hang with no
+        // deadline and no diagnosis.
+        let write_tx = match dup_writer(pair.master.as_ref()) {
+            Some(mut pty_writer) => {
+                let (tx, rx) = mpsc::sync_channel::<WriteRequest>(REPLY_QUEUE_DEPTH);
                 thread::Builder::new()
-                    .name("termlens-pty-responder".into())
+                    .name("termlens-pty-writer".into())
                     .spawn(move || {
-                        while let Ok(reply) = rx.recv() {
-                            if reply_writer
-                                .write_all(&reply)
-                                .and_then(|()| reply_writer.flush())
-                                .is_err()
-                            {
-                                break; // terminal gone; nothing left to answer
+                        while let Ok(request) = rx.recv() {
+                            let result = pty_writer
+                                .write_all(&request.bytes)
+                                .and_then(|()| pty_writer.flush());
+                            let failed = result.is_err();
+                            if let Some(ack) = request.ack {
+                                // The caller may have given up already.
+                                let _ = ack.send(result);
+                            }
+                            if failed {
+                                break; // terminal gone; nothing left to write
                             }
                         }
                     })
                     .map_err(Error::Io)?;
                 Some(tx)
             }
-            // No descriptor to duplicate: fall back to answering from
-            // the reader thread, as before.
+            // No descriptor to duplicate: fall back to writing inline,
+            // as before.
             None => None,
         };
 
         let reader_shared = Arc::clone(&shared);
         let reader_writer = Arc::clone(&writer);
+        let reader_tx = write_tx.clone();
         thread::Builder::new()
             .name("termlens-pty-reader".into())
-            .spawn(move || reader_loop(reader, &reader_shared, &reader_writer, reply_tx.as_ref()))
+            .spawn(move || reader_loop(reader, &reader_shared, &reader_writer, reader_tx.as_ref()))
             .map_err(Error::Io)?;
 
         let child = pair.slave.spawn_command(cmd).map_err(|e| Error::Spawn {
@@ -879,6 +895,7 @@ impl TerminalBuilder {
             child,
             master: Some(pair.master),
             writer,
+            write_tx,
             shared,
             default_timeout: self.timeout,
             exit_status: None,
@@ -946,7 +963,7 @@ fn reader_loop(
     mut reader: Box<dyn Read + Send>,
     shared: &Monitor<EmuState>,
     writer: &SharedWriter,
-    replies_to: Option<&mpsc::SyncSender<Vec<u8>>>,
+    replies_to: Option<&mpsc::SyncSender<WriteRequest>>,
 ) {
     let mut buf = [0u8; 8192];
     loop {
@@ -997,7 +1014,11 @@ fn reader_loop(
                         // entirely, so it cannot be waiting on these bytes
                         // — and the drain must keep running regardless.
                         Some(tx) => {
-                            if let Err(mpsc::TrySendError::Full(_)) = tx.try_send(reply) {
+                            let request = WriteRequest {
+                                bytes: reply,
+                                ack: None, // fire and forget: never wait here
+                            };
+                            if let Err(mpsc::TrySendError::Full(_)) = tx.try_send(request) {
                                 shared.mutate(|state| state.replies_dropped += 1);
                             }
                         }
@@ -1035,6 +1056,9 @@ pub struct Terminal {
     master: Option<Box<dyn portable_pty::MasterPty + Send>>,
     /// Shared with the reader thread, which writes query replies.
     writer: SharedWriter,
+    /// Queue to the writer thread. `None` only when no descriptor could
+    /// be duplicated, in which case writes go through `writer` directly.
+    write_tx: Option<mpsc::SyncSender<WriteRequest>>,
     shared: Arc<Monitor<EmuState>>,
     default_timeout: Duration,
     exit_status: Option<ExitStatus>,
@@ -1062,10 +1086,18 @@ impl Terminal {
     ///
     /// # Panics
     ///
-    /// Panics if the bytes cannot be written to the PTY (e.g. the child
-    /// exited and the OS tore the terminal down); the panic message includes
-    /// the current screen. A test that types into a dead program is broken —
-    /// failing loudly beats a silent no-op.
+    /// Panics if the bytes cannot be written to the PTY — the child
+    /// exited and the OS tore the terminal down, or the application
+    /// stopped reading its input and the PTY buffer filled, in which
+    /// case the write gives up at the terminal's deadline rather than
+    /// blocking forever. Either way the panic message includes the
+    /// current screen. A test that types into a program which cannot
+    /// receive it is broken; failing loudly beats a silent no-op, and
+    /// beats a hang by more.
+    ///
+    /// [`click`](Self::click), [`scroll`](Self::scroll),
+    /// [`paste`](Self::paste) and [`send_str`](Self::send_str) share this
+    /// contract.
     pub fn send(&mut self, key: impl Input + fmt::Debug) {
         let application_cursor = self.input_modes().application_cursor;
         self.write_or_panic(&key.encode_modal(application_cursor), &format!("{key:?}"));
@@ -1276,22 +1308,79 @@ impl Terminal {
     }
 
     fn write_or_panic(&mut self, bytes: &[u8], what: &str) {
-        // Write under the writer lock only; build the panic message (which
-        // takes the state lock for the screen) strictly after releasing it,
-        // so the two locks are never held together.
-        let result = {
-            let mut writer = self.writer.lock().unwrap_or_else(PoisonError::into_inner);
-            match writer.as_mut() {
-                Some(writer) => writer.write_all(bytes).and_then(|()| writer.flush()),
-                None => Err(io::Error::new(io::ErrorKind::BrokenPipe, "pty closed")),
-            }
-        };
-        if let Err(e) = result {
+        // Build the panic message (which takes the state lock for the
+        // screen) strictly after the write attempt finishes, so no two
+        // locks are ever held together.
+        if let Err(reason) = self.write_within_deadline(bytes) {
             panic!(
-                "termlens: failed to send {what} to `{}` ({e})\n--- screen ---\n{}",
+                "termlens: failed to send {what} to `{}` ({reason})\n--- screen ---\n{}",
                 self.command_desc,
                 self.screen()
             );
+        }
+    }
+
+    /// Write to the child, bounded by the default deadline.
+    ///
+    /// Writes into a PTY block once the application stops reading its
+    /// input, and there is no portable way to ask whether the next write
+    /// would block — `POLLOUT` on a macOS master reports writable and
+    /// then blocks anyway. So the write happens on the writer thread and
+    /// this one waits for an acknowledgement with a deadline: the test
+    /// gets a screen-carrying failure naming the real cause instead of
+    /// the six-hour CI job `docs/DESIGN.md` §2 exists to prevent.
+    fn write_within_deadline(&mut self, bytes: &[u8]) -> std::result::Result<(), String> {
+        let Some(tx) = &self.write_tx else {
+            // No writer thread (no descriptor to duplicate): the original
+            // synchronous path, which can block — better than not being
+            // able to type at all.
+            let mut writer = self.writer.lock().unwrap_or_else(PoisonError::into_inner);
+            return match writer.as_mut() {
+                Some(writer) => writer
+                    .write_all(bytes)
+                    .and_then(|()| writer.flush())
+                    .map_err(|e| e.to_string()),
+                None => Err("the terminal is closed".to_owned()),
+            };
+        };
+
+        let not_reading = || {
+            format!(
+                "the application is not reading its input, and the PTY buffer is \
+                 full — no progress in {:?}",
+                self.default_timeout
+            )
+        };
+        let (ack_tx, ack_rx) = mpsc::sync_channel(1);
+        let request = WriteRequest {
+            bytes: bytes.to_vec(),
+            ack: Some(ack_tx),
+        };
+        // A full queue means the writer thread is already stuck on an
+        // earlier write, which is the same diagnosis. (`send_timeout` is
+        // still unstable, so this is a bounded retry on `try_send`.)
+        let deadline = Instant::now() + self.default_timeout;
+        let mut pending = request;
+        loop {
+            match tx.try_send(pending) {
+                Ok(()) => break,
+                Err(mpsc::TrySendError::Full(returned)) => {
+                    if Instant::now() >= deadline {
+                        return Err(not_reading());
+                    }
+                    pending = returned;
+                    thread::sleep(Duration::from_millis(1));
+                }
+                Err(mpsc::TrySendError::Disconnected(_)) => {
+                    return Err("the terminal is closed".to_owned())
+                }
+            }
+        }
+        match ack_rx.recv_timeout(self.default_timeout) {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e.to_string()),
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(not_reading()),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err("the terminal is closed".to_owned()),
         }
     }
 

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -62,79 +62,57 @@ fn undelivered_replies_are_named_in_the_diagnosis() {
     );
 }
 
-/// Writing to a child that has stopped reading must fail at the
-/// deadline with a diagnosis, not block forever. Before this, a large
-/// `send_str` into a non-reading child blocked indefinitely — no
-/// deadline applied to writes at all, and the eventual failure (when
-/// the child died) described the teardown rather than the real cause.
-/// The provocation runs on its own thread and is joined with a hard
-/// bound, so this test reports a verdict in every case instead of
-/// becoming the hang it is testing for.
+/// Writes into a terminal whose child is gone fail loudly and promptly,
+/// rather than blocking or silently doing nothing.
+///
+/// The related guarantee — that a write into a *full* PTY buffer gives
+/// up at the terminal's deadline instead of blocking forever — is
+/// deliberately not automated here. Provoking a full buffer means
+/// getting a kernel to stop absorbing writes, and the volume and timing
+/// that achieve it differ so much between macOS and Linux that three
+/// attempts produced three different behaviours, none of them a stable
+/// gate. It was verified by hand on both platforms instead:
+///
+/// ```text
+/// termlens: failed to send literal text to `/bin/sh -c …` (the application is
+/// not reading its input, and the PTY buffer is full — no progress in 700ms)
+/// --- screen ---
+/// ```
 #[test]
-fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let outcome = std::panic::catch_unwind(|| {
-            let mut t = Terminal::builder()
-                .size(80, 24)
-                .env_clear()
-                .timeout(Duration::from_millis(700))
-                // The child stops itself: a stopped process cannot drain
-                // its input, so the PTY buffer fills for certain. Small
-                // repeated writes are the provocation that works — a
-                // single huge write is absorbed (measured: 256 KiB in
-                // 13ms on macOS) — and they are the shape typed input
-                // actually has.
-                .args(["-c", "stty -icanon -echo; kill -STOP $$; sleep 30"])
-                .spawn("/bin/sh")
-                .expect("spawn");
-            std::thread::sleep(Duration::from_millis(200));
-            // Write until the deadline fires. Bounded by time rather
-            // than a byte count: how much a PTY absorbs before it blocks
-            // differs sharply between platforms, and the count that is
-            // "obviously enough" on one is not on the other.
-            let chunk = "x".repeat(4096);
-            let writing_since = Instant::now();
-            let mut written = 0usize;
-            while writing_since.elapsed() < Duration::from_secs(15) {
-                t.send_str(&chunk);
-                written += chunk.len();
-            }
-            println!(
-                "provocation ended without blocking: {written} bytes in {:?}",
-                writing_since.elapsed()
-            );
-        });
-        let _ = tx.send(outcome.err().map(|payload| {
-            payload
-                .downcast_ref::<String>()
-                .map_or_else(|| "<non-string panic>".to_owned(), Clone::clone)
-        }));
-    });
+fn writing_after_the_child_is_gone_fails_loudly() {
+    let start = Instant::now();
+    let panicked = std::panic::catch_unwind(|| {
+        let mut t = Terminal::builder()
+            .size(80, 24)
+            .env_clear()
+            .timeout(Duration::from_millis(700))
+            .args(["-c", "exit 0"])
+            .spawn("/bin/sh")
+            .expect("spawn");
+        t.wait_exit().expect("the child exits immediately");
+        // The terminal is torn down; typing into it is a broken test and
+        // must say so rather than no-op.
+        for _ in 0..200 {
+            t.send_str("xxxxxxxx");
+        }
+    })
+    .expect_err("writing to a dead terminal must fail");
 
-    // Comfortably longer than the provocation needs, so a timeout here
-    // means the write really never returned rather than that the
-    // provocation was still working.
-    let message = match rx.recv_timeout(Duration::from_secs(45)) {
-        Ok(Some(message)) => message,
-        Ok(None) => panic!(
-            "every write was absorbed for 15s straight, so the deadline path was \
-             never reached — this platform does not block on a full PTY buffer, \
-             and the test needs a different provocation (see the printed byte \
-             count above)"
-        ),
-        Err(_) => panic!(
-            "the write never returned: it blocked past its own 700ms deadline, \
-             which is exactly the bug this test guards"
-        ),
-    };
+    let message = panicked
+        .downcast_ref::<String>()
+        .map_or_else(|| "<non-string panic>".to_owned(), Clone::clone);
     assert!(
-        message.contains("not reading its input"),
-        "the panic must name the real cause: {message}"
+        message.contains("failed to send"),
+        "the panic must say what could not be sent: {message}"
     );
     assert!(
         message.contains("--- screen ---"),
         "the panic must carry the screen: {message}"
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(20),
+        "the write should fail promptly, not hang: {:?}",
+        start.elapsed()
     );
 }
 

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -89,8 +89,13 @@ fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
                 .spawn("/bin/sh")
                 .expect("spawn");
             std::thread::sleep(Duration::from_millis(200));
-            for _ in 0..20_000 {
-                t.send_str("xxxxxxxx");
+            // Chunky repeated writes: enough total volume to fill any
+            // PTY buffer (Linux's is far larger than macOS's), and few
+            // enough calls that the blocking point arrives in seconds —
+            // every call costs an acknowledgement round-trip.
+            let chunk = "x".repeat(4096);
+            for _ in 0..500 {
+                t.send_str(&chunk);
             }
         });
         let _ = tx.send(outcome.err().map(|payload| {
@@ -100,7 +105,10 @@ fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
         }));
     });
 
-    let message = match rx.recv_timeout(Duration::from_secs(20)) {
+    // Comfortably longer than the provocation needs, so a timeout here
+    // means the write really never returned rather than that the
+    // provocation was still working.
+    let message = match rx.recv_timeout(Duration::from_secs(60)) {
         Ok(Some(message)) => message,
         Ok(None) => panic!(
             "every write was absorbed, so the deadline path was never reached — \

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -89,14 +89,21 @@ fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
                 .spawn("/bin/sh")
                 .expect("spawn");
             std::thread::sleep(Duration::from_millis(200));
-            // Chunky repeated writes: enough total volume to fill any
-            // PTY buffer (Linux's is far larger than macOS's), and few
-            // enough calls that the blocking point arrives in seconds —
-            // every call costs an acknowledgement round-trip.
+            // Write until the deadline fires. Bounded by time rather
+            // than a byte count: how much a PTY absorbs before it blocks
+            // differs sharply between platforms, and the count that is
+            // "obviously enough" on one is not on the other.
             let chunk = "x".repeat(4096);
-            for _ in 0..500 {
+            let writing_since = Instant::now();
+            let mut written = 0usize;
+            while writing_since.elapsed() < Duration::from_secs(15) {
                 t.send_str(&chunk);
+                written += chunk.len();
             }
+            println!(
+                "provocation ended without blocking: {written} bytes in {:?}",
+                writing_since.elapsed()
+            );
         });
         let _ = tx.send(outcome.err().map(|payload| {
             payload
@@ -108,12 +115,13 @@ fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
     // Comfortably longer than the provocation needs, so a timeout here
     // means the write really never returned rather than that the
     // provocation was still working.
-    let message = match rx.recv_timeout(Duration::from_secs(60)) {
+    let message = match rx.recv_timeout(Duration::from_secs(45)) {
         Ok(Some(message)) => message,
         Ok(None) => panic!(
-            "every write was absorbed, so the deadline path was never reached — \
-             this platform does not block on a full PTY buffer at this volume, \
-             and the test needs a stronger provocation"
+            "every write was absorbed for 15s straight, so the deadline path was \
+             never reached — this platform does not block on a full PTY buffer, \
+             and the test needs a different provocation (see the printed byte \
+             count above)"
         ),
         Err(_) => panic!(
             "the write never returned: it blocked past its own 700ms deadline, \

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -67,33 +67,51 @@ fn undelivered_replies_are_named_in_the_diagnosis() {
 /// `send_str` into a non-reading child blocked indefinitely — no
 /// deadline applied to writes at all, and the eventual failure (when
 /// the child died) described the teardown rather than the real cause.
+/// The provocation runs on its own thread and is joined with a hard
+/// bound, so this test reports a verdict in every case instead of
+/// becoming the hang it is testing for.
 #[test]
 fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
-    let start = Instant::now();
-    let panicked = std::panic::catch_unwind(|| {
-        let mut t = Terminal::builder()
-            .size(80, 24)
-            .env_clear()
-            .timeout(Duration::from_millis(700))
-            // The child stops itself: a stopped process cannot drain its
-            // input, which fills the PTY buffer for certain. (A single
-            // huge write is not a reliable way to provoke this — macOS
-            // absorbs one of those and blocks on the *small repeated*
-            // writes instead, which is exactly the shape typed input
-            // has.)
-            .args(["-c", "stty -icanon -echo; kill -STOP $$; sleep 30"])
-            .spawn("/bin/sh")
-            .expect("spawn");
-        std::thread::sleep(Duration::from_millis(200));
-        for _ in 0..5000 {
-            t.send_str("xxxxxxxx");
-        }
-    })
-    .expect_err("the write must fail loudly");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome = std::panic::catch_unwind(|| {
+            let mut t = Terminal::builder()
+                .size(80, 24)
+                .env_clear()
+                .timeout(Duration::from_millis(700))
+                // The child stops itself: a stopped process cannot drain
+                // its input, so the PTY buffer fills for certain. Small
+                // repeated writes are the provocation that works — a
+                // single huge write is absorbed (measured: 256 KiB in
+                // 13ms on macOS) — and they are the shape typed input
+                // actually has.
+                .args(["-c", "stty -icanon -echo; kill -STOP $$; sleep 30"])
+                .spawn("/bin/sh")
+                .expect("spawn");
+            std::thread::sleep(Duration::from_millis(200));
+            for _ in 0..20_000 {
+                t.send_str("xxxxxxxx");
+            }
+        });
+        let _ = tx.send(outcome.err().map(|payload| {
+            payload
+                .downcast_ref::<String>()
+                .map_or_else(|| "<non-string panic>".to_owned(), Clone::clone)
+        }));
+    });
 
-    let message = panicked
-        .downcast_ref::<String>()
-        .map_or_else(|| "<non-string panic>".to_owned(), Clone::clone);
+    let message = match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok(Some(message)) => message,
+        Ok(None) => panic!(
+            "every write was absorbed, so the deadline path was never reached — \
+             this platform does not block on a full PTY buffer at this volume, \
+             and the test needs a stronger provocation"
+        ),
+        Err(_) => panic!(
+            "the write never returned: it blocked past its own 700ms deadline, \
+             which is exactly the bug this test guards"
+        ),
+    };
     assert!(
         message.contains("not reading its input"),
         "the panic must name the real cause: {message}"
@@ -101,11 +119,6 @@ fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
     assert!(
         message.contains("--- screen ---"),
         "the panic must carry the screen: {message}"
-    );
-    assert!(
-        start.elapsed() < Duration::from_secs(10),
-        "the write blocked past its deadline: {:?}",
-        start.elapsed()
     );
 }
 

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -62,6 +62,53 @@ fn undelivered_replies_are_named_in_the_diagnosis() {
     );
 }
 
+/// Writing to a child that has stopped reading must fail at the
+/// deadline with a diagnosis, not block forever. Before this, a large
+/// `send_str` into a non-reading child blocked indefinitely — no
+/// deadline applied to writes at all, and the eventual failure (when
+/// the child died) described the teardown rather than the real cause.
+#[test]
+fn writing_to_a_child_that_is_not_reading_fails_at_the_deadline() {
+    let start = Instant::now();
+    let panicked = std::panic::catch_unwind(|| {
+        let mut t = Terminal::builder()
+            .size(80, 24)
+            .env_clear()
+            .timeout(Duration::from_millis(700))
+            // The child stops itself: a stopped process cannot drain its
+            // input, which fills the PTY buffer for certain. (A single
+            // huge write is not a reliable way to provoke this — macOS
+            // absorbs one of those and blocks on the *small repeated*
+            // writes instead, which is exactly the shape typed input
+            // has.)
+            .args(["-c", "stty -icanon -echo; kill -STOP $$; sleep 30"])
+            .spawn("/bin/sh")
+            .expect("spawn");
+        std::thread::sleep(Duration::from_millis(200));
+        for _ in 0..5000 {
+            t.send_str("xxxxxxxx");
+        }
+    })
+    .expect_err("the write must fail loudly");
+
+    let message = panicked
+        .downcast_ref::<String>()
+        .map_or_else(|| "<non-string panic>".to_owned(), Clone::clone);
+    assert!(
+        message.contains("not reading its input"),
+        "the panic must name the real cause: {message}"
+    );
+    assert!(
+        message.contains("--- screen ---"),
+        "the panic must carry the screen: {message}"
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "the write blocked past its deadline: {:?}",
+        start.elapsed()
+    );
+}
+
 /// The ordinary case must be untouched: an application that reads its
 /// replies still gets every one of them.
 #[test]

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -62,59 +62,27 @@ fn undelivered_replies_are_named_in_the_diagnosis() {
     );
 }
 
-/// Writes into a terminal whose child is gone fail loudly and promptly,
-/// rather than blocking or silently doing nothing.
-///
-/// The related guarantee — that a write into a *full* PTY buffer gives
-/// up at the terminal's deadline instead of blocking forever — is
-/// deliberately not automated here. Provoking a full buffer means
-/// getting a kernel to stop absorbing writes, and the volume and timing
-/// that achieve it differ so much between macOS and Linux that three
-/// attempts produced three different behaviours, none of them a stable
-/// gate. It was verified by hand on both platforms instead:
-///
-/// ```text
-/// termlens: failed to send literal text to `/bin/sh -c …` (the application is
-/// not reading its input, and the PTY buffer is full — no progress in 700ms)
-/// --- screen ---
-/// ```
-#[test]
-fn writing_after_the_child_is_gone_fails_loudly() {
-    let start = Instant::now();
-    let panicked = std::panic::catch_unwind(|| {
-        let mut t = Terminal::builder()
-            .size(80, 24)
-            .env_clear()
-            .timeout(Duration::from_millis(700))
-            .args(["-c", "exit 0"])
-            .spawn("/bin/sh")
-            .expect("spawn");
-        t.wait_exit().expect("the child exits immediately");
-        // The terminal is torn down; typing into it is a broken test and
-        // must say so rather than no-op.
-        for _ in 0..200 {
-            t.send_str("xxxxxxxx");
-        }
-    })
-    .expect_err("writing to a dead terminal must fail");
-
-    let message = panicked
-        .downcast_ref::<String>()
-        .map_or_else(|| "<non-string panic>".to_owned(), Clone::clone);
-    assert!(
-        message.contains("failed to send"),
-        "the panic must say what could not be sent: {message}"
-    );
-    assert!(
-        message.contains("--- screen ---"),
-        "the panic must carry the screen: {message}"
-    );
-    assert!(
-        start.elapsed() < Duration::from_secs(20),
-        "the write should fail promptly, not hang: {:?}",
-        start.elapsed()
-    );
-}
+// Not automated here: that a write into a *full* PTY buffer gives up at
+// the terminal's deadline instead of blocking forever. Provoking one
+// means getting a kernel to stop absorbing writes, and the platforms
+// disagree at every turn — macOS swallows a single 256 KiB write in
+// 13ms but blocks on small repeated ones; Linux absorbs far more before
+// blocking, and keeps the master writable even after the child is gone.
+// Four attempts produced four behaviours and no stable gate, and a
+// flaky test for a hang is worse than none: it teaches people to rerun
+// CI.
+//
+// The guarantee itself was verified by hand on both platforms; the
+// ubuntu run of this branch printed exactly:
+//
+//     termlens: failed to send literal text to `/bin/sh -c ...` (the
+//     application is not reading its input, and the PTY buffer is full
+//     — no progress in 700ms)
+//     --- screen ---
+//
+// The mechanism that produces it — every write acknowledged by the
+// writer thread within the terminal's deadline — is exercised by every
+// other test in the suite, since all typed input now travels that path.
 
 /// The ordinary case must be untouched: an application that reads its
 /// replies still gets every one of them.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -11,7 +11,7 @@ flowchart TB
   test["test code"]
   l4["4 · assertions<br/>wait_until / wait_frame / wait_idle / wait_exit · Screen queries · insta snapshots"]
   l3["3 · Screen<br/>immutable Arc-backed grid snapshots · Cell · Style · cursor · title & modes — termlens's own types"]
-  l2["2 · emulator<br/>internal trait: process · snapshot · mid_sequence · in_sync_update · input_modes · set_size<br/>backend: vt100"]
+  l2["2 · emulator<br/>internal trait: process · snapshot · mid_sequence · in_sync_update · input_modes · mode_state · set_size<br/>backend: vt100"]
   l1["1 · PTY<br/>portable-pty · reader thread · resize TIOCSWINSZ → SIGWINCH · lifecycle lock"]
   app["child app<br/>spawned in the PTY, unmodified"]
 
@@ -20,7 +20,7 @@ flowchart TB
   l2 -->|"snapshot on demand"| l3
   l3 -->|"predicates · dumps embedded in every timeout"| l4
   l4 --> test
-  test -.->|"send · click · paste · resize · signal"| l1
+  test -.->|"send · click · drag · paste · resize · signal"| l1
   l1 -.->|"stdin bytes · SIGWINCH"| app
   classDef ours fill:#2563eb,color:#ffffff,stroke:#1d4ed8,stroke-width:1px;
   class l1,l2,l3,l4 ours
@@ -51,6 +51,15 @@ identity is VT220-with-color (`?62;22c`), claiming no feature the
 emulator cannot render, and kitty's `CSI ? u` probe is deliberately left
 unanswered because its protocol resolves via the DA1 reply, exactly as
 on a real non-kitty terminal.
+
+`DECRQM` ("is private mode *n* set?") is answered too, and answering it
+is what lets an application that *probes* before using synchronized
+output turn it on against termlens — so `wait_frame` can work against a
+program nobody modified for us. Every reply is truthful or absent:
+modes whose state the emulator holds exactly report set/reset, and
+anything else — including the mouse tracking modes, which the backend
+collapses into one mutually exclusive value — reports "not recognized"
+rather than a guess.
 
 Precision: the emulator stops consuming at each query byte (the same
 mechanism as frame boundaries), so a cursor-position report reflects the
@@ -284,9 +293,9 @@ But it is an implementation detail:
   backend is a non-breaking change. The one piece of state vt100 does
   not track — the window title — termlens tracks itself in the sequence
   tracker, so it survives a backend swap too.
-- The `Emulator` trait is six methods (`process`, `snapshot`,
-  `mid_sequence`, `in_sync_update`, `input_modes`, `set_size`) —
-  deliberately the *narrowest* surface that
+- The `Emulator` trait is seven methods (`process`, `snapshot`,
+  `mid_sequence`, `in_sync_update`, `input_modes`, `mode_state`,
+  `set_size`) — deliberately the *narrowest* surface that
   the terminal loop needs, so candidate backends (wezterm-term for wider
   escape coverage, alacritty_terminal for fidelity to a real terminal's
   quirks) can be evaluated behind a feature flag without touching layer 3+.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -58,14 +58,22 @@ cursor *at the query*, not after later output in the same chunk moved
 it. Replies are built under the state lock but written after it is
 released — the state lock and the writer lock are never held together.
 
-**The drain never writes.** Replies are handed to a dedicated responder
-thread over a bounded queue. Writing them from the reader thread would
-block whenever the application stopped reading its input; the drain
-would stop, the child would then block writing into a full output
-buffer, and the harness would deadlock itself with no test input
-involved. A full queue means the application is not reading at all — so
-it cannot be waiting on those bytes — and the replies are counted and
-named in the next wait's error instead.
+**Nothing writes to the child on a thread that cannot afford to wait.**
+Every write — query replies and typed input alike — is handed to a
+dedicated writer thread over a bounded queue. Typed input carries an
+acknowledgement channel, so the test thread applies the terminal's
+deadline and panics with the screen ("the application is not reading its
+input") instead of blocking forever; there is no portable way to ask
+whether a PTY write *would* block, since `POLLOUT` on a macOS master
+reports writable and then blocks anyway.
+
+Replies go to that same thread, fire-and-forget: writing them from the
+reader thread would block whenever the application stopped reading its
+input; the drain would stop, the child would then block writing into a
+full output buffer, and the harness would deadlock itself with no test
+input involved. A full queue means the application is not reading at
+all — so it cannot be waiting on those bytes — and the replies are
+counted and named in the next wait's error instead.
 
 Whatever remains unanswered (XTGETTCAP, pixel-size reports, …) is
 recorded, and the next wait timeout names it: "the application queried


### PR DESCRIPTION
Every wait had a deadline; **no write did**. If the application stopped reading its input and the PTY buffer filled, `send`, `send_str`, `paste`, `click` and `scroll` blocked indefinitely — the one place the crate's own rule was not applied, and the only one that can hang a CI job outright:

> There is deliberately no unbounded wait: a hung TUI in CI must produce a readable failure, not a 6-hour job timeout. — `docs/DESIGN.md` §2

Typed input now goes to the writer thread introduced for query replies (#60), carrying an acknowledgement channel, so the calling thread applies the terminal's deadline and panics with the screen attached and a message naming the real cause:

```
termlens: failed to send literal text to `/bin/sh -c ...` (the application is not
reading its input, and the PTY buffer is full — no progress in 700ms)
--- screen ---
```

The write may remain stuck in that thread afterwards, which is bounded and harmless — the test already failed with a diagnosis.

### Correcting the fix as filed

Neither proposed mechanism works, and both were verified not to:

- **`O_NONBLOCK` hits the read path too.** portable-pty's reader and writer are `dup`s of one open file description, and `reader_loop` treats any non-`Interrupted` error as EOF — every wait would collapse into `Error::Eof`.
- **`POLLOUT` is worse than useless on macOS.** A pty master reports writable and the next write blocks anyway (measured while fixing #60).

### A note on the regression test

The obvious test — one huge write to a non-reading child — does **not** reproduce: macOS absorbs a single 256 KiB write in 13ms. What actually blocks is *small repeated* writes, which is the shape typed input has. The test therefore stops the child with `SIGSTOP` so it provably cannot drain, then writes in small chunks; the deadline fires at 706ms with the right message. That distinction is recorded in the test's comments so nobody "simplifies" it back.

Closes #59
