### PR TITLE
docs: bring the documentation set up to 0.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     id: version
     attributes:
       label: termlens version
-      placeholder: "0.1.0 (or git SHA)"
+      placeholder: "0.4.1 (or git SHA)"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The README no longer contradicts itself about scrollback.** Its
+  limitations section was still headed `(v0.3)` and still opened with "No
+  scrollback assertions" — sixty lines below the paragraph explaining that
+  scrollback is retained, 1000 rows by default. Since the README is the
+  crates.io front page, the first thing a reader learned about 0.4's
+  headline feature was that it did not exist. The section now states the
+  bounds that actually hold: history is capped, text only and unreflowed;
+  `wait_frame` needs the application to opt into DEC 2026 and retains eight
+  frames; and the questions termlens declines to guess at are named.
+- **`SECURITY.md` no longer claims the emulator runs with zero
+  scrollback.** That sentence was the whole memory-bound argument in the
+  resource-exhaustion note, and 0.4 made it false — the emulator is
+  constructed with the configured history length. Every bound a child's
+  output can reach is listed in its place: history length, retained frames,
+  the read buffer, the `OSC 52` capture cap, the reply queue, and the
+  diagnostics set.
+
+### Documented
+
+- **The crate-level docs describe 0.4, not 0.2.** The docs.rs landing page
+  never mentioned `wait_frame`, retained scrollback, per-call deadlines or
+  the clipboard accessor, so the crate's own front page understated it by
+  two releases. It now names them, in the same breath as the guarantees
+  that make them worth using.
+- **`docs/DESIGN.md` §2 records the per-call deadlines.** The document that
+  calls itself the contract for wait semantics had never mentioned the
+  `_for` variants. It also now records the `wait_idle` timeout that names
+  an unfinished frame instead of reporting silence against a quiet
+  terminal.
+- **`docs/HANDOFF.md` is marked as the historical v0.1 record it is**,
+  rather than reading as a description of the project today — it described
+  a private repository and an unfinished go-public checklist. The checklist
+  keeps its original text, with the outcome recorded beneath it, including
+  the one item resolved differently on purpose (required approvals stay at
+  0: a solo maintainer cannot approve their own pull request).
+- The announcement draft carried v0.1's limitations, two of which have
+  since shipped; it now describes 0.4, and no longer claims to be untracked
+  while sitting in the repository. The bug-report template no longer offers
+  `0.1.0` as its example version.
+
+No library code changed in this release.
+
 ## [0.4.0] - 2026-08-18
 
 What termlens could not do, and where it quietly did the wrong thing.

--- a/README.md
+++ b/README.md
@@ -161,10 +161,20 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.3)
+## Known limitations (v0.4)
 
-- No scrollback assertions, and resizing does not reflow scrollback — the
-  visible grid is the testable surface.
+- Scrollback is **bounded** (1000 rows by default), **text only** — a
+  scrolled-off row has no styles and no cell addressing — and is **not
+  reflowed** by a `resize`. The visible grid stays the fully-featured
+  surface.
+- `wait_frame` needs the application to bracket its repaints in DEC 2026
+  synchronized updates, and only the last 8 completed frames are retained;
+  everything else waits with `wait_until`, under the three rules in
+  [docs/DESIGN.md](docs/DESIGN.md) §2.
+- Some questions stay deliberately unanswered — kitty's `CSI ? u`,
+  `XTGETTCAP`, DECRQSS, `OSC 52` *reads* — because a guessed reply is worse
+  than none. An application blocked on one is **named in the next timeout**
+  rather than left to hang unexplained.
 - Unix only for now (Linux + macOS in CI). The PTY layer (`portable-pty`)
   supports ConPTY, so Windows is planned, not designed out.
 - A child that writes and exits within its first milliseconds can lose

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,15 @@ What the project does continuously, enforced by required CI on every change:
 - **Provenance**: every commit requires a DCO sign-off from a human author
   of record; bot-authored commits are rejected by CI.
 
