### PR TITLE
feat(screen): capture OSC 52 clipboard writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ chords, and cursor keys are encoded exactly as the application
 configured its terminal (SGR mouse, bracketed paste, DECCKM) — because
 the emulator knows which modes the app enabled. The same knowledge is
 readable from every `Screen`: the window title, the alternate-screen
-flag, and the input modes are plain accessors, so "did the app enter the
-alt screen?" is an assertion, not an inference.
+flag, the input modes and the last `OSC 52` clipboard write are plain
+accessors, so "did the app enter the alt screen?" and "did it copy the
+right text?" are assertions, not inferences.
 
 Screens are immutable snapshots taken under the same
 lock the reader writes through, so every assertion sees a consistent

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -20,10 +20,66 @@
 
 use std::sync::Arc;
 
+use crate::screen::Clipboard;
+
 /// OSC strings are captured whole (titles must not truncate), but bounded:
 /// a buggy or hostile stream must not grow memory without limit. No real
 /// title comes anywhere near this.
-const OSC_CAPTURE_MAX: usize = 4096;
+const OSC_CAPTURE_MAX: usize = 64 * 1024;
+
+/// Decode standard base64 (`OSC 52` payloads). `None` for anything that is
+/// not valid: an out-of-alphabet byte, a bad length, or padding in the
+/// wrong place. Returning `None` rather than a best effort is the point —
+/// a partially decoded clipboard would be indistinguishable from a
+/// correct one, and a test asserting on it would pass while proving
+/// nothing.
+fn decode_base64(input: &[u8]) -> Option<Vec<u8>> {
+    fn value(b: u8) -> Option<u32> {
+        match b {
+            b'A'..=b'Z' => Some(u32::from(b - b'A')),
+            b'a'..=b'z' => Some(u32::from(b - b'a') + 26),
+            b'0'..=b'9' => Some(u32::from(b - b'0') + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+
+    // Padding is optional in the wild but must be trailing and must not
+    // exceed two bytes; what remains has to be a whole number of quanta.
+    let body = input.strip_suffix(b"==").map_or_else(
+        || input.strip_suffix(b"=").unwrap_or(input),
+        |stripped| stripped,
+    );
+    let pad = input.len() - body.len();
+    if pad > 0 && input.len() % 4 != 0 {
+        return None;
+    }
+    if body.len() % 4 == 1 {
+        return None; // one leftover character encodes nothing
+    }
+
+    let mut out = Vec::with_capacity(body.len() / 4 * 3 + 2);
+    for quantum in body.chunks(4) {
+        let mut bits = 0u32;
+        for &b in quantum {
+            bits = (bits << 6) | value(b)?;
+        }
+        // A short final quantum carries 1 or 2 bytes; shift it up to a
+        // full 24-bit group and keep only the bytes it actually encodes.
+        let carried = match quantum.len() {
+            4 => 3,
+            3 => 2,
+            _ => 1,
+        };
+        bits <<= 6 * (4 - quantum.len());
+        for i in 0..carried {
+            #[allow(clippy::cast_possible_truncation)]
+            out.push((bits >> (16 - 8 * i)) as u8);
+        }
+    }
+    Some(out)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum State {
@@ -133,9 +189,16 @@ pub(crate) struct SeqTracker {
     /// Content bytes of the current OSC string (no `ESC ]`, no
     /// terminator), kept whole so titles never truncate.
     osc_buf: Vec<u8>,
+    /// Set when the current OSC string hit [`OSC_CAPTURE_MAX`]. What was
+    /// captured is then a prefix, and a prefix of base64 can still decode —
+    /// to the wrong thing. Reporting the truncation is the only honest
+    /// option, so it is tracked rather than inferred.
+    osc_truncated: bool,
     /// The window title as most recently set via `OSC 0`/`OSC 2`; empty
     /// until the application sets one. Shared so snapshots clone for free.
     title: Arc<str>,
+    /// The most recent `OSC 52` clipboard write, decoded.
+    clipboard: Option<Arc<Clipboard>>,
 }
 
 impl SeqTracker {
@@ -156,7 +219,9 @@ impl SeqTracker {
             seq_buf: [0; 24],
             seq_len: 0,
             osc_buf: Vec::new(),
+            osc_truncated: false,
             title: Arc::from(""),
+            clipboard: None,
         }
     }
 
@@ -174,6 +239,12 @@ impl SeqTracker {
     /// True while the stream is inside a DEC 2026 synchronized update.
     pub(crate) fn in_sync_update(&self) -> bool {
         self.sync_update
+    }
+
+    /// The most recent `OSC 52` clipboard write, or `None` if the
+    /// application has not copied anything.
+    pub(crate) fn clipboard(&self) -> Option<Arc<Clipboard>> {
+        self.clipboard.clone()
     }
 
     /// The window title as most recently set via `OSC 0`/`OSC 2` (empty
@@ -204,6 +275,8 @@ impl SeqTracker {
     fn push_osc(&mut self, b: u8) {
         if self.osc_buf.len() < OSC_CAPTURE_MAX {
             self.osc_buf.push(b);
+        } else {
+            self.osc_truncated = true;
         }
     }
 
@@ -365,6 +438,28 @@ impl SeqTracker {
                         .or_else(|| content.strip_prefix(b"2;"))
                     {
                         self.title = Arc::from(String::from_utf8_lossy(title));
+                    } else if let Some(rest) = content.strip_prefix(b"52;") {
+                        // OSC 52 write: `targets ; base64`. The reads were
+                        // classified above, so anything here is a write.
+                        // Captured rather than answered — "did it copy the
+                        // right thing?" is otherwise unanswerable, since the
+                        // only evidence a test can see is the app's own
+                        // toast, which proves the code path ran and nothing
+                        // about the payload.
+                        //
+                        // Base64 has no `;`, so the first one is the
+                        // separator. No separator at all is not a write.
+                        if let Some(sep) = rest.iter().position(|&b| b == b';') {
+                            let targets = String::from_utf8_lossy(&rest[..sep]).into_owned();
+                            let payload = &rest[sep + 1..];
+                            let text = if self.osc_truncated {
+                                None
+                            } else {
+                                decode_base64(payload)
+                                    .and_then(|bytes| String::from_utf8(bytes).ok())
+                            };
+                            self.clipboard = Some(Arc::new(Clipboard::new(&targets, text)));
+                        }
                     }
                     return SeqEvent::None;
                 }
@@ -417,6 +512,7 @@ impl SeqTracker {
                 }
                 b']' => {
                     self.osc_buf.clear();
+                    self.osc_truncated = false;
                     State::Osc
                 }
                 // DCS, SOS, PM, APC — string sequences terminated by ST.
@@ -603,6 +699,91 @@ mod tests {
         assert!(!t.in_sync_update());
         t.feed(b"\x1b[?20260h"); // different mode number
         assert!(!t.in_sync_update());
+    }
+
+    #[test]
+    fn base64_decodes_or_refuses() {
+        assert_eq!(
+            decode_base64(b"dGhlIHRpdGxl").as_deref(),
+            Some(&b"the title"[..])
+        );
+        // Every padding shape.
+        assert_eq!(decode_base64(b"YQ==").as_deref(), Some(&b"a"[..]));
+        assert_eq!(decode_base64(b"YWI=").as_deref(), Some(&b"ab"[..]));
+        assert_eq!(decode_base64(b"YWJj").as_deref(), Some(&b"abc"[..]));
+        // Unpadded is common in the wild and unambiguous.
+        assert_eq!(decode_base64(b"YQ").as_deref(), Some(&b"a"[..]));
+        assert_eq!(decode_base64(b"YWI").as_deref(), Some(&b"ab"[..]));
+        // A real write of nothing.
+        assert_eq!(decode_base64(b"").as_deref(), Some(&b""[..]));
+
+        // Refusals: out of alphabet, impossible length, misplaced padding.
+        assert_eq!(decode_base64(b"not base64!"), None);
+        assert_eq!(decode_base64(b"YWJjZ"), None);
+        assert_eq!(decode_base64(b"Y===="), None);
+        // One leftover character encodes nothing.
+        assert_eq!(decode_base64(b"Y"), None);
+    }
+
+    #[test]
+    fn osc52_writes_are_captured_with_their_target() {
+        let t = fed(b"\x1b]52;c;V2lyZSB1cCB0aGUgUFRZIHJlYWRlcg==\x07");
+        let clip = t.clipboard().expect("a write was observed");
+        assert_eq!(clip.targets(), "c");
+        assert_eq!(clip.text(), Some("Wire up the PTY reader"));
+
+        // Primary selection, ST-terminated instead of BEL.
+        let t = fed(b"\x1b]52;p;c2VsZWN0ZWQgd29yZHM=\x1b\\");
+        let clip = t.clipboard().expect("a write was observed");
+        assert_eq!(clip.targets(), "p");
+        assert_eq!(clip.text(), Some("selected words"));
+
+        // No target named: the terminal would pick its default, and we
+        // report what the application actually sent rather than guessing.
+        let t = fed(b"\x1b]52;;Y29waWVk\x07");
+        assert_eq!(t.clipboard().expect("write").targets(), "");
+
+        // The most recent write wins.
+        let t = fed(b"\x1b]52;c;YQ==\x07\x1b]52;c;YWI=\x07");
+        assert_eq!(t.clipboard().expect("write").text(), Some("ab"));
+    }
+
+    #[test]
+    fn an_undecodable_payload_is_not_an_empty_clipboard() {
+        // The distinction the whole feature rests on: a test asserting
+        // `text() == Some("")` must not pass on a payload we could not read.
+        let empty = fed(b"\x1b]52;c;\x07");
+        assert_eq!(empty.clipboard().expect("write").text(), Some(""));
+
+        let broken = fed(b"\x1b]52;c;!!!not base64!!!\x07");
+        assert_eq!(broken.clipboard().expect("write").text(), None);
+        assert_eq!(broken.clipboard().expect("write").targets(), "c");
+
+        // Valid base64 that is not text.
+        let not_utf8 = fed(b"\x1b]52;c;//8=\x07");
+        assert_eq!(not_utf8.clipboard().expect("write").text(), None);
+    }
+
+    #[test]
+    fn a_payload_past_the_capture_bound_is_reported_as_unreadable() {
+        // A prefix of base64 can still decode — to the wrong thing. Any
+        // truncation must therefore read as "could not decode".
+        let mut stream = b"\x1b]52;c;".to_vec();
+        stream.extend(std::iter::repeat_n(b'A', OSC_CAPTURE_MAX + 64));
+        stream.push(0x07);
+        let t = fed(&stream);
+        assert_eq!(t.clipboard().expect("write").text(), None);
+    }
+
+    #[test]
+    fn a_clipboard_read_is_a_query_not_a_write() {
+        let mut t = SeqTracker::new();
+        let events: Vec<SeqEvent> = b"\x1b]52;c;?\x07".iter().map(|&b| t.step(b)).collect();
+        assert!(matches!(
+            events.last(),
+            Some(SeqEvent::Query(Query::Unanswerable(_)))
+        ));
+        assert!(t.clipboard().is_none(), "a read must not invent a write");
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -64,6 +64,7 @@ impl Emulator for Vt100Emulator {
             bracketed_paste: screen.bracketed_paste(),
             application_cursor: screen.application_cursor(),
             mouse: convert_mouse(screen.mouse_protocol_mode()),
+            clipboard: self.tracker.clipboard(),
         };
         Screen::from_parts(
             cols,

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -71,7 +71,7 @@ mod wait;
 
 pub use error::{Error, Result};
 pub use keys::{Chord, Input, Key};
-pub use screen::{Cell, Color, MouseMode, Screen, Style};
+pub use screen::{Cell, Clipboard, Color, MouseMode, Screen, Style};
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{ExitStatus, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder};

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -66,6 +66,50 @@ pub enum MouseMode {
     AnyMotion,
 }
 
+/// What an application copied with `OSC 52`, as observed at one snapshot.
+///
+/// Read it from a snapshot via [`Screen::clipboard`]. A toast on screen
+/// proves the copy path ran; this proves the payload, which is usually the
+/// behaviour actually under test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Clipboard {
+    targets: Arc<str>,
+    text: Option<Arc<str>>,
+}
+
+impl Clipboard {
+    pub(crate) fn new(targets: &str, text: Option<String>) -> Self {
+        Self {
+            targets: Arc::from(targets),
+            text: text.map(Arc::from),
+        }
+    }
+
+    /// The copied text, or `None` when the payload was not usable text.
+    ///
+    /// `None` means the application sent something termlens could not
+    /// decode: base64 with invalid characters or a broken length, bytes
+    /// that are not valid UTF-8, or a payload past the capture bound. It is
+    /// deliberately distinct from `Some("")`, which is a real write of
+    /// nothing — the way an application clears the clipboard.
+    #[must_use]
+    pub fn text(&self) -> Option<&str> {
+        self.text.as_deref()
+    }
+
+    /// The selections written to, exactly as the application named them:
+    /// `c` (clipboard), `p` (primary), `q`, `s`, or `0`–`7`, in any
+    /// combination — an application writing to the wrong one is a real bug
+    /// worth catching.
+    ///
+    /// Empty means the application named none, in which case a real
+    /// terminal picks its default (xterm: clipboard *and* primary).
+    #[must_use]
+    pub fn targets(&self) -> &str {
+        &self.targets
+    }
+}
+
 /// Out-of-band terminal state captured with each snapshot. Deliberately
 /// invisible in the text rendering (existing snapshot files stay valid);
 /// exposed through the accessors on [`Screen`].
@@ -76,6 +120,9 @@ pub(crate) struct TermState {
     pub(crate) bracketed_paste: bool,
     pub(crate) application_cursor: bool,
     pub(crate) mouse: MouseMode,
+    /// Behind an `Arc` deliberately: `Screen` is embedded in every
+    /// `Error` and cloned on every wait, so its size is load-bearing.
+    pub(crate) clipboard: Option<Arc<Clipboard>>,
 }
 
 impl Default for TermState {
@@ -86,6 +133,7 @@ impl Default for TermState {
             bracketed_paste: false,
             application_cursor: false,
             mouse: MouseMode::None,
+            clipboard: None,
         }
     }
 }
@@ -255,6 +303,31 @@ impl Screen {
     #[must_use]
     pub fn mouse_mode(&self) -> MouseMode {
         self.state.mouse
+    }
+
+    /// The most recent `OSC 52` clipboard write observed at this snapshot,
+    /// or `None` if the application has not copied anything yet.
+    ///
+    /// Snapshot state, so it follows snapshot rules: the value is what the
+    /// clipboard held at this observation, which makes a
+    /// [`wait_frame`](crate::Terminal::wait_frame) or
+    /// [`wait_until`](crate::Terminal::wait_until) predicate over a
+    /// clipboard write well-defined.
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.wait_until(|s| s.clipboard().is_some_and(|c| c.text() == Some("the title")))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Clipboard *reads* (`OSC 52 ; c ; ?`) are a different sequence and
+    /// are not answered: they stay named in timeout errors, so an
+    /// application blocked on one is diagnosed rather than left hanging.
+    #[must_use]
+    pub fn clipboard(&self) -> Option<&Clipboard> {
+        self.state.clipboard.as_deref()
     }
 
     /// The cell at `(row, col)`, or `None` when out of bounds.
@@ -856,6 +929,7 @@ mod tests {
         assert!(!default.bracketed_paste());
         assert!(!default.application_cursor());
         assert_eq!(default.mouse_mode(), MouseMode::None);
+        assert!(default.clipboard().is_none());
 
         let state = TermState {
             title: Arc::from("my app"),
@@ -863,12 +937,15 @@ mod tests {
             bracketed_paste: true,
             application_cursor: true,
             mouse: MouseMode::AnyMotion,
+            clipboard: Some(Arc::new(Clipboard::new("c", Some("copied".into())))),
         };
         let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
         let s = Screen::from_parts(1, 1, 0, 0, true, cells, state);
         assert_eq!(s.title(), "my app");
         assert!(s.alternate_screen() && s.bracketed_paste() && s.application_cursor());
         assert_eq!(s.mouse_mode(), MouseMode::AnyMotion);
+        let clip = s.clipboard().expect("captured");
+        assert_eq!((clip.targets(), clip.text()), ("c", Some("copied")));
         // Out-of-band state never leaks into the text format.
         assert_eq!(format!("{s}"), "size: 1x1  cursor: 0,0\nx");
     }

--- a/crates/termlens/tests/state.rs
+++ b/crates/termlens/tests/state.rs
@@ -1,5 +1,6 @@
-//! Out-of-band terminal state on `Screen`: title, alternate screen, and
-//! the input modes — asserted directly instead of inferred from the grid.
+//! Out-of-band terminal state on `Screen`: title, alternate screen, the
+//! input modes and the `OSC 52` clipboard — asserted directly instead of
+//! inferred from the grid.
 
 use std::time::Duration;
 
@@ -71,6 +72,65 @@ fn mouse_mode_reports_the_exact_tracking_mode() -> termlens::Result<()> {
     t.wait_until(|s| s.contains("1000") && s.mouse_mode() == MouseMode::PressRelease)?;
     t.send(Key::Enter);
     t.wait_until(|s| s.contains("1003") && s.mouse_mode() == MouseMode::AnyMotion)?;
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn a_clipboard_write_is_observable_with_its_payload() -> termlens::Result<()> {
+    // The taskboard case from the coverage study: `y` copies the selected
+    // title and paints a toast. The toast proves the code path ran; the
+    // payload is the behaviour under test.
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(5))
+        .args([
+            "-c",
+            concat!(
+                r"printf '\033]52;c;V2lyZSB1cCB0aGUgUFRZIHJlYWRlcg==\007'; ",
+                r"printf 'copied to clipboard'; read guard"
+            ),
+        ])
+        .spawn("/bin/sh")?;
+
+    // Assertable in a predicate, because it is snapshot state.
+    t.wait_until(|s| {
+        s.clipboard()
+            .is_some_and(|c| c.text() == Some("Wire up the PTY reader"))
+    })?;
+
+    let s = t.screen();
+    let clip = s.clipboard().expect("the write was captured");
+    assert_eq!(clip.text(), Some("Wire up the PTY reader"));
+    assert_eq!(clip.targets(), "c");
+    // And the base64 never reached the grid.
+    assert!(
+        !s.contains("V2lyZSB1cCB0"),
+        "the escape leaked into the grid:\n{s}"
+    );
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn an_unreadable_clipboard_payload_is_reported_as_such() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(5))
+        .args([
+            "-c",
+            r"printf '\033]52;p;not~valid~base64\007'; printf 'done'; read guard",
+        ])
+        .spawn("/bin/sh")?;
+
+    t.wait_until(|s| s.contains("done"))?;
+    let s = t.screen();
+    let clip = s.clipboard().expect("a write was still observed");
+    // Distinguishable from an empty clipboard, which is the point.
+    assert_eq!(clip.text(), None);
+    assert_eq!(clip.targets(), "p");
+
     t.send(Key::Enter);
     assert!(t.wait_exit()?.success());
     Ok(())

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -71,6 +71,19 @@ would close a loop on itself: the application concludes the terminal has
 no mouse, never enables tracking, and `click` then refuses, blaming the
 application for a decision we caused.
 
+`OSC 52` is the one sequence we **capture** rather than answer. A write
+(`OSC 52 ; targets ; base64`) is not a question, and the only evidence a
+test could otherwise see is the application's own toast — which proves the
+code path ran and nothing about the payload, when the payload is the
+behaviour under test. So the decoded most-recent write lands on the
+snapshot (`Screen::clipboard`), with the target selections exactly as the
+application named them, since writing to the wrong one is a real bug. A
+payload we cannot decode — bad base64, not UTF-8, or past the capture
+bound — reports as `None` and never as `Some("")`: a test asserting an
+empty clipboard must not pass on something we failed to read. Clipboard
+*reads* (`OSC 52 ; … ; ?`) are questions, and stay named-but-unanswered
+like the rest.
+
 Precision: the emulator stops consuming at each query byte (the same
 mechanism as frame boundaries), so a cursor-position report reflects the
 cursor *at the query*, not after later output in the same chunk moved


### PR DESCRIPTION
Captures `OSC 52` writes onto the snapshot, so "did it copy the right thing?" is answerable.

```rust
t.wait_until(|s| s.clipboard().is_some_and(|c| c.text() == Some("Wire up the PTY reader")))?;

let clip = t.screen().clipboard().expect("captured");
assert_eq!(clip.text(),    Some("Wire up the PTY reader"));
assert_eq!(clip.targets(), "c");
```

### Capture, not answer

`Screen::clipboard() -> Option<&Clipboard>`, with `text()` and `targets()`. Targets are reported exactly as the application named them — `c`, `p`, `q`, `s`, `0`–`7`, in any combination, and empty when it named none — because writing to the primary selection when it meant the clipboard is a real bug, and substituting a default would hide it.

### The three details the issue said decide trustworthiness

**An undecodable payload is not an empty clipboard.** `text()` returns `None` for bad base64, for bytes that are not UTF-8, and for a payload past the capture bound; `Some("")` means a real write of nothing, which is how an application *clears* the clipboard. A test asserting an empty clipboard must not pass on something we failed to read.

**Truncation is tracked, not inferred.** This is the part that would have been easy to get quietly wrong: a *prefix* of base64 still decodes, just to the wrong text. So `OSC_CAPTURE_MAX` now records that it was hit, and any truncated payload reports as unreadable. The bound rose from 4 KiB to 64 KiB — enough for realistic clipboard payloads, still bounded, and the buffer is per-terminal.

**Reads stay unanswered.** `OSC 52 ; c ; ?` is a question and keeps its existing named-but-unanswered handling, so an application blocked on one is still diagnosed. Answering it would mean handing back whatever a previous write stored; deferred as the issue permits, and `a_clipboard_read_is_a_query_not_a_write` pins that a read does not invent a write.

### Implementation notes

Captured in `SeqTracker` alongside the existing `OSC 0`/`OSC 2` title tracking rather than through vt100's `Callbacks::copy_to_clipboard`, which also exists: the tracker is backend-independent, so this keeps working if the emulator behind the internal trait is ever swapped, and it keeps all OSC handling in one place.

The base64 decoder is twenty lines of table lookup in-crate — no dependency for that — and it **refuses rather than guessing**: out-of-alphabet bytes, impossible lengths and misplaced padding all return `None`. Unpadded input is accepted since it is common in the wild and unambiguous.

`TermState`'s clipboard sits behind an `Arc`. Without it, the extra 32 bytes pushed `Screen` — embedded in every `Error` and cloned on every wait — over clippy's `result_large_err` threshold. Boxing keeps `Screen` small and clones cheap.

### Tests

Unit (`emu::seq`): `base64_decodes_or_refuses` (every padding shape, unpadded, and four refusals), `osc52_writes_are_captured_with_their_target` (BEL and ST terminators, empty target, most-recent-wins), `an_undecodable_payload_is_not_an_empty_clipboard`, `a_payload_past_the_capture_bound_is_reported_as_unreadable`, `a_clipboard_read_is_a_query_not_a_write`.

Integration (`state`): `a_clipboard_write_is_observable_with_its_payload` — the taskboard case from the study, using the study's exact base64, asserting the text, the target, *and* that the escape never reached the grid. Plus `an_unreadable_clipboard_payload_is_reported_as_such`.

Full suite green (17 suites), 14 doctests, fmt and clippy clean. `docs/DESIGN.md` §1 explains why this one sequence is captured rather than answered.

Closes #82
