### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-17
+
+The features the first real user's coverage study asked for, in the
+order it ranked them, plus the terminal-query work that lets
+capability-probing applications run against termlens unmodified.
+
 ### Changed
 
 - `Scroll` gained `Left` and `Right` variants and is now
@@ -32,7 +38,19 @@ listed under a **Changed** or **Removed** heading.
   application enabled, and refused with a typed error when the mode
   cannot express the gesture — a drag under X10, which reports no
   release, is an error rather than a misleading half-gesture.
-
+- termlens answers **`DECRQM`** ("is private mode *n* set?"), so an
+  application that probes before using synchronized output enables it
+  against termlens — `wait_frame` works against programs nobody
+  modified for the harness. Replies are truthful or absent: modes whose
+  state the emulator holds exactly report set/reset, everything else
+  reports "not recognized" rather than a guess. `DECRQSS`, `OSC 4`
+  palette reads and `OSC 52` clipboard reads are now recognized too, so
+  an application blocked on one is named in the timeout instead of
+  hanging silently.
+- `TerminalBuilder::foreground_rgb` configures the `OSC 10` answer,
+  which was hardcoded white. Applications that pick a theme by
+  comparing foreground and background luminance can now be tested
+  against both.
 - Every wait now takes a per-call deadline: `wait_frame_for`,
   `wait_idle_for` and `wait_exit_for` join `wait_until_for`. One
   known-slow step no longer forces the builder timeout up for every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "crossterm",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "crossterm",
 ]
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "crossterm",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -563,7 +563,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.2.1"
+version = "0.3.0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.2.1" }
+termlens = { path = "crates/termlens", version = "0.3.0" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
Version bump and CHANGELOG date for **v0.3.0** — the [v0.3 milestone](https://github.com/vyncint/termlens/milestone/3), all six issues closed.

The coverage study's three ranked asks, in its order:

| | |
|---|---|
| #53 | Per-call deadlines on every wait — `wait_frame_for`, `wait_idle_for`, `wait_exit_for` |
| #54 | A fuller mouse API — buttons, drag, modifier chords, horizontal wheel |
| #55 | A short frame history, so a burst arriving in one read is assertable step by step |

Plus the work that came out of probing 0.2.x:

| | |
|---|---|
| #56 | **DECRQM answered truthfully**, so applications that probe before using synchronized output enable it against termlens unmodified; DECRQSS / OSC 4 / OSC 52 named instead of hanging silently |
| #58 | `foreground_rgb` — the OSC 10 answer was hardcoded white |
| #59 | A deadline on writes — the last unbounded wait in the crate |

**Semver**: one breaking change, under `### Changed` — `Scroll` gained `Left`/`Right` and became `#[non_exhaustive]`, so exhaustive matches need a wildcard arm and further variants are additive. A 0.2.x → 0.3.0 minor bump is where that belongs under this project's stated policy.

Gates: fmt, clippy (all targets/features), **17 suites green in both debug and release**, doctests, doc build with `-D warnings`, cargo-deny, and changelog extraction verified for `0.3.0`. Stress ×100 on both OSes is running against final main.

Two design corrections were recorded on their issues before implementation, because the filed fixes could not work as written: #55's queue needed a cursor design that doesn't break a shipped test, and #59's `O_NONBLOCK`/`POLLOUT` mechanism is unusable here (`POLLOUT` on a macOS pty master reports writable and then blocks).

Closes the v0.3 milestone.