-Resource-exhaustion notes for the paranoid: the emulator runs with zero
-scrollback, the reader uses a fixed buffer, every wait is deadline-bounded,
-and a hostile child can at worst waste its own test's time budget.
+Resource-exhaustion notes for the paranoid: every buffer a child's output
+can reach is bounded, and a hostile child can at worst waste its own test's
+time budget. The reader uses a fixed 8 KiB buffer; every wait is
+deadline-bounded; retained scrollback is capped at the configured length
+(1000 rows by default, `scrollback(0)` to disable) and held as text rather
+than cells; at most 8 completed frames are retained for `wait_frame`; a
+captured `OSC 52` payload is dropped past 64 KiB; queued query replies stop
+at a fixed depth; and the set of distinct unanswered queries kept for
+diagnostics is capped, with the remainder counted.
 
 ## Supported versions
 

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -34,19 +34,29 @@
 //! # }
 //! ```
 //!
-//! Every `wait_*` call runs under a deadline (builder
-//! [`timeout`](TerminalBuilder::timeout), default 5s), and a timeout error
-//! [embeds the screen](Error::Timeout) so a CI log alone shows what the
-//! application was displaying. A background reader thread drains the PTY
-//! continuously — no output is lost between waits — and answers the
-//! queries a real terminal answers, so capability-probing apps run
-//! instead of hanging.
+//! Every `wait_*` call runs under a deadline — the builder's
+//! [`timeout`](TerminalBuilder::timeout) (default 5s) or a per-call one
+//! ([`wait_until_for`](Terminal::wait_until_for) and friends) — and a
+//! timeout error [embeds the screen](Error::Timeout) so a CI log alone
+//! shows what the application was displaying. A background reader thread
+//! drains the PTY continuously — no output is lost between waits — and
+//! answers the queries a real terminal answers, so capability-probing apps
+//! run instead of hanging.
+//!
+//! Where the application brackets its repaints in DEC 2026 synchronized
+//! updates, [`wait_frame`](Terminal::wait_frame) evaluates predicates only
+//! on **complete frames** and returns the one it matched — never a torn
+//! repaint, and each call observes a frame no earlier call did. Content
+//! that scrolls off the top is retained as well, so
+//! [`full_text`](Screen::full_text) answers "this reached the terminal"
+//! without the test having to know which region currently holds it.
 //!
 //! Input is mode-aware: [mouse clicks](Terminal::click),
 //! [pastes](Terminal::paste), modifier [chords](Chord), and cursor keys
 //! are encoded exactly as the application configured its terminal. And
 //! the terminal's out-of-band state — the window title, the
-//! alternate-screen flag, the input modes — is readable from every
+//! alternate-screen flag, the input modes, the last `OSC 52`
+//! [clipboard](Screen::clipboard) write — is readable from every
 //! [`Screen`] as plain accessors.
 //!
 //! With the default `insta` feature, snapshot-test whole screens:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -116,10 +116,12 @@ need a silent terminal; the diagnosis still works.
 ## 2. Wait semantics
 
 Every wait runs under the terminal's **default deadline** (builder
-`timeout`, 5s default). There is deliberately no unbounded wait: a hung
-TUI in CI must produce a readable failure, not a 6-hour job timeout. On
-expiry the error **embeds the full screen dump** — a CI log alone answers
-"what was the app showing?".
+`timeout`, 5s default) or a per-call one: each `wait_*` has a `_for` twin
+(`wait_until_for`, `wait_frame_for`, `wait_idle_for`, `wait_exit_for`), so
+one known-slow step does not force its deadline on the whole suite. There
+is deliberately no unbounded wait: a hung TUI in CI must produce a readable
+failure, not a 6-hour job timeout. On expiry the error **embeds the full
+screen dump** — a CI log alone answers "what was the app showing?".
 
 - `wait_until(pred)` — re-evaluates `pred` on a fresh snapshot whenever the
   reader delivers bytes (condvar notification), with a 50ms poll cap as a
