### PR TITLE
feat(frames)!: give wait_frame a cursor and return the matched frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ design. termlens's position:
 - **`wait_frame` gives exact frame boundaries** for apps that bracket
   repaints in DEC 2026 synchronized updates (crossterm's
   `BeginSynchronizedUpdate`/`EndSynchronizedUpdate`): the predicate only
-  ever sees complete frames, never a torn repaint. The last 8 frames are
-  retained, so a burst arriving in one read is assertable step by step —
-  and applications that *probe* for synchronized output before using it
-  get a truthful `DECRQM` answer, so they enable it against termlens
-  unmodified.
+  ever sees complete frames, never a torn repaint, and the call returns
+  the frame it matched. Each call observes a frame no earlier call did, so
+  a burst arriving in one read is assertable step by step in emission
+  order, one repaint cannot satisfy two waits, and a superseded frame
+  cannot answer a wait made after your input. Applications that *probe*
+  for synchronized output before using it get a truthful `DECRQM` answer,
+  so they enable it against termlens unmodified.
 - **Every wait takes a per-call deadline** (`wait_until_for`,
   `wait_frame_for`, `wait_idle_for`, `wait_exit_for`), so one slow step
   doesn't force a generous timeout on the whole suite. Writes are bounded

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -352,7 +352,11 @@ struct EmuState {
     /// [`FRAME_HISTORY`]. Several frames can complete inside one read, so
     /// keeping only the newest made rapid intermediate states — a
     /// progress counter ticking 1, 2, 3 in one write — unobservable.
-    frames: VecDeque<Screen>,
+    ///
+    /// Each frame carries its `frames_seen` index at publication, which is
+    /// what lets a waiter ask for frames *newer than the last one it was
+    /// given* rather than rescanning the whole ring forever.
+    frames: VecDeque<(u64, Screen)>,
     /// Whether to answer recognized terminal queries (builder-configured).
     respond: bool,
     /// Background color reported to OSC 11 queries.
@@ -900,6 +904,7 @@ impl TerminalBuilder {
             default_timeout: self.timeout,
             exit_status: None,
             command_desc,
+            frame_cursor: 0,
         })
     }
 }
