### PR TITLE
chore: release v0.4.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     id: version
     attributes:
       label: termlens version
-      placeholder: "0.4.1 (or git SHA)"
+      placeholder: "0.4.2 (or git SHA)"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,19 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
-## [0.4.1] - 2026-08-19
+## [0.4.2] - 2026-08-19
 
 The documentation set, brought up to what 0.4 actually does.
 
 Two statements were wrong and the rest understated the crate by a
 release or two. No library code changed.
+
+*0.4.1 was tagged for exactly this content and never published: its
+release run caught a latent race in this suite's own UTF-8 mouse test —
+padding written after a click could be read by the script's exit guard
+instead of by `head`, ending the child early so the next write failed
+with EIO. Fixed before publishing, so the version on crates.io is the one
+whose gates all passed.*
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crossterm",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crossterm",
 ]
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crossterm",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -563,7 +563,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.4.1" }
+termlens = { path = "crates/termlens", version = "0.4.2" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
## What & why

Cuts **0.4.2**, the documentation-only patch release originally cut as
0.4.1.

`v0.4.1` was tagged and its release run **failed before publishing** —
`ci / test (macos-latest)` hit a latent race in the suite's own UTF-8
mouse test (fixed in #114). Nothing reached crates.io, so the version
number is being retired rather than reused: the tag stands unpublished and
0.4.2 ships the same documentation work plus the test fix.

- `workspace.package.version` → `0.4.2` (lockfile refreshed by `cargo check`)
- `CHANGELOG.md`: the `[0.4.1]` section becomes `[0.4.2]`, with a note
  recording why 0.4.1 is absent from crates.io
- bug-report template example version → `0.4.2`
- `extract-changelog.sh v0.4.2` verified locally

The library code is unchanged since 0.4.0; `cargo-semver-checks` has an
identical API to compare against.

## Checklist

- [x] Linked an issue (or explained above why none exists) — release chore
- [x] Tests added/updated for the change — none needed; #114 carried the test fix
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated — this PR is the release section move
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none