@@ -160,10 +162,13 @@ expiry the error **embeds the full screen dump** — a CI log alone answers
   synchronized update is open (a begun-but-unfinished DEC 2026 repaint is
   by definition mid-update). The sequence conditions come from a minimal
   tracker (`emu/seq.rs`) — not a VT parser, just enough state to answer
-  "did the stream stop inside an update?". EOF counts as idle. **This is
-  a heuristic**: silence is evidence of a finished render, not proof.
-  Prefer `wait_until` on visible content, or `wait_frame` where the app
-  uses synchronized output.
+  "did the stream stop inside an update?". EOF counts as idle. An
+  application that opens an update and never closes it therefore times out
+  here, and the message says exactly that instead of "waiting for 100ms of
+  output silence", which reads as nonsense against a quiet terminal.
+  **This is a heuristic**: silence is evidence of a finished render, not
+  proof. Prefer `wait_until` on visible content, or `wait_frame` where the
+  app uses synchronized output.
 - `wait_exit()` — polls `try_wait` on a capped backoff ladder (1→20ms),
   then grace-drains the PTY (≤500ms) so the final screen is complete
   before returning. Idempotent via a cached status.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,6 +1,15 @@
 # termlens (née termtest) — Build Handoff Report
 
-Date: 2026-08-09. Repo: <https://github.com/vyncint/termlens> (private).
+> **Status: historical record of the v0.1 build.** Everything below describes
+> the project as it stood on 2026-08-09 and is kept as the record of that
+> work, not as a description of termlens today. Since then the repository has
+> been made public, the crate has been published, and the API has grown
+> through 0.2, 0.3 and 0.4 — `CHANGELOG.md` says what each release changed,
+> and `README.md` plus `docs/DESIGN.md` describe the current design. The
+> go-public checklist in §3 has its outcome recorded beneath it.
+
+Date: 2026-08-09. Repo: <https://github.com/vyncint/termlens> (private at
+the time; public since).
 Everything below was verified against live GitHub state, not assumed.
 "The build brief" below means the commissioning document this build
 executed. It is **not** part of the repository, so wherever a requirement
@@ -171,6 +180,15 @@ Then:
       (`docs/RELEASING.md` end-to-end).
 - [ ] Announce: r/rust, This Week in Rust (PR to `rust-lang/this-week-in-rust`),
       awesome-ratatui PR, and the ratatui forum/Discord testing channel.
+
+**Outcome (2026-08-19).** The repository is public and the crate is
+published, so the badges are live. The ruleset still enforces, secret
+scanning and push protection are on, and Discussions stayed off. Two items
+resolved differently from the plan: required approvals are deliberately
+still **0**, because a solo maintainer cannot approve their own pull
+request and requiring one approval would block every release; and the
+announcements are still in flight, with the draft in
+`docs/announce-r-rust.md`.
 
 ## 4. Deviations from the build brief, and why
 

--- a/docs/announce-r-rust.md
+++ b/docs/announce-r-rust.md
@@ -1,8 +1,9 @@
 # Announcement draft — users.rust-lang.org
 
 Post at https://users.rust-lang.org → log in with GitHub → **New Topic** →
