### PR TITLE
test(input): stop the utf8 mouse guard losing a race with its own padding

### DIFF
--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -162,7 +162,15 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
             "-c",
             concat!(
                 r"stty -icanon -echo; printf '\033[?1000h\033[?1005h'; printf READY; ",
-                r"head -c 7 | od -An -tx1 | tr -d ' \n'; printf ' WIRE-EOF'; read guard"
+                r"head -c 7 | od -An -tx1 | tr -d ' \n'; printf ' WIRE-EOF'; ",
+                // A loop with a sentinel, not a bare `read guard`: the
+                // padding below is a separate write from the click, so
+                // whether head's buffered read swallows it or leaves it
+                // queued is a race. A bare guard loses that race — it
+                // consumes a padding newline, the shell exits, and the
+                // final write below hits a dead PTY with EIO. Only QUIT
+                // ends this script, so the padding cannot end it early.
+                r#"while read guard; do [ "$guard" = QUIT ] && exit 0; done"#
             ),
         ])
         .spawn("/bin/sh")?;
@@ -170,6 +178,10 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
 
     // Column 100 is 0x85 as a bare byte; UTF-8 must send c2 85.
     t.click(100, 3)?;
+    // Padding, so a regression to the 6-byte legacy form unblocks `head`
+    // and shows the wire instead of timing out. Seven of them because a
+    // correct click already supplied all seven bytes; these are only ever
+    // read when it did not.
     t.send_str("\n\n\n\n\n\n\n");
     t.wait_until(|s| s.contains("WIRE-EOF"))?;
 
@@ -178,7 +190,7 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
         wire.contains("1b5b4d20c28524"),
         "expected ESC [ M 0x20 c2 85 0x24 (UTF-8 column 100), got: {wire}"
     );
-    t.send_str("\n");
+    t.send_str("QUIT\n");
     assert!(t.wait_exit()?.success());
     Ok(())
 }


### PR DESCRIPTION
## What & why

The `v0.4.1` release pipeline failed on `ci / test (macos-latest)`:

```
test mouse_reports_follow_the_utf8_encoding ... FAILED
panicked at crates/termlens/src/terminal.rs:1415:13:
termlens: failed to send literal text to `/bin/sh -c stty -icanon -echo; …` (Input/output error (os error 5))
```

The same commit had passed `test (macos-latest)` on #113 minutes earlier
and 100/100 macOS stress iterations before that. **The mechanism is in the
test, not the library** — no library code has changed since 0.4.0.

### The race

`t.click(100, 3)` and `t.send_str("\n\n\n\n\n\n\n")` are two separate
writes.

- **Normally:** `head -c 7`'s buffered read takes the click's seven bytes
  *and* the padding in one go and discards the excess, so nothing reaches
  `read guard`. The test's final `send_str("\n")` releases it. ✅
- **Under load:** `head`'s read returns the click's seven bytes alone.
  `head` exits with the padding still queued, `read guard` consumes a
  newline, the shell exits — and the final write lands on a dead PTY. EIO.

### Confirmed, not guessed

A throwaway probe forced that interleaving (wait for `WIRE-EOF`, *then*
send the padding). Against the old script the child was dead every time;
against the sentinel loop the same probe passes 5/5. The probe is not
retained — a test asserting that a test's guard cannot be released is
meta-noise, and the mechanism is recorded in a comment at the site.

### The fix

`read guard` becomes `while read guard; do [ "$guard" = QUIT ] && exit 0; done`,
and the test ends with `send_str("QUIT\n")`. Padding can no longer end the
script; only the sentinel can.

The padding stays — it is what turns a regression to the six-byte legacy
encoding into a visible wire dump instead of a ten-second timeout.

### Verification

- `--test input` × 40 debug runs: 0 failures
- full workspace suite × 6 release runs, `--test-threads=4`: 0 failures
- forced-interleaving probe × 5: 0 failures (old script: fails every time)
- `fmt` and `clippy --all-targets --all-features` clean

No changelog entry: nothing user-facing changed.

## Checklist

- [x] Linked an issue (or explained above why none exists) — found by the release run
- [x] Tests added/updated for the change — this *is* the test fix; verification above
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]` — n/a, not user-facing
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none