### PR TITLE
docs(waits): say that a snapshot can be a half-painted frame

### DIFF
--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1097,6 +1097,31 @@ impl Terminal {
     ///
     /// Taken under the reader lock: the snapshot is a consistent view of
     /// everything the child had written up to this instant.
+    ///
+    /// # It may be a half-painted frame
+    ///
+    /// "Up to this instant" is the literal truth, and the instant can fall
+    /// **inside** a repaint. An application that brackets every repaint in
+    /// DEC 2026 synchronized updates is no exception: `screen()` returns
+    /// the live grid unconditionally, so if the application has opened an
+    /// update and painted three of its five rows, that is what you get.
+    /// Only [`wait_frame`](Self::wait_frame) is frame-gated, and it is
+    /// frame-gated *because* this is not.
+    ///
+    /// This is deliberate — a torn read is exactly what you want when
+    /// diagnosing an application hung mid-repaint, which is why timeout
+    /// and [`Error::Eof`](crate::Error::Eof) screens keep showing it — but
+    /// it means a whole-screen assertion needs one of:
+    ///
+    /// - the `Screen` returned by [`wait_frame`](Self::wait_frame), for an
+    ///   application that emits synchronized updates: it is the frame the
+    ///   predicate matched, complete by construction;
+    /// - [`wait_idle`](Self::wait_idle) first, which will not call a
+    ///   terminal idle while an update is open (see there) — the "settle
+    ///   before whole-screen snapshots" rule on
+    ///   [`wait_until`](Self::wait_until);
+    /// - or a predicate naming the last thing the application paints, so
+    ///   that its truth implies the repaint finished.
     #[must_use]
     pub fn screen(&self) -> Screen {
         self.shared.lock().snapshot()
@@ -1428,10 +1453,16 @@ impl Terminal {
     ///    snapshotting a whole screen — not on a line drawn midway.
     /// 3. **Settle before whole-screen snapshots**: a snapshot asserts on
     ///    cells no predicate named, so [`wait_idle`](Self::wait_idle)
-    ///    first.
+    ///    first. This is also what keeps such a snapshot from being torn:
+    ///    a predicate here can become true *inside* a repaint, and
+    ///    [`screen`](Self::screen) taken at that moment is half-painted —
+    ///    including for an application that brackets every repaint
+    ///    correctly. `wait_idle` will not declare idleness while an update
+    ///    is open.
     ///
     /// Applications that emit DEC 2026 synchronized updates need none of
-    /// this — [`wait_frame`](Self::wait_frame) sees only complete frames.
+    /// this — [`wait_frame`](Self::wait_frame) sees only complete frames
+    /// and hands back the one it matched.
     /// After a [`resize`](Self::resize), also see the stale-frame trap
     /// documented there.
     ///
@@ -1679,9 +1710,18 @@ impl Terminal {
         }
     }
 
-    /// Block until the terminal has been quiet — no bytes for `quiet` and
-    /// the stream not ending mid-escape-sequence. EOF counts as idle
-    /// (nothing more can arrive).
+    /// Block until the terminal has been quiet — no bytes for `quiet`, the
+    /// stream not ending mid-escape-sequence, and **no synchronized update
+    /// left open**. EOF counts as idle (nothing more can arrive).
+    ///
+    /// That last condition is a guarantee, not an implementation detail: an
+    /// application that has begun a DEC 2026 repaint and not finished it is
+    /// mid-update in exactly the sense a half-received escape sequence is,
+    /// so it is not idle. This is what makes the "settle before
+    /// whole-screen snapshots" rule work — after `wait_idle` returns, a
+    /// [`screen`](Self::screen) snapshot cannot be a torn frame. An
+    /// application that opens an update and never closes it therefore times
+    /// out here, and the error says so.
     ///
     /// This is a heuristic: "no output for N ms" is evidence, not proof,
     /// that the application finished rendering. Prefer
@@ -1737,11 +1777,26 @@ impl Terminal {
 
             let now = Instant::now();
             if now >= deadline {
+                // A terminal that is *silent* but mid-frame would otherwise
+                // time out "waiting for 100ms of output silence", which
+                // reads as nonsense to someone looking at a quiet terminal.
+                // Name the real state: the application is inside a repaint
+                // it never finished.
+                let stuck_mid_frame = guard.emu.in_sync_update();
                 let screen = guard.peek_snapshot();
                 let note = guard.query_note();
                 drop(guard);
+                let waiting_for = if stuck_mid_frame {
+                    format!(
+                        "{quiet:?} of output silence — the application is inside an \
+                         unfinished DEC 2026 synchronized update (Begin with no End), so \
+                         the screen below is a half-painted frame{note}"
+                    )
+                } else {
+                    format!("{quiet:?} of output silence{note}")
+                };
                 return Err(Error::Timeout {
-                    waiting_for: format!("{quiet:?} of output silence{note}"),
+                    waiting_for,
                     timeout,
                     screen,
                 });

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -75,14 +75,19 @@ fn apps_without_synchronized_output_time_out_with_guidance() {
     // hello-tui never emits DEC 2026.
     let mut t = Terminal::builder()
         .size(80, 24)
-        .timeout(Duration::from_millis(500))
+        // Generous default: the fixture's first paint is not what is under
+        // test here, and on a loaded runner it can take a while. The
+        // deadline that matters is the per-call one below.
+        .timeout(Duration::from_secs(10))
         .env_clear()
         .spawn(util::fixture_bin("hello-tui"))
         .unwrap();
     t.wait_until(|s| s.contains("╯")).unwrap();
 
     let start = Instant::now();
-    let err = t.wait_frame(|_| true).unwrap_err();
+    let err = t
+        .wait_frame_for(|_| true, Duration::from_millis(500))
+        .unwrap_err();
     assert!(start.elapsed() >= Duration::from_millis(500));
 
     let msg = err.to_string();
@@ -440,4 +445,68 @@ fn a_resize_stops_offering_frames_drawn_at_the_old_size() -> termlens::Result<()
         "a pre-resize frame must not answer a post-resize wait: {stale:?}"
     );
     Ok(())
+}
+
+/// `screen()` is the live grid even for an application that brackets
+/// every repaint — the tear is real, documented, and wanted for
+/// diagnosis. `wait_frame`'s return value is the frame-consistent read.
+#[test]
+fn a_snapshot_can_be_mid_frame_for_a_synchronized_application() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                // Frame OPEN, one of two rows painted.
+                r"printf '\033[?2026h\033[2J\033[HROW-ONE'; read a; ",
+                // Second row, then the frame closes.
+                r"printf '\033[2;1HROW-TWO\033[?2026l'; read b"
+            ),
+        ])
+        .spawn("sh")?;
+
+    t.wait_until(|s| s.contains("ROW-ONE"))?;
+    let torn = t.screen();
+    assert!(torn.contains("ROW-ONE"), "row 0 is painted:\n{torn}");
+    assert!(
+        torn.row_text(1).trim_end().is_empty(),
+        "the frame is not finished, and screen() says so:\n{torn}"
+    );
+
+    t.send(Key::Enter);
+    // The frame-consistent read has both rows, by construction.
+    let frame = t.wait_frame(|s| s.contains("ROW-TWO"))?;
+    assert!(
+        frame.contains("ROW-ONE") && frame.contains("ROW-TWO"),
+        "{frame}"
+    );
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// A terminal that is silent *because* it is stuck mid-repaint used to
+/// time out "waiting for 100ms of output silence", which reads as
+/// nonsense next to a quiet terminal.
+#[test]
+fn a_wait_idle_timeout_names_an_unfinished_frame() {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_millis(600))
+        .args(["-c", r"printf '\033[?2026hhalf a frame'; read guard"])
+        .spawn("sh")
+        .unwrap();
+    t.wait_until(|s| s.contains("half a frame")).unwrap();
+
+    let err = t.wait_idle(Duration::from_millis(100)).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unfinished DEC 2026 synchronized update"),
+        "the real state must be named: {msg}"
+    );
+    assert!(
+        msg.contains("half-painted frame"),
+        "and what the embedded screen is: {msg}"
+    );
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -158,6 +158,35 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
 `Drop` kills + reaps the child unconditionally (unless already reaped):
 tests never leak zombies, including on panic.
 