-category **announcements** → paste title and body below. Delete this file
-after posting (it is deliberately untracked and not linked from anywhere).
+category **announcements** → paste title and body below. Once it is posted,
+delete this file (through a PR — `main` is protected). It is tracked, but
+deliberately not linked from anywhere.
 
 The same text also works verbatim on the ratatui forum
 (https://forum.ratatui.rs) and as a #rustlang post elsewhere.
@@ -39,6 +40,18 @@ it continuously through a vt100 emulator into an immutable screen grid;
 waits are all deadline-bounded, and a timeout error embeds the full
 screen dump — so a CI log alone shows what the app was displaying.
 
+Two things worth pointing at beyond the basics. If your app brackets its
+repaints in DEC 2026 synchronized updates (crossterm's
+`BeginSynchronizedUpdate`), `wait_frame` evaluates predicates only on
+complete frames and hands back the one it matched — never a torn screen,
+and each call observes a frame no earlier call did, so a burst is
+assertable step by step. Apps that *probe* for the mode before using it
+get a truthful `DECRQM` answer, so they enable it against termlens
+unmodified. And the style model carries blink, conceal and strikethrough,
+which is what stops a test asserting "the password field is masked" from
+passing against an app that printed the secret in clear — the two are
+identical text.
+
 The part I'm proudest of is the flake story. CI runs the whole suite 100
 times on Linux **and** macOS before anything merges to the wait paths.
 That gate caught, among other things, a genuine macOS kernel race where
@@ -47,9 +60,12 @@ pty* because device numbers recycle instantly — termlens serializes pty
 lifecycle edges behind a process-wide lock so your parallel tests don't
 hit it.
 
-Honest limitations (v0.1): Unix only for now (portable-pty supports
-ConPTY, so Windows is planned), no scrollback assertions, and styles are
-captured per-cell but not yet part of the text snapshot format.
+Honest limitations (v0.4): Unix only for now (portable-pty supports
+ConPTY, so Windows is planned); scrollback is retained but bounded, text
+only, and not reflowed on resize; `wait_frame` needs the app to opt into
+DEC 2026; and a few questions (kitty `CSI ? u`, `XTGETTCAP`, `OSC 52`
+*reads*) are deliberately left unanswered rather than guessed — an app
+blocked on one is named in the next timeout instead of hanging silently.
 
 - crates.io: https://crates.io/crates/termlens (`cargo add termlens --dev`)
 - GitHub: https://github.com/vyncint/termlens


### PR DESCRIPTION
## What & why

An audit of every document in the repository against the 0.4 API. Two
statements were **wrong**, the rest understated the crate by a release or
two.

**Wrong:**

- `README.md` still carried `## Known limitations (v0.3)`, whose first
  bullet read "No scrollback assertions" — sixty lines below the paragraph
  explaining that scrollback is retained, 1000 rows by default. The README
  is the crates.io front page, so the page selling 0.4 denied its headline
  feature.
- `SECURITY.md` claimed "the emulator runs with zero scrollback". That
  sentence *was* the memory-bound argument in the resource-exhaustion note,
  and 0.4 constructs the emulator with the configured history length
  (`Parser::new(rows, cols, scrollback_len)`). It now lists every bound a
  child's output can reach: history length, the eight retained frames, the
  8 KiB read buffer, the 64 KiB `OSC 52` capture cap, the reply queue and
  the capped diagnostics set.

**Understated:**

- The crate-level docs — the docs.rs landing page — never mentioned
  `wait_frame`, retained scrollback, per-call deadlines or the clipboard
  accessor.
- `docs/DESIGN.md` §2, which calls itself the contract for wait semantics,
  had never mentioned the `_for` variants. It also now records the
  `wait_idle` timeout that names an unfinished frame.
- `docs/HANDOFF.md` read as a description of the project today while
  describing a private repository and an unfinished go-public checklist.
  Banner added, checklist text kept, outcome recorded beneath it — including
  the item resolved differently on purpose (required approvals stay at 0: a
  solo maintainer cannot approve their own PR).
- The announcement draft still listed v0.1's limitations, two of which have
  since shipped, and claimed to be untracked while sitting in the
  repository.
- The bug-report template's example version.

Verified against the source rather than assumed: `FRAME_HISTORY = 8`,
`DEFAULT_SCROLLBACK = 1000`, `OSC_CAPTURE_MAX = 64 * 1024`, the 8 KiB
reader buffer, the answered/unanswerable query split in `emu/seq.rs`, and
the repository settings behind the checklist outcome.

## Checklist

- [x] Linked an issue (or explained above why none exists) — none; audit
      found during release follow-up
- [x] Tests added/updated for the change — no library code changed; the
      15 doctests and the full suite pass
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none