### PR TITLE
fix(queries): report mouse tracking modes as reset when none is active

### DIFF
--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -107,13 +107,7 @@ impl Emulator for Vt100Emulator {
                 ModeState::Reset
             }
         };
-        // Only modes whose state we hold exactly. The mouse tracking
-        // modes are the interesting exclusion: vt100 collapses 9/1000/
-        // 1002/1003 into one mutually exclusive value, so an application
-        // that enabled several (crossterm's EnableMouseCapture sends
-        // 1000, 1002 and 1003 together) would be told the others are
-        // *reset* — a guess dressed up as an answer. Reporting the exact
-        // match and nothing else keeps every reply true.
+        // Only modes whose state we hold exactly.
         match mode {
             // Synchronized output. Answering at all is the point: an
             // application that probes before bracketing its repaints can
@@ -132,20 +126,28 @@ impl Emulator for Vt100Emulator {
                 screen.mouse_protocol_encoding(),
                 ::vt100::MouseProtocolEncoding::Utf8
             )),
-            9 | 1000 | 1002 | 1003 => {
-                let current = match screen.mouse_protocol_mode() {
-                    ::vt100::MouseProtocolMode::None => 0,
-                    ::vt100::MouseProtocolMode::Press => 9,
-                    ::vt100::MouseProtocolMode::PressRelease => 1000,
-                    ::vt100::MouseProtocolMode::ButtonMotion => 1002,
-                    ::vt100::MouseProtocolMode::AnyMotion => 1003,
-                };
-                if current == mode {
-                    ModeState::Set
-                } else {
-                    ModeState::NotRecognized
-                }
-            }
+            // The mouse tracking modes need care, because vt100 collapses
+            // all four into one mutually exclusive value. Two cases, and
+            // only one of them is ambiguous:
+            //
+            // - Nothing is tracking. Then nothing was collapsed, and every
+            //   tracking mode is genuinely reset — a fact, not a guess. This
+            //   is the state every application is in when it probes at
+            //   startup, so it is the case that decides whether
+            //   capability detection works at all.
+            // - A *different* mode is tracking. The application may have set
+            //   several (crossterm's EnableMouseCapture sends 1000, 1002 and
+            //   1003 together) and vt100 kept only the last, so claiming the
+            //   others are reset would be a guess dressed up as an answer.
+            //   `NotRecognized` stays honest here.
+            9 | 1000 | 1002 | 1003 => match screen.mouse_protocol_mode() {
+                ::vt100::MouseProtocolMode::None => ModeState::Reset,
+                ::vt100::MouseProtocolMode::Press if mode == 9 => ModeState::Set,
+                ::vt100::MouseProtocolMode::PressRelease if mode == 1000 => ModeState::Set,
+                ::vt100::MouseProtocolMode::ButtonMotion if mode == 1002 => ModeState::Set,
+                ::vt100::MouseProtocolMode::AnyMotion if mode == 1003 => ModeState::Set,
+                _ => ModeState::NotRecognized,
+            },
             _ => ModeState::NotRecognized,
         }
     }
@@ -305,6 +307,41 @@ mod tests {
         assert!(!s.bracketed_paste());
         assert!(!s.application_cursor());
         assert_eq!(s.mouse_mode(), MouseMode::None);
+    }
+
+    #[test]
+    fn mouse_tracking_modes_are_reset_until_one_is_enabled() {
+        // The state every application is in when it probes at startup.
+        // Nothing was collapsed, so "reset" is a fact rather than a guess —
+        // and answering it is what lets capability detection succeed.
+        let emu = emu_with(b"plain");
+        for mode in [9, 1000, 1002, 1003] {
+            assert_eq!(emu.mode_state(mode), ModeState::Reset, "mode {mode}");
+        }
+    }
+
+    #[test]
+    fn an_active_tracking_mode_reports_itself_and_stays_silent_on_the_rest() {
+        let emu = emu_with(b"\x1b[?1002h");
+        assert_eq!(emu.mode_state(1002), ModeState::Set);
+        // Genuinely ambiguous: crossterm's EnableMouseCapture sends 1000,
+        // 1002 and 1003 together and vt100 keeps only the last, so calling
+        // the others reset would be a guess dressed up as an answer.
+        for mode in [9, 1000, 1003] {
+            assert_eq!(
+                emu.mode_state(mode),
+                ModeState::NotRecognized,
+                "mode {mode}"
+            );
+        }
+    }
+
+    #[test]
+    fn turning_tracking_off_returns_every_mode_to_reset() {
+        let emu = emu_with(b"\x1b[?1002h\x1b[?1002l");
+        for mode in [9, 1000, 1002, 1003] {
+            assert_eq!(emu.mode_state(mode), ModeState::Reset, "mode {mode}");
+        }
     }
 
     #[test]

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -300,3 +300,33 @@ fn replies_are_not_echoed_into_the_screen() -> termlens::Result<()> {
     assert!(t.wait_exit()?.success());
     Ok(())
 }
