### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-19
+
+The documentation set, brought up to what 0.4 actually does.
+
+Two statements were wrong and the rest understated the crate by a
+release or two. No library code changed.
+
 ### Fixed
 
 - **The README no longer contradicts itself about scrollback.** Its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "crossterm",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "crossterm",
 ]
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "crossterm",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -563,7 +563,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.4.0" }
+termlens = { path = "crates/termlens", version = "0.4.1" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
## What & why

Cuts **0.4.1**, a documentation-only patch release. It carries the audit
merged in #111: two statements in the docs were wrong about 0.4 — the
README's limitations section still said "No scrollback assertions", and
`SECURITY.md` still rested its memory-bound argument on "the emulator runs
with zero scrollback" — plus several places that understated the crate by a
release or two.

Both wrong statements are on pages a user reads before the API: the README
is the crates.io front page, and `SECURITY.md` is the posture document. That
is what makes them worth a release rather than a wait.

- `workspace.package.version` → `0.4.1` (lockfile refreshed by `cargo check`)
- `CHANGELOG.md`: `[Unreleased]` → `[0.4.1] - 2026-08-19`, fresh empty
  `[Unreleased]` above
- `extract-changelog.sh 0.4.1` verified locally — 48 lines, the section only

No library code changed, so `cargo-semver-checks` has nothing to compare
against but an identical API.

## Checklist

- [x] Linked an issue (or explained above why none exists) — release chore
- [x] Tests added/updated for the change — none needed; full suite green on the merged base
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated — this PR is the release section move
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none