### PR TITLE
fix(frames): publish a frame only when an End closes a Begin

### DIFF
--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -279,7 +279,17 @@ impl SeqTracker {
                     self.sync_update = true;
                     return SeqEvent::SyncBegin;
                 }
-                b'l' => {
+                // Only an End that closes a Begin we saw ends a frame.
+                // An unmatched End is ordinary application behaviour, not a
+                // malformed stream: programs defensively reset terminal
+                // modes at startup and on crash, and such a reset string
+                // naturally contains `?2026l`. Treating it as a frame would
+                // manufacture one out of whatever happened to be on the
+                // grid — and, worse, push `frames_seen` off zero, which is
+                // what gates the "never emitted a synchronized update"
+                // diagnosis. Silently not ending a frame is the whole
+                // correct response.
+                b'l' if self.sync_update => {
                     self.sync_update = false;
                     return SeqEvent::SyncEnd;
                 }
@@ -593,6 +603,34 @@ mod tests {
         assert!(!t.in_sync_update());
         t.feed(b"\x1b[?20260h"); // different mode number
         assert!(!t.in_sync_update());
+    }
+
+    #[test]
+    fn an_end_that_closes_no_begin_is_not_a_frame() {
+        // Applications reset terminal modes defensively at startup and on
+        // crash, and such a reset string contains `?2026l`. It must not end
+        // a frame that never began.
+        let mut t = SeqTracker::new();
+        let events: Vec<SeqEvent> = b"\x1b[?2026l".iter().map(|&b| t.step(b)).collect();
+        assert!(!events.contains(&SeqEvent::SyncEnd));
+        assert!(!t.in_sync_update());
+
+        // Taken verbatim from a real crash handler.
+        let reset = b"\x1b[?2026l\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?2004l\x1b[?1049l";
+        let mut t = SeqTracker::new();
+        let events: Vec<SeqEvent> = reset.iter().map(|&b| t.step(b)).collect();
+        assert!(!events.contains(&SeqEvent::SyncEnd));
+
+        // And the End of a real frame still ends it, once only.
+        let mut t = SeqTracker::new();
+        let events: Vec<SeqEvent> = b"\x1b[?2026h\x1b[?2026l\x1b[?2026l"
+            .iter()
+            .map(|&b| t.step(b))
+            .collect();
+        assert_eq!(
+            events.iter().filter(|e| **e == SeqEvent::SyncEnd).count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1491,6 +1491,15 @@ impl Terminal {
     /// a burst like a progress counter ticking `1`, `2`, `3` in one
     /// write is observable step by step by three successive calls.
     ///
+    /// A frame is one *completed* synchronized update: an
+    /// `EndSynchronizedUpdate` that closes a Begin this terminal actually
+    /// saw. An unmatched End publishes nothing — the `?2026l` inside the
+    /// mode-reset string applications emit defensively at startup and on
+    /// crash is not a repaint, and treating it as one would both invent a
+    /// frame and hide the "never emitted a synchronized update" diagnosis
+    /// below. A Begin/End pair that changed no cell *does* publish: the
+    /// count is of repaints, not of changes.
+    ///
     /// Two honest limits follow from the retention bound: a burst longer
     /// than 8 frames drops its oldest, and because retained frames stay
     /// matchable, a predicate that was true of an earlier frame resolves

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -234,3 +234,75 @@ fn wait_idle_does_not_resolve_inside_an_open_synchronized_update() {
     );
     // Drop kills the parked child.
 }
+
+#[test]
+fn an_unmatched_end_publishes_no_frame() {
+    // `?2026l` with no Begin must not manufacture a frame out of whatever
+    // is on the grid — and must leave the frame count at zero, since that
+    // is what gates the diagnosis below.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(600))
+        .args([
+            "-c",
+            r"printf '\033[2J\033[HNO-BEGIN\033[?2026l'; read guard",
+        ])
+        .spawn("sh")
+        .unwrap();
+    t.wait_until(|s| s.contains("NO-BEGIN")).unwrap();
+
+    let err = t.wait_frame(|s| s.contains("NO-BEGIN")).unwrap_err();
+    assert!(
+        err.to_string().contains("never emitted"),
+        "a phantom frame would both match and suppress the diagnosis: {err}"
+    );
+}
+
+#[test]
+fn a_defensive_mode_reset_keeps_the_never_emitted_diagnosis() {
+    // Verbatim from a real crash handler: applications reset terminal modes
+    // defensively, and such a string contains `?2026l`. One stray End used
+    // to replace the pointed diagnosis with a frame count, which reads as
+    // "the app is frame-capable, your predicate is wrong".
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(600))
+        .args([
+            "-c",
+            concat!(
+                r"printf '\033[?2026l\033[?25h\033[?1000l\033[?1002l",
+                r"\033[?1003l\033[?2004l\033[?1049l'; ",
+                r"printf '\033[2J\033[HPLAIN-PAINT'; read guard"
+            ),
+        ])
+        .spawn("sh")
+        .unwrap();
+    t.wait_until(|s| s.contains("PLAIN-PAINT")).unwrap();
+
+    let err = t.wait_frame(|s| s.contains("NEVER-DRAWN")).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("never emitted a DEC 2026 synchronized update"),
+        "the reset must not look like a repaint: {msg}"
+    );
+    assert!(
+        !msg.contains("complete frames observed"),
+        "no frame was drawn, so no count should be claimed: {msg}"
+    );
+}
+
+#[test]
+fn a_begin_end_pair_that_drew_nothing_is_still_a_frame() {
+    // Deliberate: `frames_seen` counts repaints, not changes. An
+    // application that opens and closes a synchronized update completed a
+    // repaint, even if the result is identical — deciding otherwise would
+    // mean diffing grids and calling a genuine no-op repaint a non-event.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(5))
+        .args([
+            "-c",
+            r"printf '\033[2J\033[HSTATIC'; printf '\033[?2026h\033[?2026l'; read guard",
+        ])
+        .spawn("sh")
+        .unwrap();
+    t.wait_frame(|s| s.contains("STATIC")).unwrap();
+    t.send(Key::Enter);
+}


### PR DESCRIPTION
Publishes a frame only when an `EndSynchronizedUpdate` closes a Begin the tracker actually saw.

### Verified before fixing

Both reproductions from the issue, against the release commit:

```
#86 bare ?2026l              -> wait_frame Ok        (phantom frame matched)
#86 with defensive reset     -> "... (1 complete frames observed)"
#86 control (no stray End)   -> "... never emitted a DEC 2026 synchronized update ..."
```

The middle line is the whole point: the stray End did not produce a false pass, it **suppressed the diagnosis**. After the fix the reset case and the control produce byte-identical messages.

### The fix

Three lines at the root cause — `SeqTracker` reports `SyncEnd` only when `sync_update` is set, so an End that closes nothing is simply not a frame end. `frames_seen` never leaves zero, and the diagnosis survives.

An unmatched End is legitimate application behaviour, not a malformed stream, so it neither warns nor errors, exactly as the issue asks.

### The other question the issue left open

Whether a Begin/End pair that changed nothing should publish. **It does**, and the rustdoc now says so: the application completed a repaint, and deciding otherwise would mean diffing grids and calling a genuine no-op repaint a non-event. `frames_seen` counts repaints, not changes. Pinned by `a_begin_end_pair_that_drew_nothing_is_still_a_frame`.

### Tests

- `emu::seq::an_end_that_closes_no_begin_is_not_a_frame` — bare End, the verbatim crash-handler reset string, and a double End after a real Begin ending the frame exactly once.
- `frames::an_unmatched_end_publishes_no_frame`
- `frames::a_defensive_mode_reset_keeps_the_never_emitted_diagnosis` — the reset taken verbatim from a real crash handler, asserting the diagnosis appears *and* that no frame count is claimed.
- `frames::a_begin_end_pair_that_drew_nothing_is_still_a_frame`

Full suite green (17 suites), fmt and clippy clean.

Closes #86
