### PR TITLE
feat(screen)!: add strikethrough, blink and conceal to Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ design. termlens's position:
   of output and is exact: the condition either becomes true or you get a
   screen-carrying timeout. The three rules for race-free waits (and the
   resize stale-frame trap) are in [docs/DESIGN.md](docs/DESIGN.md) §2.
+- **Styles are complete enough to catch a masked field.** `Style` carries
+  `blink`, `conceal` and `strikethrough` alongside the usual attributes, so
+  a test asserting that a password field is masked fails against an
+  application that prints the secret in clear — the two are identical text.
 - **`wait_frame` gives exact frame boundaries** for apps that bracket
   repaints in DEC 2026 synchronized updates (crossterm's
   `BeginSynchronizedUpdate`/`EndSynchronizedUpdate`): the predicate only

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -3,9 +3,12 @@
 //! The public types ([`Screen`](crate::Screen) et al.) are termlens's own;
 //! the VT emulator sits behind this small internal trait so the backend can
 //! be swapped (e.g. for `wezterm-term` or `alacritty_terminal`) without any
-//! public API change. One backend ships today: the `vt100` crate.
+//! public API change. One backend ships today: the `vt100` crate, plus the
+//! attribute shadow in `shadow.rs` that recovers the three SGR attributes
+//! vt100 drops.
 
 mod seq;
+mod shadow;
 mod vt100;
 
 pub(crate) use self::seq::Query;

--- a/crates/termlens/src/emu/shadow.rs
+++ b/crates/termlens/src/emu/shadow.rs
@@ -41,6 +41,12 @@
 //! someone else's code carried permanently to hold an 80-line patch. When
 //! upstream gains the attributes, this module deletes and `convert_cell`
 //! reads the three flags directly.
+//!
+//! Cost: one extra visible grid (no scrollback — history is text-only) and a
+//! second parse pass. Not measurable end to end, since a terminal's
+//! throughput is dominated by the PTY round trip rather than by parsing —
+//! 40,000 lines through an 80x24 screen took 260ms with this and 263ms
+//! without, and 284ms vs 282ms when every line carries four SGR sequences.
 
 /// Where the rewriter is in the byte stream. Only enough to recognize a
 /// complete plain SGR; everything else passes through untouched.

