### PR TITLE
docs(tests): drop a v0.1 forward reference from input.rs

### DIFF
--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -1,5 +1,5 @@
-//! Typed input beyond plain keys: mouse (mode-aware), and — as the tier
-//! progresses — modifier chords, bracketed paste, and cursor-key modes.
+//! Typed input beyond plain keys: mouse (mode-aware), modifier chords,
+//! bracketed paste, and cursor-key modes.
 
 use std::time::Duration;
 


### PR DESCRIPTION
## What & why

Follow-up to #111, caught while verifying the `0.4.1` package contents.

`tests/input.rs` still opened with input beyond plain keys arriving "as the
tier progresses — modifier chords, bracketed paste, and cursor-key modes".
All three shipped in 0.2, and this file has tested them ever since
(`modifier_chords_round_trip_through_crossterms_parser`,
`paste_is_one_event_under_bracketed_paste`,
`arrows_follow_the_apps_cursor_key_mode`, among 11 tests).

Worth the extra PR because `tests/` is included in the published crate —
`cargo package` lists `termlens-0.4.1/tests/input.rs` — so the sentence
ships to crates.io. It is the last forward-looking phrase left in any
shipped source file (`grep` for `as the tier|for now|not yet|will be|TODO`
across `src/`, `tests/` and `examples/` now returns nothing).

Comment-only; no changelog entry, since nothing user-facing changed.

## Checklist

- [x] Linked an issue (or explained above why none exists) — follow-up to #111
- [x] Tests added/updated for the change — comment only
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]` — n/a, not user-facing
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none