+### `screen()` is the live grid, frames or no frames
+
+`wait_frame` is the only frame-gated observation in the crate. `screen()`
+returns the grid as it stands, and "as it stands" can be **inside** a
+repaint — for an application that brackets every repaint in DEC 2026
+exactly as intended, just as much as for one that never heard of
+synchronized output. Open an update, paint row 1, and a snapshot taken
+there has row 1 and nothing else. The application did everything right
+and still gets the pre-2026 failure mode.
+
+This is deliberate, and the alternative is worse. Serving the newest
+*complete* frame from `screen()` while an update is open would mean that
+a `wait_until` predicate could match content the following `screen()`
+does not show — the predicate reads the live grid, so it sees the
+half-painted row that the substituted frame lacks. Disagreeing with your
+own predicate is a nastier failure than tearing. And the torn read is
+positively wanted in one case: an application hung mid-repaint is
+diagnosed by seeing the half-painted grid, which is why timeout and
+`Error::Eof` screens keep showing it.
+
+So the honest answer is three routes to a frame-consistent screen, each
+matching a way of waiting:
+
+| you waited with | use |
+|---|---|
+| `wait_frame` | the `Screen` it returns — the matched frame, complete by construction |
+| `wait_until` | `wait_idle` after it (no idleness while an update is open), then `screen()` |
+| neither | a predicate naming the last thing the app paints, so its truth implies the repaint finished |
+
 ### The three rules for race-free waits
 
 `wait_until(pred)` guarantees exactly one thing: every byte up to and