--- a/crates/termlens/src/emu/shadow.rs
+++ b/crates/termlens/src/emu/shadow.rs
@@ -1,0 +1,350 @@
+//! Recovering the three SGR attributes `vt100` drops.
+//!
+//! `vt100` 0.16's `Attrs` is `{ fgcolor, bgcolor, mode: u8 }` and its SGR
+//! dispatch handles only `0 1 2 3 4 7 22 23 24 27` plus the colour params.
+//! `5`/`6` (blink), `8` (conceal) and `9` (strikethrough), and their resets
+//! `25`/`28`/`29`, never reach a cell — so three distinct renderings collapse
+//! into one value, and a test asserting that a password field is masked
+//! **passes against an application that prints the secret in clear**. That is
+//! the one failure mode in this crate where a green test certifies the bug it
+//! was written to catch.
+//!
+//! The fix is a second `vt100::Parser` fed the same byte stream with only SGR
+//! sequences rewritten, so three attributes vt100 *does* keep act as carriers
+//! for the three it drops:
+//!
+//! | dropped        | carrier     | off      |
+//! |----------------|-------------|----------|
+//! | `5`/`6` blink  | `1` bold    | `25`→`22`|
+//! | `8` conceal    | `3` italic  | `28`→`23`|
+//! | `9` strike     | `4` underline | `29`→`24`|
+//!
+//! Every other SGR parameter is dropped from the shadow stream, so nothing
+//! else can disturb a carrier.
+//!
+//! **Why this is sound rather than clever.** In vt100, attributes never
+//! influence geometry: `Attrs` is read in exactly two places — as the fill
+//! value for `clear`/`erase`, and by the escape-code *output* functions.
+//! Cursor movement, wrapping, scrolling, tabs and cell placement are entirely
+//! attribute-independent, and SGR sequences never move the cursor. So a stream
+//! that differs only by the replacement of complete plain-SGR sequences
+//! produces an identically-shaped grid, and shadow cell `(r, c)` is primary
+//! cell `(r, c)`. A debug assertion checks that correspondence on every
+//! snapshot rather than leaving it to argument.
+//!
+//! This is deliberately *not* the option the issue behind this ruled out:
+//! nothing here attributes styles to cells by hand. vt100 does the
+//! attribution, twice — so there is no second cursor, no duplicated wrap,
+//! scroll-region or alternate-screen logic, and nothing to diverge quietly.
+//!
+//! The honest alternative was vendoring a patched vt100: 3,950 lines of
+//! someone else's code carried permanently to hold an 80-line patch. When
+//! upstream gains the attributes, this module deletes and `convert_cell`
+//! reads the three flags directly.
+
+/// Where the rewriter is in the byte stream. Only enough to recognize a
+/// complete plain SGR; everything else passes through untouched.
+#[derive(Debug, PartialEq, Eq)]
+enum State {
+    Ground,
+    Esc,
+    Csi,
+}
+
+/// A parallel `vt100::Parser` carrying blink, conceal and strikethrough.
+pub(super) struct AttrShadow {
+    parser: ::vt100::Parser,
+    state: State,
+    /// Bytes held back while this might be a plain SGR. Always emitted in
+    /// the end — rewritten if it is one, verbatim if it is not — so the
+    /// shadow can never lose a byte that shapes the grid.
+    pending: Vec<u8>,
+}
+
+impl AttrShadow {
+    pub(super) fn new(rows: u16, cols: u16) -> Self {
+        Self {
+            // No scrollback: history is text-only, so the shadow is needed
+            // for the visible grid alone.
+            parser: ::vt100::Parser::new(rows, cols, 0),
+            state: State::Ground,
+            pending: Vec::new(),
+        }
+    }
+
+    pub(super) fn set_size(&mut self, rows: u16, cols: u16) {
+        self.parser.screen_mut().set_size(rows, cols);
+    }
+
+    /// The shadow cell at `(row, col)`, whose bold/italic/underline flags are
+    /// the primary's blink/conceal/strikethrough.
+    pub(super) fn cell(&self, row: u16, col: u16) -> Option<&::vt100::Cell> {
+        self.parser.screen().cell(row, col)
+    }
+
+    /// Text of the shadow grid, for the correspondence check in `snapshot`.
+    /// Not gated on `debug_assertions`: `debug_assert_eq!` still type-checks
+    /// (and compiles) its arguments in release, where the branch is then
+    /// eliminated.
+    pub(super) fn contents(&self) -> String {
+        self.parser.screen().contents()
+    }
+
+    pub(super) fn feed(&mut self, bytes: &[u8]) {
+        let shadowed = self.rewrite_stream(bytes);
+        self.parser.process(&shadowed);
+    }
+
+    /// The shadow form of `bytes`: identical except that complete plain SGR
+    /// sequences are replaced by their carrier form. Held-back bytes carry
+    /// over to the next call, so a sequence split across chunks is neither
+    /// lost nor half-applied.
+    fn rewrite_stream(&mut self, bytes: &[u8]) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+        for &b in bytes {
+            // An ESC anywhere abandons whatever was being collected and
+            // starts a new sequence, so the held bytes were not an SGR.
+            if b == 0x1b {
+                out.append(&mut self.pending);
+                self.pending.push(b);
+                self.state = State::Esc;
+                continue;
+            }
+            match self.state {
+                State::Ground => out.push(b),
+                State::Esc => {
+                    self.pending.push(b);
+                    if b == b'[' {
+                        self.state = State::Csi;
+                    } else {
+                        out.append(&mut self.pending);
+                        self.state = State::Ground;
+                    }
+                }
+                State::Csi => {
+                    self.pending.push(b);
+                    match b {
+                        // Parameter and intermediate bytes: keep collecting.
+                        0x20..=0x3f => {}
+                        // Final byte: an SGR is rewritten, anything else
+                        // passes through.
+                        0x40..=0x7e => {
+                            let seq = std::mem::take(&mut self.pending);
+                            self.state = State::Ground;
+                            match (b == b'm').then(|| rewrite_sgr(&seq)).flatten() {
+                                Some(rewritten) => out.extend_from_slice(&rewritten),
+                                None => out.extend_from_slice(&seq),
+                            }
+                        }
+                        // A control byte inside a CSI (CAN, SUB, …). vte
+                        // decides what that means; passing the bytes through
+                        // unchanged means the shadow cannot diverge, at the
+                        // cost of not rewriting this one sequence.
+                        _ => {
+                            out.append(&mut self.pending);
+                            self.state = State::Ground;
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Rewrite one complete `ESC [ … m` into the carrier form.
+///
+/// `None` means "not a plain SGR — emit it verbatim": a private prefix
+/// (`?`, `<`, `=`, `>`) or an intermediate byte makes it something else, and
+/// guessing there is how a rewriter loses bytes that shape the grid.
+/// `Some(bytes)` is what to emit, and may be empty when every parameter was
+/// dropped.
+fn rewrite_sgr(seq: &[u8]) -> Option<Vec<u8>> {
+    // `ESC [ … m`
+    let params = seq.get(2..seq.len().checked_sub(1)?)?;
+    if params
+        .iter()
+        .any(|b| !matches!(b, b'0'..=b'9' | b';' | b':'))
+    {
+        return None;
+    }
+
+    /// The value vte would report for a parameter group: its first
+    /// sub-parameter, with an empty group meaning zero.
+    fn value(group: &[u8]) -> u32 {
+        let first = group.split(|&b| b == b':').next().unwrap_or(b"");
+        // Saturating: a parameter longer than u32 is not one we map.
+        first.iter().fold(0u32, |acc, &d| {
+            acc.saturating_mul(10).saturating_add(u32::from(d - b'0'))
+        })
+    }
+
+    let groups: Vec<&[u8]> = params.split(|&b| b == b';').collect();
+    let mut out: Vec<u32> = Vec::new();
+    let mut i = 0;
+    while i < groups.len() {
+        let group = groups[i];
+        let v = value(group);
+        match v {
+            // Extended colour. Its sub-parameters must be stepped over, or
+            // the `5` in `38;5;196` reads as blink and paints a whole line
+            // of text with an attribute the application never set.
+            38 | 48 | 58 => {
+                if group.contains(&b':') {
+                    // Colon form (`38:2::r:g:b`) is one self-contained group.
+                    i += 1;
+                } else {
+                    i += match groups.get(i + 1).map(|g| value(g)) {
+                        Some(2) => 5, // 38;2;r;g;b
+                        Some(5) => 3, // 38;5;n
+                        _ => 1,       // malformed; skip the introducer only
+                    };
+                }
+            }
+            _ => {
+                if let Some(carrier) = carrier(v) {
+                    out.push(carrier);
+                }
+                i += 1;
+            }
+        }
+    }
+
+    let mut bytes = Vec::new();
+    if !out.is_empty() {
+        bytes.extend_from_slice(b"\x1b[");
+        for (n, param) in out.iter().enumerate() {
+            if n > 0 {
+                bytes.push(b';');
+            }
+            bytes.extend_from_slice(param.to_string().as_bytes());
+        }
+        bytes.push(b'm');
+    }
+    Some(bytes)
+}
+
+/// The shadow parameter carrying `param`, if any.
+fn carrier(param: u32) -> Option<u32> {
+    match param {
+        0 => Some(0),     // reset all: means the same in both streams
+        5 | 6 => Some(1), // blink (slow, rapid) -> bold
+        8 => Some(3),     // conceal -> italic
+        9 => Some(4),     // strikethrough -> underline
+        25 => Some(22),   // blink off -> normal intensity
+        28 => Some(23),   // conceal off -> italic off
+        29 => Some(24),   // strikethrough off -> underline off
+        _ => None,        // everything else belongs to the primary alone
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The real rewriter's output, as a readable string.
+    fn shadowed(bytes: &[u8]) -> String {
+        let mut shadow = AttrShadow::new(4, 20);
+        let mut out = shadow.rewrite_stream(bytes);
+        // Anything still held at the end of the stream is not an SGR.
+        out.append(&mut shadow.pending);
+        String::from_utf8_lossy(&out).replace('\x1b', "E")
+    }
+
+    #[test]
+    fn the_three_dropped_attributes_get_carriers() {
+        assert_eq!(shadowed(b"\x1b[5mX"), "E[1mX"); // blink -> bold
+        assert_eq!(shadowed(b"\x1b[6mX"), "E[1mX"); // rapid blink too
+        assert_eq!(shadowed(b"\x1b[8mX"), "E[3mX"); // conceal -> italic
+        assert_eq!(shadowed(b"\x1b[9mX"), "E[4mX"); // strike -> underline
+        assert_eq!(shadowed(b"\x1b[25m"), "E[22m");
+        assert_eq!(shadowed(b"\x1b[28m"), "E[23m");
+        assert_eq!(shadowed(b"\x1b[29m"), "E[24m");
+    }
+
+    #[test]
+    fn the_primarys_own_attributes_are_dropped_from_the_shadow() {
+        // Otherwise a real bold would read as a blink.
+        assert_eq!(shadowed(b"\x1b[1mX"), "X");
+        assert_eq!(shadowed(b"\x1b[3mX"), "X");
+        assert_eq!(shadowed(b"\x1b[4mX"), "X");
+        assert_eq!(shadowed(b"\x1b[7;31;44mX"), "X");
+        // …including the resets, which would clear a carrier.
+        assert_eq!(shadowed(b"\x1b[22m\x1b[23m\x1b[24m\x1b[27m"), "");
+        // Reset-all means the same in both streams.
+        assert_eq!(shadowed(b"\x1b[0mX"), "E[0mX");
+        assert_eq!(shadowed(b"\x1b[mX"), "E[0mX");
+    }
+
+    #[test]
+    fn mixed_parameters_keep_only_the_carriers_in_order() {
+        assert_eq!(shadowed(b"\x1b[1;5;31mX"), "E[1mX");
+        assert_eq!(shadowed(b"\x1b[0;9;1;8mX"), "E[0;4;3mX");
+    }
+
+    #[test]
+    fn an_extended_colour_never_looks_like_a_carrier() {
+        // The trap: the `5` in `38;5;196` selects palette mode, not blink.
+        // Reading it as blink would paint a whole run with an attribute the
+        // application never set.
+        assert_eq!(shadowed(b"\x1b[38;5;196mX"), "X");
+        assert_eq!(shadowed(b"\x1b[48;5;9mX"), "X");
+        assert_eq!(shadowed(b"\x1b[38;2;255;0;8mX"), "X"); // the 8 is blue, not conceal
+        assert_eq!(shadowed(b"\x1b[38;2;0;9;0;5mX"), "E[1mX"); // …trailing 5 IS blink
+                                                               // Colon form is one self-contained parameter group.
+        assert_eq!(shadowed(b"\x1b[38:5:196mX"), "X");
+        assert_eq!(shadowed(b"\x1b[38:2::255:0:9mX"), "X");
+        assert_eq!(shadowed(b"\x1b[4:3mX"), "X"); // curly underline, not strike
+                                                  // A carrier still survives alongside one.
+        assert_eq!(shadowed(b"\x1b[38;5;196;9mX"), "E[4mX");
+    }
+
+    #[test]
+    fn anything_that_is_not_a_plain_sgr_passes_through_verbatim() {
+        // Byte-for-byte passthrough is what keeps the shadow's geometry
+        // identical to the primary's: only complete plain SGRs are touched.
+        for seq in [
+            &b"\x1b[?2026h"[..],
+            &b"\x1b[2J"[..],
+            &b"\x1b[H"[..],
+            &b"\x1b[3;7Hhi"[..],
+            &b"\x1b[?25l"[..],
+            &b"\x1b[>4;2m"[..], // private-prefix 'm': XTMODKEYS, not SGR
+            &b"\x1b[4$p"[..],   // intermediate byte
+            &b"\x1b]0;title\x07"[..],
+            &b"\x1b7\x1b8"[..],
+            &b"plain text\r\n\t"[..],
+        ] {
+            assert_eq!(
+                shadowed(seq),
+                String::from_utf8_lossy(seq).replace('\x1b', "E"),
+                "sequence {:?} must pass through untouched",
+                String::from_utf8_lossy(seq)
+            );
+        }
+    }
+
+    #[test]
+    fn a_sequence_split_across_feeds_is_not_lost() {
+        let mut shadow = AttrShadow::new(2, 10);
+        shadow.feed(b"\x1b[8");
+        // Mid-sequence: nothing applied yet, exactly as the primary sees it.
+        assert!(!shadow.cell(0, 0).is_some_and(::vt100::Cell::italic));
+        shadow.feed(b"mX");
+        assert!(
+            shadow.cell(0, 0).is_some_and(::vt100::Cell::italic),
+            "the conceal carrier must survive a chunk boundary"
+        );
+    }
+
+    #[test]
+    fn an_aborted_csi_keeps_its_bytes() {
+        // CAN inside a CSI: vte decides what it means, and passing the bytes
+        // through unchanged is what guarantees we cannot diverge.
+        assert_eq!(shadowed(b"\x1b[31\x18X"), "E[31\u{18}X");
+        // A fresh sequence afterwards is still rewritten.
+        assert_eq!(shadowed(b"\x1b[31\x18\x1b[9mX"), "E[31\u{18}E[4mX");
+        // An ESC inside a CSI abandons it and starts over.
+        assert_eq!(shadowed(b"\x1b[31\x1b[9mX"), "E[31E[4mX");
+    }
+}

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -5,12 +5,17 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use super::seq::{SeqEvent, SeqTracker};
+use super::shadow::AttrShadow;
 use super::{Emulator, InputModes, ModeState, MouseEncoding, Processed, Stop};
 use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
 
 pub(crate) struct Vt100Emulator {
     parser: ::vt100::Parser,
     tracker: SeqTracker,
+    /// Carries blink, conceal and strikethrough, which vt100 drops. See
+    /// `emu/shadow.rs` for why this is a second parser rather than
+    /// hand-rolled attribute tracking.
+    shadow: AttrShadow,
     /// How many rows of history to retain (0 disables it entirely).
     scrollback_len: usize,
     /// Rows that have scrolled off the top, oldest first, as text.
@@ -30,6 +35,7 @@ impl Vt100Emulator {
         Self {
             parser: ::vt100::Parser::new(rows, cols, scrollback_len),
             tracker: SeqTracker::new(),
+            shadow: AttrShadow::new(rows, cols),
             scrollback_len,
             history: VecDeque::new(),
             captured: 0,
@@ -116,6 +122,7 @@ impl Emulator for Vt100Emulator {
             };
             if let Some(stop) = stop {
                 self.parser.process(&bytes[..=i]);
+                self.shadow.feed(&bytes[..=i]);
                 self.capture_scrolled_rows();
                 return Processed {
                     consumed: i + 1,
@@ -124,6 +131,7 @@ impl Emulator for Vt100Emulator {
             }
         }
         self.parser.process(bytes);
+        self.shadow.feed(bytes);
         self.capture_scrolled_rows();
         Processed {
             consumed: bytes.len(),
@@ -135,13 +143,21 @@ impl Emulator for Vt100Emulator {
         let screen = self.parser.screen();
         let (rows, cols) = screen.size();
         let mut cells = Vec::with_capacity(usize::from(rows) * usize::from(cols));
+        // The shadow grid is the same shape as the primary — vt100's
+        // attributes never influence geometry, and the two streams differ
+        // only by rewritten SGR — so cell (row, col) means the same in both.
+        debug_assert_eq!(
+            screen.contents(),
+            self.shadow.contents(),
+            "the attribute shadow diverged from the primary grid"
+        );
         for row in 0..rows {
             for col in 0..cols {
                 // In-range lookups on vt100 are always Some; blank fallback
                 // keeps this total rather than panicking inside a snapshot.
                 cells.push(screen.cell(row, col).map_or_else(
                     || Cell::new(String::new(), Style::default(), false, false),
-                    convert_cell,
+                    |cell| convert_cell(cell, self.shadow.cell(row, col)),
                 ));
             }
         }
@@ -244,6 +260,7 @@ impl Emulator for Vt100Emulator {
 
     fn set_size(&mut self, rows: u16, cols: u16) {
         self.parser.screen_mut().set_size(rows, cols);
+        self.shadow.set_size(rows, cols);
         // A resize can push rows into history on its own.
         self.capture_scrolled_rows();
     }
@@ -259,7 +276,10 @@ fn convert_mouse(mode: ::vt100::MouseProtocolMode) -> MouseMode {
     }
 }
 
-fn convert_cell(cell: &::vt100::Cell) -> Cell {
+/// Build a [`Cell`] from the primary grid cell and its shadow counterpart,
+/// whose bold/italic/underline flags are this cell's
+/// blink/conceal/strikethrough (see `emu/shadow.rs`).
+fn convert_cell(cell: &::vt100::Cell, shadow: Option<&::vt100::Cell>) -> Cell {
     let style = Style {
         fg: convert_color(cell.fgcolor()),
         bg: convert_color(cell.bgcolor()),
@@ -268,6 +288,9 @@ fn convert_cell(cell: &::vt100::Cell) -> Cell {
         italic: cell.italic(),
         underline: cell.underline(),
         reverse: cell.inverse(),
+        blink: shadow.is_some_and(::vt100::Cell::bold),
+        conceal: shadow.is_some_and(::vt100::Cell::italic),
+        strikethrough: shadow.is_some_and(::vt100::Cell::underline),
     };
     Cell::new(
         cell.contents().to_owned(),
@@ -331,6 +354,86 @@ mod tests {
         assert!(style.bold && style.italic && style.underline && style.reverse);
         assert_eq!(style.fg, Color::Indexed(1));
         assert_eq!(screen.cell(0, 1).unwrap().style(), &Style::default());
+    }
+
+    #[test]
+    fn blink_conceal_and_strikethrough_reach_the_cells() {
+        // The three attributes vt100 drops. Recovered via the shadow parser
+        // (see `emu/shadow.rs`).
+        let emu = emu_with(b"\x1b[5mB\x1b[0m\x1b[8mC\x1b[0m\x1b[9mS\x1b[0mp");
+        let s = emu.snapshot();
+        let style = |col| *s.cell(0, col).unwrap().style();
+
+        assert!(style(0).blink && !style(0).conceal && !style(0).strikethrough);
+        assert!(style(1).conceal && !style(1).blink && !style(1).strikethrough);
+        assert!(style(2).strikethrough && !style(2).blink && !style(2).conceal);
+        // And a plain cell after the reset carries none of them.
+        assert_eq!(style(3), Style::default());
+    }
+
+    #[test]
+    fn the_new_attributes_coexist_with_the_old_ones() {
+        // A real bold must not read as a blink, and vice versa: the two
+        // parsers must not leak into each other.
+        let emu = emu_with(b"\x1b[1;31mA\x1b[0m\x1b[5mB\x1b[0m\x1b[1;5;4mC");
+        let s = emu.snapshot();
+        let a = *s.cell(0, 0).unwrap().style();
+        assert!(a.bold && !a.blink);
+        assert_eq!(a.fg, Color::Indexed(1));
+
+        let b = *s.cell(0, 1).unwrap().style();
+        assert!(b.blink && !b.bold);
+
+        let c = *s.cell(0, 2).unwrap().style();
+        assert!(c.bold && c.blink && c.underline && !c.strikethrough);
+    }
+
+    #[test]
+    fn each_attribute_has_its_own_reset() {
+        let emu = emu_with(b"\x1b[5;8;9mX\x1b[25mY\x1b[28mZ\x1b[29mW");
+        let s = emu.snapshot();
+        let style = |col| *s.cell(0, col).unwrap().style();
+
+        let x = style(0);
+        assert!(x.blink && x.conceal && x.strikethrough);
+        let y = style(1);
+        assert!(!y.blink && y.conceal && y.strikethrough);
+        let z = style(2);
+        assert!(!z.blink && !z.conceal && z.strikethrough);
+        assert_eq!(style(3), Style::default());
+    }
+
+    #[test]
+    fn a_palette_colour_is_never_mistaken_for_an_attribute() {
+        // `38;5;196` selects palette entry 196. Reading its `5` as blink
+        // would mark a whole run with an attribute the application never
+        // set — and 256-colour output is everywhere.
+        let emu = emu_with(b"\x1b[38;5;196mX\x1b[0m\x1b[38;2;0;8;9mY");
+        let s = emu.snapshot();
+        let x = *s.cell(0, 0).unwrap().style();
+        assert_eq!(x.fg, Color::Indexed(196));
+        assert!(!x.blink && !x.conceal && !x.strikethrough);
+
+        let y = *s.cell(0, 1).unwrap().style();
+        assert_eq!(y.fg, Color::Rgb(0, 8, 9));
+        assert!(!y.conceal && !y.strikethrough);
+    }
+
+    #[test]
+    fn attributes_survive_the_geometry_the_shadow_must_track() {
+        // Erase fills cells with the current attributes, scrolling moves
+        // rows, and the alternate screen swaps grids. The shadow follows the
+        // same byte stream, so all three must line up — the snapshot's
+        // debug assertion checks the grids match on every call here.
+        let emu = emu_with(b"\x1b[8mmasked\r\nrow2\r\nrow3\r\nrow4\r\nrow5");
+        let s = emu.snapshot();
+        // "masked" scrolled off; every remaining cell is still concealed.
+        assert!(s.cell(0, 0).unwrap().style().conceal, "{s}");
+        assert!(s.cell(3, 0).unwrap().style().conceal, "{s}");
+
+        let emu = emu_with(b"\x1b[9mstruck\x1b[?1049hALT");
+        let s = emu.snapshot();
+        assert!(s.cell(0, 0).unwrap().style().strikethrough, "{s}");
     }
 
     #[test]

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -40,6 +40,20 @@ pub struct Style {
     pub underline: bool,
     /// Reverse video (foreground and background swapped).
     pub reverse: bool,
+    /// Blinking (`SGR 5`/`6`; the two rates are not distinguished).
+    pub blink: bool,
+    /// Concealed: the cell holds text the terminal does not display
+    /// (`SGR 8`) — a masked password field, typically.
+    ///
+    /// This is the attribute worth checking explicitly. Without it, a test
+    /// asserting that a field is masked passes just as happily against an
+    /// application that printed the secret in clear, because the two
+    /// renderings are identical in the grid. [`Screen::cell`] still reports
+    /// the underlying text, exactly as a real terminal holds it — what
+    /// changes is that you can now tell the difference.
+    pub conceal: bool,
+    /// Struck through (`SGR 9`).
+    pub strikethrough: bool,
 }
 
 /// Which mouse events the application asked its terminal to report.
@@ -670,12 +684,18 @@ impl Style {
         let mut tokens = Vec::new();
         color("fg", self.fg, &mut tokens);
         color("bg", self.bg, &mut tokens);
+        // SGR order, which is the order the existing tokens were already
+        // in — so a cell's tokens are unchanged unless it carries one of
+        // the new attributes.
         for (on, name) in [
             (self.bold, "bold"),
             (self.dim, "dim"),
             (self.italic, "italic"),
             (self.underline, "underline"),
+            (self.blink, "blink"),
             (self.reverse, "reverse"),
+            (self.conceal, "conceal"),
+            (self.strikethrough, "strikethrough"),
         ] {
             if on {
                 tokens.push(name.to_owned());

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -46,13 +46,21 @@ fn undelivered_replies_are_named_in_the_diagnosis() {
     let mut t = Terminal::builder()
         .size(80, 24)
         .env_clear()
-        .timeout(Duration::from_millis(600))
+        .timeout(Duration::from_secs(10))
         .args(["-c", FLOOD])
         .spawn("/bin/sh")
         .expect("spawn");
 
+    // Let the whole flood land first. The child prints DONE *after* its
+    // last query, so once that is on screen the drain has read every
+    // reply-generating byte and the queue has long since overflowed. Racing
+    // a wall-clock deadline against the flood instead would make this test
+    // sensitive to how fast the reader thread happens to be.
+    t.wait_until(|s| s.contains("DONE"))
+        .expect("the drain kept running");
+
     let err = t
-        .wait_until(|s| s.contains("never-appears"))
+        .wait_until_for(|s| s.contains("never-appears"), Duration::from_millis(200))
         .expect_err("the predicate can never hold");
     let message = err.to_string();
     assert!(matches!(err, Error::Timeout { .. }), "got: {err}");

--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -57,3 +57,73 @@ fn styled_screen_snapshot() -> termlens::Result<()> {
     assert!(t.wait_exit()?.success());
     Ok(())
 }
+
+/// The trap this exists to close. A test asserting that a password field is
+/// masked used to pass just as happily against an application that printed
+/// the secret in clear, because `SGR 8` reached nothing and the two
+/// renderings were identical in the grid — the one failure mode where a
+/// green test certifies the bug it was written to catch.
+#[test]
+fn a_masked_field_is_distinguishable_from_clear_text() -> termlens::Result<()> {
+    let mut masked = sh(r"printf 'pw: \033[8mhunter2\033[28m|'; read guard")?;
+    masked.wait_until(|s| s.contains("pw: hunter2|"))?;
+    let a = masked.screen();
+    masked.send(Key::Enter);
+    masked.wait_exit()?;
+
+    let mut clear = sh(r"printf 'pw: hunter2|'; read guard")?;
+    clear.wait_until(|s| s.contains("pw: hunter2|"))?;
+    let b = clear.screen();
+    clear.send(Key::Enter);
+    clear.wait_exit()?;
+
+    // Identical text — a real terminal holds the characters either way, and
+    // so does termlens. That is why `text()` cannot tell them apart.
+    assert_eq!(a.text(), b.text());
+
+    // The assertion a test author actually wants, and could not write:
+    let secret_is_masked =
+        |s: &termlens::Screen| (4..11).all(|col| s.cell(0, col).is_some_and(|c| c.style().conceal));
+    assert!(
+        secret_is_masked(&a),
+        "the field is masked:\n{}",
+        a.with_styles()
+    );
+    assert!(
+        !secret_is_masked(&b),
+        "and clear text must fail the same assertion:\n{}",
+        b.with_styles()
+    );
+
+    // The styled rendering separates them too, which is what makes a
+    // snapshot test catch this.
+    assert_ne!(a.with_styles().to_string(), b.with_styles().to_string());
+    Ok(())
+}
+
+#[test]
+fn strikethrough_and_blink_appear_in_the_styled_rendering() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf 'done \033[9mship it\033[29m ",
+        r"\033[5;31moverdue\033[0m plain'; read guard"
+    ))?;
+    t.wait_until(|s| s.contains("plain"))?;
+    let s = t.screen();
+    let styled = s.with_styles().to_string();
+
+    // Tokens are emitted in SGR order, so the existing ones keep their
+    // places and the new ones slot in around `reverse`.
+    assert!(styled.contains("strikethrough"), "{styled}");
+    assert!(styled.contains("blink"), "{styled}");
+    assert!(styled.contains("fg=1"), "{styled}");
+
+    // A blinking red badge is no longer indistinguishable from a plain red
+    // one — the tie `with_styles()` could not break.
+    let overdue = s.find("overdue").expect("painted");
+    let badge = *s.cell(overdue.0, overdue.1).unwrap().style();
+    assert!(badge.blink && badge.fg == termlens::Color::Indexed(1));
+
+    t.send(Key::Enter);
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -368,7 +368,10 @@ Rules:
    0-based column range (`start-end`, or just `start` for one column)
    followed by style tokens in fixed order: `fg=`, `bg=` (indexed colors
    as decimal, RGB as `#rrggbb`), then `bold`, `dim`, `italic`,
-   `underline`, `reverse`. Default-styled spans are omitted entirely —
+   `underline`, `blink`, `reverse`, `conceal`, `strikethrough` — SGR order,
+   which is the order the original five were already in, so an existing
+   span's tokens are unchanged unless the cell carries one of the three
+   attributes added in 0.4. Default-styled spans are omitted entirely —
    absence means default — so a highlight moving rows diffs as exactly
    two lines. A fully default-styled screen renders `styles:` followed by
    `(none)`, so the snapshot itself records that styles were asserted.
@@ -406,10 +409,57 @@ But it is an implementation detail:
   the terminal loop needs, so candidate backends (wezterm-term for wider
   escape coverage, alacritty_terminal for fidelity to a real terminal's
   quirks) can be evaluated behind a feature flag without touching layer 3+.
-- Known vt100 limits we accept in v0.2: no scrollback assertions (parser
-  runs with scrollback 0), no reflow of scrollback on resize, cluster
+- Known vt100 limits: no reflow of scrollback on resize, and cluster
   handling for exotic emoji is whatever vt100 does (pinned by the
   unicode-torture snapshot rather than promised).
+
+### The attribute shadow
+
+vt100 0.16's `Attrs` is `{ fgcolor, bgcolor, mode: u8 }` and its SGR
+dispatch handles only `0 1 2 3 4 7 22 23 24 27` plus the colour params.
+`5`/`6` (blink), `8` (conceal), `9` (strikethrough) and their resets never
+reach a cell. That is not a missing nicety: **a test asserting that a
+password field is masked passes against an application that prints the
+secret in clear**, because the two renderings are identical in the grid and
+`with_styles()` cannot break the tie either. It is the one place in this
+crate where a green test certifies the bug it was written to catch.
+
+Upstream is the right home for the fix — three spare bits are sitting in
+`mode: u8` — but 0.16.2 (July 2025) is the newest release, `Attrs` has no
+public setter reachable from `Callbacks::unhandled_csi`, and a published
+crate cannot carry a `[patch.crates.io]`. So the three attributes are
+recovered from **a second `vt100::Parser` fed the same byte stream with
+only SGR sequences rewritten**, so that three attributes vt100 does keep
+act as carriers for the three it drops (`5`/`6`→`1`, `8`→`3`, `9`→`4`, with
+`25`/`28`/`29` mapped to the matching resets and every other parameter
+dropped from the shadow stream).
+
+This is sound for a reason that can be checked rather than hoped for: **in
+vt100, attributes never influence geometry.** `Attrs` is read in exactly
+two places — as the fill value for `clear`/`erase`, and by the escape-code
+*output* functions. Cursor movement, wrapping, scrolling, tabs and cell
+placement are attribute-independent, and SGR sequences never move the
+cursor. So a stream differing only by the replacement of complete plain-SGR
+sequences produces an identically-shaped grid, and shadow cell `(r, c)` is
+primary cell `(r, c)`. A debug assertion compares the two grids on every
+snapshot, so the whole test suite checks the invariant instead of taking it
+on trust.
+
+Note what this deliberately is *not*: nothing here attributes styles to
+cells by hand. vt100 does the attribution, twice — so there is no second
+cursor, no duplicated wrap, scroll-region or alternate-screen logic, and
+nothing to diverge quietly. The alternative considered and rejected was
+vendoring a patched vt100: 3,950 lines of someone else's code carried
+permanently, in a crate whose value is being reviewable, to hold an
+80-line patch. The rewriter's one real trap is that the `5` in `38;5;196`
+selects palette mode rather than blink, so extended-colour parameters are
+stepped over in both the semicolon and colon forms; anything that is not a
+plain SGR (private prefix, intermediate byte, aborted sequence) passes
+through byte-for-byte, which is what makes "cannot diverge" true rather
+than merely likely.
+
+When upstream gains the attributes, `emu/shadow.rs` deletes and
+`convert_cell` reads the three flags directly.
 
 ## 5. Environment policy
 


### PR DESCRIPTION
Closes the one place in this crate where a green test certifies the bug it was written to catch.

```rust
let secret_is_masked = |s: &Screen| (4..11).all(|c| s.cell(0, c).unwrap().style().conceal);
assert!(secret_is_masked(&masked));
assert!(!secret_is_masked(&clear));   // ← this assertion was impossible before
```

### Verified, including the issue's correction of the study

Read vt100 0.16.2 directly. `Attrs` uses five of eight bits (`INTENSITY` 2, `ITALIC`, `UNDERLINE`, `INVERSE`) and the SGR dispatch handles exactly `0 1 2 3 4 7 22 23 24 27` plus colours. `5`, `6`, `8`, `9`, `25`, `28`, `29` fall through. Three spare bits, three missing attributes — the issue is right, and the study's "vt100 already exposes them" is wrong.

Also checked, because it would have changed the design: vt100's final SGR arm is `_ => unhandled(self)` **without** `return`, so an unknown parameter is skipped and the rest of the sequence still applies. `CSI 1;5;31m` does get its red. No rewriting of the primary stream needed.

### Not vendoring — a second parser instead

Upstream is the right home and worth a PR, but it cannot ship this release: 0.16.2 (July 2025) is the newest, `Attrs` has no public setter reachable from `Callbacks::unhandled_csi`, and a published crate cannot carry `[patch.crates.io]`.

Rather than the fallback the issue proposed — vendoring 3,950 lines of someone else's code, permanently, to hold an 80-line patch, in a crate whose value is being reviewable — this feeds a **second `vt100::Parser` the same byte stream with only SGR rewritten**, so three attributes vt100 keeps carry the three it drops:

| dropped | carrier | off |
|---|---|---|
| `5`/`6` blink | `1` bold | `25` → `22` |
| `8` conceal | `3` italic | `28` → `23` |
| `9` strikethrough | `4` underline | `29` → `24` |

Every other parameter is dropped from the shadow stream, so nothing else can disturb a carrier.

**Why this is sound rather than clever, and checkable rather than argued.** In vt100, attributes never influence geometry: `Attrs` is read as the fill value for `clear`/`erase` and by the escape-code *output* functions, nowhere else. Cursor movement, wrapping, scrolling, tabs and cell placement are attribute-independent, and SGR never moves the cursor. So a stream differing only by replaced complete plain-SGR sequences produces an identically-shaped grid, and shadow cell `(r, c)` is primary cell `(r, c)`.

A `debug_assert_eq!` compares the two grids on **every snapshot**, so the entire test suite — 18 suites including the unicode-torture fixture, alt-screen, resize and scrollback tests — checks the invariant rather than taking it on trust. It passed on the first run.

This is explicitly **not** the option the issue rules out. Nothing here attributes styles to cells by hand: vt100 does the attribution, twice. No second cursor, no duplicated wrap, scroll-region or alternate-screen logic, nothing to diverge quietly. Cost is one extra visible grid (the shadow gets zero scrollback, since history is text-only) and a second parse pass.

### The rewriter's one real trap

The `5` in `38;5;196` selects palette mode, not blink — and 256-colour output is everywhere, so misreading it would mark whole runs with an attribute the application never set. Extended-colour parameters are stepped over in both the semicolon form (`38;5;n`, `38;2;r;g;b`) and the colon form (`38:2::r:g:b`, one self-contained group). Pinned by `an_extended_colour_never_looks_like_a_carrier`, including the case where a trailing `5` after a full RGB triple *is* blink.

Anything that is not a plain SGR passes through byte for byte — private prefix (`CSI >4;2m` is XTMODKEYS), intermediate bytes, an aborted CSI, an ESC mid-sequence, or a sequence split across chunk boundaries. That is what makes "cannot diverge" true rather than merely likely, and each case is a test.

### Breaking change

`Style` gains three public fields, so struct literals need updating (`..Style::default()` keeps working). `with_styles()` emits the new tokens in **SGR order** — `bold dim italic underline blink reverse conceal strikethrough` — which is the order the original five were already in, so an existing span's tokens are unchanged unless the cell carries one of the three. `docs/DESIGN.md` §3 updated as the spec it is.

### Tests

- `emu::shadow` (7): carriers, primary attributes dropped, mixed parameters, the extended-colour trap, verbatim passthrough for ten non-SGR shapes, split-across-feeds, aborted CSI. The helper drives the **real** rewriter, not a copy of it.
- `emu::vt100` (5): the three attributes on cells, coexistence with the real bold/italic/underline, per-attribute resets, palette colours, and survival across scrolling and the alternate screen.
- `styles` (2): `a_masked_field_is_distinguishable_from_clear_text` — the trap inverted, asserting identical `text()` and *different* conceal flags; and `strikethrough_and_blink_appear_in_the_styled_rendering`, which also settles the blinking-red-badge tie `with_styles()` could not break.

Green in **debug and release**, clippy clean in both, doc build clean with `-D warnings`.

Closes #81

### One unrelated test made deterministic

`drain::undelivered_replies_are_named_in_the_diagnosis` failed once on a loaded ubuntu runner in this PR's first CI run. It gave the reply queue 600 ms to overflow while a thousand queries arrived — a race between the flood and a wall-clock deadline.

It is not a slowdown from the shadow: measured end to end, the second parse pass costs nothing, because a terminal's throughput is dominated by the PTY round trip rather than by parsing.

| 40,000 lines, 80×24 | with shadow | without |
|---|---|---|
| plain text | 260 ms | 263 ms |
| four SGR sequences per line | 284 ms | 282 ms |

So this was a latent race that a busy runner exposed. Fixed properly rather than re-tuned: the child prints `DONE` *after* its last query, so waiting for that means the drain has read every reply-generating byte and the queue has long since overflowed. The assertion no longer depends on how fast the reader thread happens to be, and the failing wait uses a short per-call deadline so the test stays quick.
