### PR TITLE
test(styles): settle before comparing whole-screen snapshots

### DIFF
--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -22,14 +22,22 @@ fn list_with_highlight(row: u16) -> String {
 
 #[test]
 fn moving_a_highlight_changes_the_styled_rendering_only() -> termlens::Result<()> {
+    // Both snapshots are whole-screen, so both need the third rule from
+    // `wait_until`'s own docs: settle first. `contains("item two")` becomes
+    // true before the newline *after* it is processed, and the cursor then
+    // sits at (1, 8) instead of (2, 0) — state the predicate never named but
+    // that `Display` renders, so comparing two of them without settling is a
+    // race. Found by the stress gate at iteration 17 of 100.
     let mut first = sh(&list_with_highlight(0))?;
     first.wait_until(|s| s.contains("item two"))?;
+    first.wait_idle(Duration::from_millis(50))?;
     let a = first.screen();
     first.send(Key::Enter);
     first.wait_exit()?;
 
     let mut second = sh(&list_with_highlight(1))?;
     second.wait_until(|s| s.contains("item two"))?;
+    second.wait_idle(Duration::from_millis(50))?;
     let b = second.screen();
     second.send(Key::Enter);
     second.wait_exit()?;
@@ -65,14 +73,19 @@ fn styled_screen_snapshot() -> termlens::Result<()> {
 /// green test certifies the bug it was written to catch.
 #[test]
 fn a_masked_field_is_distinguishable_from_clear_text() -> termlens::Result<()> {
+    // Settled for the same reason as above, and one more: the styled
+    // comparison below asserts a *difference*, so an incidental cursor
+    // difference would let it pass without the styles differing at all.
     let mut masked = sh(r"printf 'pw: \033[8mhunter2\033[28m|'; read guard")?;
     masked.wait_until(|s| s.contains("pw: hunter2|"))?;
+    masked.wait_idle(Duration::from_millis(50))?;
     let a = masked.screen();
     masked.send(Key::Enter);
     masked.wait_exit()?;
 
     let mut clear = sh(r"printf 'pw: hunter2|'; read guard")?;
     clear.wait_until(|s| s.contains("pw: hunter2|"))?;
+    clear.wait_idle(Duration::from_millis(50))?;
     let b = clear.screen();
     clear.send(Key::Enter);
     clear.wait_exit()?;


### PR DESCRIPTION
The stress gate caught a latent race in our own suite, on **iteration 17 of 100** (ubuntu; macOS passed 100/100).

```
left:  "size: 80x24  cursor: 2,0\nitem one\nitem two\n\n\n…"
right: "size: 80x24  cursor: 1,8\nitem one\nitem two\n\n\n…"
```

Byte-identical grids. The only difference is the **cursor**: `contains("item two")` becomes true before the newline *after* it is processed, so the cursor can still be at the end of the text rather than at the start of the next row.

That is state the predicate never named but that `Display` renders — precisely the case the third rule on `wait_until` exists for: *settle before whole-screen snapshots.* Our own suite was not following the discipline the crate documents, which is the more interesting half of this.

### Fix

`wait_idle` before each whole-screen snapshot in `moving_a_highlight_changes_the_styled_rendering_only`, with the reason and the iteration recorded in a comment.

Same hardening applied to `a_masked_field_is_distinguishable_from_clear_text`: its whole-screen comparison asserts a *difference*, so an incidental cursor difference would have let it pass **without the styles differing at all** — a test that could have passed for the wrong reason.

### Not a regression in library behaviour

The race is latent in a test written before this milestone. The two tests added next to it made the suite busier and shifted the timing enough to surface it — the same pattern as the drain test in #93, and the reason the stress gate runs before every release.

Verified 5 consecutive release-profile runs of the suite locally; full stress ×100 on both OSes runs again before the tag.