### PR DESCRIPTION
Documents the tear, states the guarantee that already existed, and makes a mid-frame hang self-diagnosing. **No new API.**

### Verified before writing

The tear reproduces exactly as the issue describes:

```
#85 mid-frame row0="ROW-ONE" row1=""
```

And — the finding that reshaped this PR — `wait_idle` **already** refuses to declare idleness while an update is open (`terminal.rs`, and `frames::wait_idle_does_not_resolve_inside_an_open_synchronized_update` has been pinning it since 0.2). Probed it to confirm: with a frame open and the application silent, `wait_idle_for(100ms, 900ms)` times out. So the third rule already documented on `wait_until` — "settle before whole-screen snapshots" — already yields a frame-consistent read. Nobody wrote that down, which is why this issue proposed building it. Recorded [in the issue](https://github.com/vyncint/termlens/issues/85#issuecomment-5329892089).

### Why neither proposed option was built

- A `TerminalBuilder` setting would make `screen()`'s meaning depend on configuration.
- A third screen accessor would sit next to `screen()` and `wait_frame`'s new return value — three ways to get a `Screen` where two already cover the two ways of waiting.

And the substitution itself is worse than the tear: serving the newest *complete* frame from `screen()` while an update is open would let a `wait_until` predicate match content the following `screen()` does not show, because the predicate reads the live grid and sees the half-painted row the substituted frame lacks. **Disagreeing with your own predicate is a nastier failure than tearing.** The torn read is also positively wanted when diagnosing an application hung mid-repaint — which is why timeout and `Eof` screens keep showing it, as the issue asks.

### What shipped

**Documentation, in the three places a reader looks.** `screen()` gains a "It may be a half-painted frame" section; `wait_until`'s rule 3 gains the reason; `docs/DESIGN.md` §2 gains a subsection with the trade-off and a table of the three routes to a frame-consistent screen, one per way of waiting:

| you waited with | use |
|---|---|
| `wait_frame` | the `Screen` it returns — complete by construction |
| `wait_until` | `wait_idle` after it, then `screen()` |
| neither | a predicate naming the last thing the app paints |

**`wait_idle`'s guarantee, stated.** It is now a promise in the rustdoc: no idleness while a synchronized update is open, because a begun-and-unfinished repaint is mid-update in the same sense a half-received escape sequence is.

**One diagnostic.** An application stuck mid-frame is silent, so it used to time out "waiting for 100ms of output silence" — nonsense next to a quiet terminal. Now:

```
timed out after 600ms while waiting for 100ms of output silence — the application
is inside an unfinished DEC 2026 synchronized update (Begin with no End), so the
screen below is a half-painted frame
```

That is the "harder edge" case in the issue: the mid-frame hang diagnoses itself.

### Tests

- `a_snapshot_can_be_mid_frame_for_a_synchronized_application` — the issue's reproduction, asserting the tear *and* that `wait_frame`'s returned frame has both rows.
- `a_wait_idle_timeout_names_an_unfinished_frame`

Also decouples the initial-paint wait in `apps_without_synchronized_output_time_out_with_guidance` from the 500 ms deadline its timing assertion needs — it hit that budget once on this machine under load, and the two extra spawns this PR adds to the suite make it likelier. The per-call deadline that v0.3 added is exactly the right tool.

19 tests green in `frames.rs` (3 consecutive runs), full suite green, clippy and fmt clean.

Closes #85