+
+#[test]
+fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
+    // The loop this closes on itself: the application probes `?1000$p`, is
+    // told "not recognized", concludes the terminal has no mouse and never
+    // sends `CSI ?1000h` — and `click` then refuses, blaming the
+    // application for a decision termlens caused.
+    //
+    // The script is written to *prove* the decision: if the reply says the
+    // mode is unrecognized it prints REFUSED and never enables tracking,
+    // so a regression fails on the wait below rather than passing quietly.
+    let mut t = sh(concat!(
+        r"stty -icanon -echo; ",
+        r#"printf '\033[?1000$p'; "#,
+        r#"reply=$(head -c 11 | tr '\033' 'E'); "#,
+        r#"case "$reply" in *';0$y') printf 'REFUSED:%s' "$reply"; read g; exit 0;; esac; "#,
+        r#"printf '\033[?1000h\033[?1006h'; printf 'MOUSE-ON:%s|' "$reply"; "#,
+        r#"click=$(head -c 20 | tr '\033' 'E'); printf 'CLICK:%s' "$click"; read g"#
+    ))?;
+    // `;2$y` = implemented and currently reset. The application proceeds.
+    t.wait_until(|s| s.contains("MOUSE-ON:E[?1000;2$y|"))?;
+
+    t.click(9, 4)?;
+    // Press and release, SGR-encoded, 1-based on the wire.
+    t.wait_until(|s| s.contains("CLICK:E[<0;10;5ME[<0;10;5m"))?;
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -57,9 +57,19 @@ is what lets an application that *probes* before using synchronized
 output turn it on against termlens — so `wait_frame` can work against a
 program nobody modified for us. Every reply is truthful or absent:
 modes whose state the emulator holds exactly report set/reset, and
-anything else — including the mouse tracking modes, which the backend
-collapses into one mutually exclusive value — reports "not recognized"
-rather than a guess.
+anything else reports "not recognized" rather than a guess.
+
+The mouse tracking modes show where that line actually falls. The
+backend collapses `9`/`1000`/`1002`/`1003` into one mutually exclusive
+value, so it cannot say which members of a group an application set —
+crossterm's `EnableMouseCapture` sends three at once and only the last
+survives. But that ambiguity exists only *while something is tracking*.
+With no tracking mode active — the state every application probes from
+at startup — nothing was collapsed and every tracking mode is genuinely
+reset, so that is what we report. Answering "not recognized" there
+would close a loop on itself: the application concludes the terminal has
+no mouse, never enables tracking, and `click` then refuses, blaming the
+application for a decision we caused.
 
 Precision: the emulator stops consuming at each query byte (the same
 mechanism as frame boundaries), so a cursor-position report reflects the


### PR DESCRIPTION
Reports `Reset` for the mouse tracking modes when nothing is tracking; keeps `NotRecognized` only for the genuinely ambiguous case.

### Verified before fixing

Swept against the release commit with nothing enabled, reading the exact reply length:

```
#83 probe   ?1000$p -> got:E[?1000;0$y     (0 = not recognized)
#83 control ?2004$p -> got:E[?2004;2$y     (2 = reset, supported)
```

After the fix the probe is identical to the control: `got:E[?1000;2$y`.

### The distinction the fix draws

Two cases hid behind one answer, and only one of them is ambiguous:

- **Nothing is tracking** — nothing was collapsed, so every tracking mode is genuinely reset. This is the state every application probes from at startup, and it is the case that decides whether capability detection works at all. `Reset` here is a fact, not a guess.
- **A different mode is tracking** — the application may have set several (crossterm's `EnableMouseCapture` sends 1000, 1002 and 1003 together) and vt100 keeps only the last, so calling the others reset would be a guess dressed up as an answer. `NotRecognized` stays.

Nothing else changes, and no reply becomes a guess.

### Tests

The end-to-end test the issue asks for, `queries::a_probe_then_enable_application_gets_its_mouse`, drives the whole loop through a real PTY: the application probes `?1000$p`, and the script *branches on the answer* — if the reply says unrecognized it prints `REFUSED` and never enables tracking, so a regression fails on the wait rather than passing quietly. On a supported answer it enables `?1000h`/`?1006h`, and the test then clicks and asserts the exact bytes the application receives:

```
CLICK:E[<0;10;5ME[<0;10;5m
```

Unit tests pin all three states, with the reason in the name:

- `mouse_tracking_modes_are_reset_until_one_is_enabled`
- `an_active_tracking_mode_reports_itself_and_stays_silent_on_the_rest` — the ambiguous case, still `NotRecognized`
- `turning_tracking_off_returns_every_mode_to_reset`

`docs/DESIGN.md` §1 now explains where the truthful/absent line actually falls, including the self-closing loop this removes.

Full suite green (17 suites), fmt and clippy clean.

Closes #83