@@ -944,6 +949,16 @@ fn check_size(cols: u16, rows: u16) -> Result<()> {
 
 /// Canonical printable shape of a known query (for diagnostics when the
 /// responder is disabled).
+/// "1 complete frame" / "2 complete frames". Timeout messages are read by
+/// people under pressure; the diagnosis is the point of this crate.
+fn frames_phrase(n: u64) -> String {
+    if n == 1 {
+        "1 complete frame".to_owned()
+    } else {
+        format!("{n} complete frames")
+    }
+}
+
 fn query_shape(query: &Query) -> String {
     match query {
         Query::CursorPosition { private: false } => "^[[6n".into(),
@@ -994,7 +1009,7 @@ fn reader_loop(
                                 if state.frames.len() == FRAME_HISTORY {
                                     state.frames.pop_front();
                                 }
-                                state.frames.push_back(frame);
+                                state.frames.push_back((state.frames_seen, frame));
                             }
                             Some(Stop::Query(query)) => {
                                 if let Some(reply) = state.answer(&query) {
@@ -1063,6 +1078,12 @@ pub struct Terminal {
     default_timeout: Duration,
     exit_status: Option<ExitStatus>,
     command_desc: String,
+    /// Index of the newest frame [`wait_frame`](Terminal::wait_frame) has
+    /// already returned from this terminal. Each call looks only past it,
+    /// so N successive calls observe N distinct frames and a frame cannot
+    /// satisfy two waits. Advanced by a resize too: a frame drawn at the
+    /// old size is not the repaint that answers the new one.
+    frame_cursor: u64,
 }
 
 impl Terminal {
@@ -1484,12 +1505,37 @@ impl Terminal {
     /// demands (single predicate, wait on the last-painted region; see
     /// `docs/DESIGN.md` §2).
     ///
-    /// Frames completed *before* the call are evaluated too, so a fast
-    /// application cannot slip one past you — including when several
-    /// complete inside a single read. The terminal retains the last
-    /// **8** completed frames and each call scans them oldest first, so
-    /// a burst like a progress counter ticking `1`, `2`, `3` in one
-    /// write is observable step by step by three successive calls.
+    /// Returns the frame that matched. Assert on *that* `Screen` rather
+    /// than calling [`screen`](Self::screen) afterwards: the live grid can
+    /// already have moved on to a newer state, and the returned frame is
+    /// the instant the predicate actually saw.
+    ///
+    /// # Each call observes a frame no earlier call did
+    ///
+    /// The terminal retains the last **8** completed frames, and each call
+    /// scans — oldest first — only those *newer than the frame it last
+    /// returned to you*. Two properties follow, and they are the ones that
+    /// make this method worth using:
+    ///
+    /// - **A burst is observable step by step.** Several frames can
+    ///   complete inside a single read; a progress counter ticking `1`,
+    ///   `2`, `3` in one write is seen by three successive calls, in the
+    ///   order the application drew them. Asking for `1` after `3` fails,
+    ///   because `1` is behind the cursor — the sequence is enforced, not
+    ///   merely available.
+    /// - **A frame cannot satisfy two waits.** N successive calls observe
+    ///   N distinct frames, so `wait_frame(x)` twice does not pass twice
+    ///   on one repaint.
+    ///
+    /// A frame completed before the call but never yet returned *is* still
+    /// matched, deliberately: a fast application cannot slip a frame past
+    /// you between your last wait and this one. What is gone is the old
+    /// behaviour where any of the last 8 frames matched forever — so
+    /// `send(key)` followed by `wait_frame(|s| s.contains(OLD_STATE))` now
+    /// times out instead of passing on the superseded frame.
+    ///
+    /// A [`resize`](Self::resize) also advances the cursor: a frame drawn
+    /// at the old size is not the repaint that answers the new one.
     ///
     /// A frame is one *completed* synchronized update: an
     /// `EndSynchronizedUpdate` that closes a Begin this terminal actually
@@ -1500,11 +1546,9 @@ impl Terminal {
     /// below. A Begin/End pair that changed no cell *does* publish: the
     /// count is of repaints, not of changes.
     ///
-    /// Two honest limits follow from the retention bound: a burst longer
-    /// than 8 frames drops its oldest, and because retained frames stay
-    /// matchable, a predicate that was true of an earlier frame resolves
-    /// immediately rather than waiting for a new one. Where that matters,
-    /// assert on something only the newer frame can show.
+    /// One honest limit follows from the retention bound: a burst longer
+    /// than 8 frames drops its oldest, so frames beyond that are gone
+    /// before any predicate can see them.
     ///
     /// ```
     /// # fn main() -> termlens::Result<()> {
@@ -1512,7 +1556,8 @@ impl Terminal {
     ///     .timeout(std::time::Duration::from_secs(10))
     ///     .args(["-c", r"printf '\033[?2026hFrame ready\033[?2026l'; read quit"])
     ///     .spawn("sh")?;
-    /// t.wait_frame(|screen| screen.contains("Frame ready"))?;
+    /// let frame = t.wait_frame(|screen| screen.contains("Frame ready"))?;
+    /// assert!(frame.contains("Frame ready"));
     /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
     /// # }
     /// ```
@@ -1523,7 +1568,7 @@ impl Terminal {
     /// application never emitted a single synchronized update, since
     /// `wait_frame` can then never succeed; use `wait_until` for such apps.
     /// [`Error::Eof`] as soon as the PTY closes with no matching frame.
-    pub fn wait_frame(&mut self, predicate: impl FnMut(&Screen) -> bool) -> Result<()> {
+    pub fn wait_frame(&mut self, predicate: impl FnMut(&Screen) -> bool) -> Result<Screen> {
         self.wait_frame_deadline(predicate, self.default_timeout)
     }
 
@@ -1538,7 +1583,7 @@ impl Terminal {
         &mut self,
         predicate: impl FnMut(&Screen) -> bool,
         timeout: Duration,
-    ) -> Result<()> {
+    ) -> Result<Screen> {
         self.wait_frame_deadline(predicate, timeout)
     }
 
@@ -1546,19 +1591,25 @@ impl Terminal {
         &mut self,
         mut predicate: impl FnMut(&Screen) -> bool,
         timeout: Duration,
-    ) -> Result<()> {
+    ) -> Result<Screen> {
         const WHAT: &str = "a complete frame matching the predicate";
         let deadline = Instant::now() + timeout;
+        let cursor = self.frame_cursor;
         let mut seen_frame = None;
         let outcome = self.shared.wait_until(deadline, |state| {
-            if state.frames_seen > 0 && seen_frame != Some(state.frames_seen) {
+            if state.frames_seen > cursor && seen_frame != Some(state.frames_seen) {
                 seen_frame = Some(state.frames_seen);
-                // Oldest retained frame first: several frames can
+                // Oldest unobserved frame first: several frames can
                 // complete inside one read, and a test asserting on a
-                // sequence must be able to see them in the order the
-                // application drew them.
-                if state.frames.iter().any(&mut predicate) {
-                    return Some(Ok(()));
+                // sequence must see them in the order the application drew
+                // them. Frames at or behind the cursor were already handed
+                // to an earlier wait and are not offered twice.
+                let matched = state
+                    .frames
+                    .iter()
+                    .find(|(index, frame)| *index > cursor && predicate(frame));
+                if let Some((index, frame)) = matched {
+                    return Some(Ok((*index, frame.clone())));
                 }
             }
             if state.eof {
@@ -1570,7 +1621,11 @@ impl Terminal {
             None
         });
         match outcome {
-            Ok(inner) => inner,
+            Ok(Ok((index, frame))) => {
+                self.frame_cursor = index;
+                Ok(frame)
+            }
+            Ok(Err(e)) => Err(e),
             Err(Expired) => {
                 // The live screen, like every other wait: the error's
                 // header says "screen at timeout" and a CI log is often
@@ -1584,7 +1639,19 @@ impl Terminal {
                     let note = guard.query_note();
                     (guard.frames_seen, screen, note)
                 };
-                let waiting_for = if frames == 0 {
+                let waiting_for = if frames > 0 && frames == cursor {
+                    // Every frame the application drew has already been
+                    // handed to an earlier wait, so it has not repainted
+                    // since. Naming that is the difference between "your
+                    // predicate is wrong" and "the app never redrew".
+                    format!(
+                        "{WHAT} — the application has not completed a repaint since the \
+                         frame this terminal last returned ({} in total). If it does not \
+                         repaint in response to this input, assert on the screen with \
+                         wait_until instead{note}",
+                        frames_phrase(frames)
+                    )
+                } else if frames == 0 {
                     // An application blocked on an unanswered probe never
                     // reaches its first repaint, so this is exactly where
                     // the query note earns its place: without it the
@@ -1595,8 +1662,13 @@ impl Terminal {
                          bracketed in BeginSynchronizedUpdate/EndSynchronizedUpdate; \
                          for other apps use wait_until (docs/DESIGN.md §2){note}"
                     )
+                } else if cursor == 0 {
+                    format!("{WHAT} ({} observed){note}", frames_phrase(frames))
                 } else {
-                    format!("{WHAT} ({frames} complete frames observed){note}")
+                    format!(
+                        "{WHAT} ({} since the last one returned, {frames} in total){note}",
+                        frames_phrase(frames - cursor)
+                    )
                 };
                 Err(Error::Timeout {
                     waiting_for,
@@ -1835,7 +1907,9 @@ impl Terminal {
     /// Wait for something only the post-SIGWINCH frame can show — content
     /// that needs the new width, a complete status bar on the new bottom
     /// row — or use [`wait_frame`](Self::wait_frame) where the app emits
-    /// synchronized updates. `docs/DESIGN.md` §2 shows the trap in full.
+    /// synchronized updates, which is unconditionally safe here: a resize
+    /// advances the frame cursor, so only a frame completed *after* it can
+    /// satisfy the wait. `docs/DESIGN.md` §2 shows the trap in full.
     ///
     /// # Errors
     ///
@@ -1854,9 +1928,14 @@ impl Terminal {
                 pixel_height: 0,
             })
             .map_err(|e| Error::Pty(format!("resize failed: {e}")))?;
-        self.shared.mutate(|state| {
+        // A frame drawn at the old size cannot be the repaint that answers
+        // this resize, so it stops being offered — which is what makes the
+        // advice in the stale-frame trap above actually hold for
+        // `wait_frame`.
+        self.frame_cursor = self.shared.mutate(|state| {
             state.emu.set_size(rows, cols);
             state.touch();
+            state.frames_seen
         });
         Ok(())
     }

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -35,20 +35,14 @@ fn a_frame_is_internally_consistent() -> termlens::Result<()> {
 
     t.send_str("hi");
     // Both the input line and the last-key line are painted in the same
-    // synchronized update; a frame satisfying one must satisfy the other.
-    t.wait_frame(|s| s.contains("input: hi"))?;
-    let frame_ok = std::cell::Cell::new(false);
-    t.wait_frame(|s| {
-        if s.contains("input: hi") {
-            frame_ok.set(s.contains("last: char:i"));
-            true
-        } else {
-            false
-        }
-    })?;
+    // synchronized update, so a frame satisfying one must satisfy the
+    // other. The returned frame is what the predicate saw, so the sibling
+    // row is checked on that exact instant rather than on a later
+    // `screen()` that may already have moved on.
+    let frame = t.wait_frame(|s| s.contains("input: hi"))?;
     assert!(
-        frame_ok.get(),
-        "frame satisfied one row but not its sibling"
+        frame.contains("last: char:i"),
+        "frame satisfied one row but not its sibling:\n{frame}"
     );
 
     t.send(Key::Esc);
@@ -65,16 +59,7 @@ fn a_torn_repaint_is_never_observed() -> termlens::Result<()> {
     // and ends the synchronized update. The bytes arrive in two bursts;
     // the frame completes only with the second.
     t.send(Key::F(2));
-    let mut observed = None;
-    t.wait_frame(|s| {
-        if s.contains("torn: left") {
-            observed = Some(s.row_text(5));
-            true
-        } else {
-            false
-        }
-    })?;
-    let row = observed.expect("predicate matched");
+    let row = t.wait_frame(|s| s.contains("torn: left"))?.row_text(5);
     assert!(
         row.contains("torn: left right"),
         "wait_frame observed a torn frame: {row:?}"
@@ -134,10 +119,12 @@ fn wait_frame_timeouts_embed_the_live_screen_not_the_last_frame() {
         screen.contains("LIVE SCREEN"),
         "the embedded screen is stale — it must match the header:\n{screen}"
     );
-    // The frame count still tells you what wait_frame actually saw.
+    // The only frame drawn was already returned, so the message says the
+    // application has not repainted rather than blaming the predicate.
+    let msg = err.to_string();
     assert!(
-        err.to_string().contains("1 complete frames observed"),
-        "the frame count belongs in the message: {err}"
+        msg.contains("has not completed a repaint") && msg.contains("1 complete frame in total"),
+        "the frame count and the reason belong in the message: {msg}"
     );
 }
 
@@ -160,12 +147,17 @@ fn every_frame_of_a_burst_is_observable_in_order() -> termlens::Result<()> {
         ])
         .spawn("sh")?;
 
-    // Wait for the last one first, so all three have certainly arrived
-    // (and been coalesced into as few reads as the OS chose).
-    t.wait_frame(|s| s.contains("STEP 3"))?;
-    // Every intermediate frame is still there.
-    t.wait_frame(|s| s.contains("STEP 1"))?;
-    t.wait_frame(|s| s.contains("STEP 2"))?;
+    // Settle on the live screen first, so all three frames have certainly
+    // arrived (and been coalesced into as few reads as the OS chose)
+    // before any of them is consumed. `wait_until` observes the grid, not
+    // the frame ring, so it leaves the cursor where it is.
+    t.wait_until(|s| s.contains("STEP 3"))?;
+
+    // Now every frame of the burst is observable, oldest first, and each
+    // call returns the frame it matched.
+    assert!(t.wait_frame(|s| s.contains("STEP 1"))?.contains("STEP 1"));
+    assert!(t.wait_frame(|s| s.contains("STEP 2"))?.contains("STEP 2"));
+    assert!(t.wait_frame(|s| s.contains("STEP 3"))?.contains("STEP 3"));
 
     t.send(Key::Enter);
     assert!(t.wait_exit()?.success());
@@ -186,13 +178,14 @@ fn a_burst_longer_than_the_retention_bound_drops_its_oldest_frames() -> termlens
         .args(["-c", &format!("printf '{script}'; read guard")])
         .spawn("sh")?;
 
-    t.wait_frame(|s| s.contains("FRAME 12"))?;
-    // The most recent 8 are retained: 05..=12.
+    t.wait_until(|s| s.contains("FRAME 12"))?;
+    // The most recent 8 are retained: 05..=12, so 05 is the oldest that
+    // can still be observed.
     t.wait_frame(|s| s.contains("FRAME 05"))?;
     // The first four are gone, and the error says how many were seen.
     let err = t.wait_frame(|s| s.contains("FRAME 01")).unwrap_err();
     assert!(
-        err.to_string().contains("12 complete frames observed"),
+        err.to_string().contains("12 in total"),
         "the frame count belongs in the message: {err}"
     );
     Ok(())
@@ -305,4 +298,146 @@ fn a_begin_end_pair_that_drew_nothing_is_still_a_frame() {
         .unwrap();
     t.wait_frame(|s| s.contains("STATIC")).unwrap();
     t.send(Key::Enter);
+}
+
+/// The headline case: `send(key); wait_frame(OLD_STATE)` used to pass on
+/// the retained frame, and the assertion after it read the old screen. A
+/// regression in which the key stopped working was invisible.
+#[test]
+fn a_superseded_frame_no_longer_satisfies_a_wait() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"printf '\033[?2026h\033[2J\033[HSTATE-A\033[?2026l'; read a; ",
+                r"printf '\033[?2026h\033[2J\033[HSTATE-B\033[?2026l'; read b"
+            ),
+        ])
+        .spawn("sh")?;
+
+    assert!(t.wait_frame(|s| s.contains("STATE-A"))?.contains("STATE-A"));
+    t.send(Key::Enter);
+
+    let stale = t.wait_frame_for(|s| s.contains("STATE-A"), Duration::from_millis(700));
+    assert!(
+        matches!(stale, Err(Error::Timeout { .. })),
+        "waiting for the superseded state must fail: {stale:?}"
+    );
+
+    // The frame the application actually drew is there for the asking.
+    assert!(t.wait_frame(|s| s.contains("STATE-B"))?.contains("STATE-B"));
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn one_frame_cannot_satisfy_two_waits() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            r"printf '\033[?2026h\033[2J\033[HONLY-FRAME\033[?2026l'; read guard",
+        ])
+        .spawn("sh")?;
+
+    t.wait_frame(|s| s.contains("ONLY-FRAME"))?;
+    let again = t.wait_frame_for(|s| s.contains("ONLY-FRAME"), Duration::from_millis(700));
+    assert!(
+        matches!(again, Err(Error::Timeout { .. })),
+        "one repaint must not satisfy two waits: {again:?}"
+    );
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The burst is observable in emission order, which means out of order it
+/// is *not*: a frame already returned is behind the cursor.
+#[test]
+fn a_burst_frame_asked_for_out_of_order_is_gone() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(700))
+        .args([
+            "-c",
+            concat!(
+                r"printf '\033[?2026h\033[HSTEP 1\033[?2026l",
+                r"\033[?2026h\033[HSTEP 2\033[?2026l",
+                r"\033[?2026h\033[HSTEP 3\033[?2026l'; read guard"
+            ),
+        ])
+        .spawn("sh")?;
+
+    t.wait_until(|s| s.contains("STEP 3"))?;
+    t.wait_frame(|s| s.contains("STEP 3"))?;
+
+    let backwards = t.wait_frame(|s| s.contains("STEP 1"));
+    assert!(
+        matches!(backwards, Err(Error::Timeout { .. })),
+        "STEP 1 was already passed over: {backwards:?}"
+    );
+    Ok(())
+}
+
+/// `wait_frame` returns the instant the predicate saw, which can differ
+/// from the live grid by the time the call returns.
+#[test]
+fn the_returned_frame_is_the_matched_instant_not_the_live_screen() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            // One complete frame, then unbracketed output that lands after
+            // the frame was published.
+            r"printf '\033[?2026h\033[2J\033[HFRAMED\033[?2026l'; printf '\r\nLIVE'; read guard",
+        ])
+        .spawn("sh")?;
+
+    let frame = t.wait_frame(|s| s.contains("FRAMED"))?;
+    t.wait_until(|s| s.contains("LIVE"))?;
+
+    assert!(
+        !frame.contains("LIVE"),
+        "the returned frame must be the instant the update ended:\n{frame}"
+    );
+    assert!(
+        t.screen().contains("LIVE"),
+        "the live screen has moved on:\n{}",
+        t.screen()
+    );
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// A frame drawn at the old size is not the repaint that answers a
+/// resize, which is what makes the advice in `resize`'s stale-frame trap
+/// hold for `wait_frame`.
+#[test]
+fn a_resize_stops_offering_frames_drawn_at_the_old_size() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_millis(700))
+        .args([
+            "-c",
+            // Paints one frame, then ignores SIGWINCH and never repaints.
+            r"printf '\033[?2026h\033[2J\033[HBEFORE-RESIZE\033[?2026l'; read guard",
+        ])
+        .spawn("sh")?;
+
+    // Deliberately not consumed: this proves the resize moves the cursor,
+    // not that an earlier wait did.
+    t.wait_until(|s| s.contains("BEFORE-RESIZE"))?;
+    t.resize(40, 10)?;
+
+    let stale = t.wait_frame(|s| s.contains("BEFORE-RESIZE"));
+    assert!(
+        matches!(stale, Err(Error::Timeout { .. })),
+        "a pre-resize frame must not answer a post-resize wait: {stale:?}"
+    );
+    Ok(())
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -117,15 +117,30 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
   including multi-mode lists); the reader splits each chunk at every
   frame end and snapshots the screen *at that instant*, so the predicate
   sees exactly the frame as the app finished it — even when the same read
-  already carries the next frame's opening bytes. The last **8**
-  completed frames are retained and each call scans them oldest first, so
-  frames completed before the call are still observable (fast apps can't
-  slip one past the wait) and a burst of frames arriving in one read can
-  be asserted on step by step. Honest caveats: a burst longer than the
-  retention bound drops its oldest frames, and a retained frame stays
-  matchable, so a predicate satisfied by an earlier frame resolves at
-  once rather than waiting for a new one. An app that never emits a
-  synchronized update makes the timeout error say so and point at
+  already carries the next frame's opening bytes. It **returns the frame
+  it matched**, so the assertion lands on the instant the predicate saw
+  rather than on a `screen()` taken afterwards, which can already be a
+  newer state.
+
+  The last **8** completed frames are retained, and each call scans —
+  oldest first — only those *newer than the frame it last returned*. That
+  one cursor gives both properties that matter: a burst arriving in one
+  read is assertable step by step in the order the application drew it
+  (asking backwards fails, so the sequence is enforced rather than
+  merely available), and a frame cannot satisfy two waits. A frame
+  completed before the call but never yet returned *is* still matched —
+  deliberately, so a fast application cannot slip one past you between
+  two waits — but a *superseded* frame no longer can, which is what makes
+  `send(key); wait_frame(old_state)` fail instead of passing on stale
+  content. `resize` advances the cursor too: a frame drawn at the old
+  size is not the repaint that answers the new one.
+
+  Honest caveat: a burst longer than the retention bound drops its
+  oldest frames. A frame is one *completed* update — an End that closes a
+  Begin we saw, so the `?2026l` in a defensive mode-reset string is not a
+  repaint — and a Begin/End pair that changed nothing still counts, since
+  the count is of repaints rather than of changes. An app that never
+  emits a synchronized update makes the timeout error say so and point at
   `wait_until`.
 - `wait_idle(quiet)` — resolves when **no bytes for `quiet`** AND the
   stream does not end mid-escape-sequence (or mid-UTF-8-character) AND no
@@ -205,7 +220,9 @@ clipped old frame still says `tasks (10)` — the wait resolves before
 the app has repainted at all. Wait for something only the
 post-SIGWINCH frame can show — content that needs the new width, a
 complete status bar on the new bottom row — or use `wait_frame` where
-the app emits synchronized updates.
+the app emits synchronized updates, which is now unconditionally safe
+here: `resize` advances the frame cursor, so only a frame completed
+*after* the resize can satisfy the wait.
 
 ### The instant-exit caveat (macOS PTY teardown)
 


### PR DESCRIPTION
Gives `wait_frame` one consumption cursor, and returns the frame it matched.

### Verified before fixing

All three reproductions, against the release commit:

```
#84 repro1 wait_frame(STATE-A) after advance     -> Ok(())      screen right after: "STATE-A"
#84 repro3 wait #1..#4 on ONE frame              -> Ok, Ok, Ok, Ok
#84 repro2 wait_frame(FRAME-1..3) after FRAME-4  -> Ok, Ok, Ok   (live screen: "FRAME-4")
```

After: `Err`, `Ok` then `Err`, `Err` — and repro 1's live screen reads `STATE-B`, which is the whole point.

### One mechanism, not three

The issue proposed a barrier at entry plus consumption. As noted [in the issue](https://github.com/vyncint/termlens/issues/84#issuecomment-5329887913), a strict entry barrier contradicts the burst promise in the very next clause — in a burst, frames 2..N *were* drawn before call #2 — and would break `the_frame_completed_before_the_call_is_evaluated`.

A per-terminal monotonic cursor delivers both. Each call scans, oldest first, only frames newer than the one it last returned:

| | before | after |
|---|---|---|
| superseded frame after `send` | matched | times out |
| burst, asked in emission order | matched | matched |
| burst, asked backwards | matched | times out |
| one frame, four waits | 4 × Ok | 1 × Ok, then times out |
| frame drawn before the call, never returned | matched | **still matches** |

That last row is deliberate and documented as a guarantee rather than a footgun: a fast application must not be able to slip a frame past the test between two waits, which is the reason retention exists.

### Two things beyond the issue

**A resize advances the cursor.** A frame drawn at the old size cannot be the repaint that answers a resize, and `resize`'s rustdoc already advised reaching for `wait_frame` there. Now that advice holds unconditionally instead of depending on whether an earlier wait happened to consume the old frame. Pinned by `a_resize_stops_offering_frames_drawn_at_the_old_size`, which deliberately does *not* consume the pre-resize frame.

**Timeout messages carry the reason, not just the count.** When every frame has already been returned, the old message — `(1 complete frames observed)` — implied the application was repainting and the predicate was wrong. It now says the application has not completed a repaint since the frame last returned, and suggests `wait_until` if it never will. Pluralization fixed while there.

### The return value earns its keep immediately

`a_frame_is_internally_consistent` and `a_torn_repaint_is_never_observed` both used a `Cell`/`Option` captured in the predicate to smuggle the matched screen out. Both are now three lines shorter and read as what they mean:

```rust
let frame = t.wait_frame(|s| s.contains("input: hi"))?;
assert!(frame.contains("last: char:i"), "frame satisfied one row but not its sibling");
```

`the_returned_frame_is_the_matched_instant_not_the_live_screen` pins the divergence directly: the returned frame does not contain output that landed after the update ended, while `screen()` does.

### Breaking change

`wait_frame` / `wait_frame_for` now return `Result<Screen>`. The dominant `t.wait_frame(..)?;` form still compiles unchanged, so the migration is opt-in per call site — but it is a signature change, hence the `!` and the 0.4 milestone.

### Tests

5 new in `frames.rs` (17 total, all green), 3 existing rewritten to the new idiom, 2 existing message expectations updated. `docs/DESIGN.md` §2 and the README rewritten for the cursor. Full suite green in debug, fmt and clippy clean, 13 doctests pass.

Closes #84
