### PR TITLE
fix(input)!: make send/send_str/paste fallible and name a departed child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ listed under a **Changed** or **Removed** heading.
   cannot be delivered is something a test can see, handle, or propagate
   with `?` — previously the only route from a failed write to the test was
   aborting it. Call sites grow a `?`; that is the whole migration.
+- **Typed input to a closed terminal is refused identically on Linux and
+  macOS.** It was not: a write to a master whose slave descriptors are all
+  closed fails with `EIO` on macOS and *succeeds* on Linux, queueing the
+  bytes for a reader that no longer exists. The same keystroke was
+  therefore an error on one CI runner and silently discarded on the other.
+  Every sender now checks for a closed terminal before writing, so the
+  answer is the same everywhere and no keystroke is lost quietly.
 - **A mouse action at a departed child names the child.** `click`, `drag`
   and `scroll` check liveness *before* the mouse-tracking mode, because a
   child that has exited necessarily never enabled tracking either — so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Changed
+
+- **`send`, `send_str` and `paste` return `Result<()>`** and no longer
+  panic. Every input call in the crate is now fallible, so a write that
+  cannot be delivered is something a test can see, handle, or propagate
+  with `?` — previously the only route from a failed write to the test was
+  aborting it. Call sites grow a `?`; that is the whole migration.
+- **A mouse action at a departed child names the child.** `click`, `drag`
+  and `scroll` check liveness *before* the mouse-tracking mode, because a
+  child that has exited necessarily never enabled tracking either — so the
+  old order reported a missing `CSI ?1000 h` for a terminal whose
+  application was simply gone. The tracking-mode error is unchanged for a
+  live application that really has not enabled it.
+
+### Added
+
+- **`Error::Write`**, carrying the screen at the moment of the failed
+  write, the way `Error::Timeout` and `Error::Eof` already do.
+  `Error::screen()` returns it.
+
 ## [0.4.2] - 2026-08-19
 
 The documentation set, brought up to what 0.4 actually does.

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ design. termlens's position:
 - **Every wait takes a per-call deadline** (`wait_until_for`,
   `wait_frame_for`, `wait_idle_for`, `wait_exit_for`), so one slow step
   doesn't force a generous timeout on the whole suite. Writes are bounded
-  too: typing into an application that has stopped reading fails with the
-  screen attached instead of hanging.
+  too, and every input call returns `Result`: typing into an application
+  that has stopped reading, or into a child that has exited, is an error
+  carrying the screen rather than a hang or a panic.
 - **`wait_idle(quiet)` is an honest heuristic** for everything else. It
   resolves when nothing arrived for `quiet`, the stream isn't
   mid-escape-sequence, and no synchronized update is open. Silence is

--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -68,14 +68,36 @@ pub enum Error {
     /// pid may belong to someone else by now).
     #[error("input not receivable: {0}")]
     Input(String),
+
+    /// Typed input could not be delivered: the child is gone and the OS
+    /// tore the terminal down, or it stopped reading its input and the
+    /// write gave up at the terminal's deadline rather than blocking
+    /// forever.
+    ///
+    /// Distinct from [`Error::Input`] on purpose. `Input` means the
+    /// application cannot make sense of these bytes — a test bug. This
+    /// means the bytes could not be handed over at all, which is a fact
+    /// about the child rather than about the test, so the screen at the
+    /// moment of the failure is embedded the way a timeout's is.
+    #[error("failed to send {what}\n--- screen at the failed write ---\n{screen}")]
+    Write {
+        /// What was being sent, which command it was going to, and why the
+        /// write failed.
+        what: Box<str>,
+        /// The screen when the write failed.
+        screen: Screen,
+    },
 }
 
 impl Error {
-    /// The screen embedded in [`Error::Timeout`] / [`Error::Eof`], if any.
+    /// The screen embedded in [`Error::Timeout`], [`Error::Eof`] or
+    /// [`Error::Write`], if any.
     #[must_use]
     pub fn screen(&self) -> Option<&Screen> {
         match self {
-            Error::Timeout { screen, .. } | Error::Eof { screen, .. } => Some(screen),
+            Error::Timeout { screen, .. }
+            | Error::Eof { screen, .. }
+            | Error::Write { screen, .. } => Some(screen),
             _ => None,
         }
     }

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -28,9 +28,9 @@ pub enum Key {
     /// sending the next key:
     ///
     /// ```text
-    /// t.send(Key::Esc);
+    /// t.send(Key::Esc)?;
     /// t.wait_until(|s| s.contains("NORMAL"))?; // Esc took effect
-    /// t.send(Key::Char('?'));                  // now unambiguous
+    /// t.send(Key::Char('?'))?;                 // now unambiguous
     /// ```
     Esc,
     /// Tab (`0x09`).

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -23,11 +23,11 @@
 //!     .args(["-c", r#"read line; echo "got: $line"; read quit"#])
 //!     .spawn("sh")?;
 //!
-//! t.send_str("hello");
-//! t.send(Key::Enter);
+//! t.send_str("hello")?;
+//! t.send(Key::Enter)?;
 //! t.wait_until(|screen| screen.contains("got: hello"))?;
 //!
-//! t.send(Key::Enter); // release `read quit`; the script finishes
+//! t.send(Key::Enter)?; // release `read quit`; the script finishes
 //! let status = t.wait_exit()?;
 //! assert!(status.success());
 //! # Ok(())

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1187,18 +1187,25 @@ impl Terminal {
     /// # Errors
     ///
     /// [`Error::Write`] when the bytes cannot be handed to the child — it
-    /// exited and the OS tore the terminal down, or it stopped reading its
-    /// input and the write gave up at the terminal's deadline rather than
-    /// blocking forever. The error embeds the screen, so a CI log shows
-    /// what the application was displaying when the keystroke had nowhere
-    /// to go.
+    /// released the terminal, or it stopped reading its input and the write
+    /// gave up at the terminal's deadline rather than blocking forever. The
+    /// error embeds the screen, so a CI log shows what the application was
+    /// displaying when the keystroke had nowhere to go.
+    ///
+    /// This is the same answer on every platform. A raw write to a closed
+    /// terminal fails with `EIO` on macOS and *succeeds* on Linux, where
+    /// the bytes queue up for a reader that no longer exists; termlens
+    /// checks first, so a keystroke is never silently swallowed on one OS
+    /// and reported on another.
     ///
     /// [`send_str`](Self::send_str), [`paste`](Self::paste),
     /// [`click`](Self::click), [`drag`](Self::drag) and
     /// [`scroll`](Self::scroll) share this contract.
     pub fn send(&mut self, key: impl Input + fmt::Debug) -> Result<()> {
+        let what = format!("{key:?}");
+        self.ensure_deliverable(&what)?;
         let application_cursor = self.input_modes().application_cursor;
-        self.write_input(&key.encode_modal(application_cursor), &format!("{key:?}"))
+        self.write_input(&key.encode_modal(application_cursor), &what)
     }
 
     /// Send a string literally (UTF-8 bytes, no key mapping, no newline).
@@ -1207,6 +1214,7 @@ impl Terminal {
     ///
     /// Same contract as [`send`](Self::send).
     pub fn send_str(&mut self, s: &str) -> Result<()> {
+        self.ensure_deliverable("literal text")?;
         self.write_input(s.as_bytes(), "literal text")
     }
 
@@ -1239,6 +1247,7 @@ impl Terminal {
     ///
     /// Same contract as [`send`](Self::send).
     pub fn paste(&mut self, text: &str) -> Result<()> {
+        self.ensure_deliverable("a paste")?;
         // Real terminals send CR for a pasted line break; \r\n collapses
         // to a single CR rather than two line breaks.
         let text = text.replace("\r\n", "\r").replace('\n', "\r");
@@ -1423,30 +1432,40 @@ impl Terminal {
         }
     }
 
-    /// Refuse an input operation the child provably cannot receive.
+    /// Refuse an input operation nothing can receive.
     ///
-    /// Called *before* the mouse-tracking check, because the two failures
-    /// are not equally likely to be the real one: a reaped child cannot
-    /// have enabled tracking either, so checking the mode first reports a
-    /// missing `CSI ?1000 h` when the actual cause is that nobody is
-    /// there. The write itself would fail too, but with EIO — accurate and
-    /// far less informative than naming the exit.
+    /// Two reasons this is a check of our own rather than a reliance on the
+    /// write failing.
+    ///
+    /// **The platforms disagree.** Writing to a master whose slave is
+    /// closed fails with `EIO` on macOS and *succeeds* on Linux, where the
+    /// bytes land in an input queue with no reader left to drain it. So
+    /// without this, the same call reports an error on one CI runner and
+    /// silently discards a keystroke on the other — and silence is the
+    /// worse half, because the test then fails at a later wait whose screen
+    /// never changed, far from the cause.
+    ///
+    /// **It gives the mouse path the right diagnosis.** Called before the
+    /// mouse-tracking check, because a child that is gone never enabled
+    /// tracking either: checking the mode first answers "no `CSI ?1000 h`
+    /// was seen", which is true and is not the reason.
+    ///
+    /// The signal is **EOF, not "did we reap something"**. EOF means every
+    /// slave descriptor is closed, which is exactly the condition under
+    /// which no one can read — while a reaped child says nothing about a
+    /// grandchild that inherited the terminal and is still reading it.
     fn ensure_deliverable(&mut self, what: &str) -> Result<()> {
-        let gone = match &self.exit_status {
-            Some(status) => Some(format!("the child has exited ({status})")),
-            None => self
-                .shared
-                .lock()
-                .eof
-                .then(|| "the child released the terminal (EOF)".to_owned()),
-        };
-        match gone {
-            None => Ok(()),
-            Some(reason) => Err(Error::Write {
-                what: format!("{what} to `{}` ({reason})", self.command_desc).into(),
-                screen: self.screen(),
-            }),
+        if !self.shared.lock().eof {
+            return Ok(());
         }
+        let reason = match &self.exit_status {
+            Some(status) => format!("the child is gone ({status}) and the terminal is closed"),
+            None => "the child released the terminal (EOF), so nothing can read this".to_owned(),
+        };
+        Err(Error::Write {
+            what: format!("{what} to `{}` ({reason})", self.command_desc).into(),
+            screen: self.screen(),
+        })
     }
 
     /// Write to the child, bounded by the default deadline.

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -598,7 +598,7 @@ impl EmuState {
 ///     .args(["-c", "echo builder-doc; read quit"])
 ///     .spawn("sh")?;
 /// t.wait_until(|s| s.contains("builder-doc"))?;
-/// # t.send(termlens::Key::Enter); // release `read quit`
+/// # t.send(termlens::Key::Enter)?; // release `read quit`
 /// # t.wait_exit()?; Ok(())
 /// # }
 /// ```
@@ -1184,32 +1184,30 @@ impl Terminal {
     /// Send one key press or modifier [`Chord`](crate::Chord). See
     /// [`Key`](crate::Key) for the encodings.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the bytes cannot be written to the PTY — the child
-    /// exited and the OS tore the terminal down, or the application
-    /// stopped reading its input and the PTY buffer filled, in which
-    /// case the write gives up at the terminal's deadline rather than
-    /// blocking forever. Either way the panic message includes the
-    /// current screen. A test that types into a program which cannot
-    /// receive it is broken; failing loudly beats a silent no-op, and
-    /// beats a hang by more.
+    /// [`Error::Write`] when the bytes cannot be handed to the child — it
+    /// exited and the OS tore the terminal down, or it stopped reading its
+    /// input and the write gave up at the terminal's deadline rather than
+    /// blocking forever. The error embeds the screen, so a CI log shows
+    /// what the application was displaying when the keystroke had nowhere
+    /// to go.
     ///
-    /// [`click`](Self::click), [`scroll`](Self::scroll),
-    /// [`paste`](Self::paste) and [`send_str`](Self::send_str) share this
-    /// contract.
-    pub fn send(&mut self, key: impl Input + fmt::Debug) {
+    /// [`send_str`](Self::send_str), [`paste`](Self::paste),
+    /// [`click`](Self::click), [`drag`](Self::drag) and
+    /// [`scroll`](Self::scroll) share this contract.
+    pub fn send(&mut self, key: impl Input + fmt::Debug) -> Result<()> {
         let application_cursor = self.input_modes().application_cursor;
-        self.write_or_panic(&key.encode_modal(application_cursor), &format!("{key:?}"));
+        self.write_input(&key.encode_modal(application_cursor), &format!("{key:?}"))
     }
 
     /// Send a string literally (UTF-8 bytes, no key mapping, no newline).
     ///
-    /// # Panics
+    /// # Errors
     ///
     /// Same contract as [`send`](Self::send).
-    pub fn send_str(&mut self, s: &str) {
-        self.write_or_panic(s.as_bytes(), "literal text");
+    pub fn send_str(&mut self, s: &str) -> Result<()> {
+        self.write_input(s.as_bytes(), "literal text")
     }
 
     /// Paste text, the way a terminal pastes.
@@ -1237,10 +1235,10 @@ impl Terminal {
     /// To send bytes with no transformation at all, use
     /// [`send_str`](Self::send_str) and write the brackets yourself.
     ///
-    /// # Panics
+    /// # Errors
     ///
     /// Same contract as [`send`](Self::send).
-    pub fn paste(&mut self, text: &str) {
+    pub fn paste(&mut self, text: &str) -> Result<()> {
         // Real terminals send CR for a pasted line break; \r\n collapses
         // to a single CR rather than two line breaks.
         let text = text.replace("\r\n", "\r").replace('\n', "\r");
@@ -1248,9 +1246,9 @@ impl Terminal {
             let mut bytes = b"\x1b[200~".to_vec();
             bytes.extend_from_slice(strip_paste_markers(&text).as_bytes());
             bytes.extend_from_slice(b"\x1b[201~");
-            self.write_or_panic(&bytes, "a bracketed paste");
+            self.write_input(&bytes, "a bracketed paste")
         } else {
-            self.write_or_panic(text.as_bytes(), "a paste");
+            self.write_input(text.as_bytes(), "a paste")
         }
     }
 
@@ -1262,10 +1260,12 @@ impl Terminal {
     ///
     /// # Errors
     ///
-    /// [`Error::Input`] when the application has not enabled mouse
-    /// tracking (feeding it mouse bytes anyway would be misparsed as
-    /// garbage keys), or when the position is unrepresentable in the
-    /// legacy encoding (columns/rows beyond 222).
+    /// [`Error::Write`] when the child is gone, checked *first* so a
+    /// reaped child is named as such instead of being reported as a
+    /// missing tracking mode. Then [`Error::Input`] when the application
+    /// has not enabled mouse tracking (feeding it mouse bytes anyway would
+    /// be misparsed as garbage keys), or when the position is
+    /// unrepresentable in the legacy encoding (columns/rows beyond 222).
     pub fn click(&mut self, col: u16, row: u16) -> Result<()> {
         self.click_with(MouseButton::Left, col, row)
     }
@@ -1291,6 +1291,7 @@ impl Terminal {
     ///
     /// Same conditions as [`click`](Self::click).
     pub fn click_with(&mut self, button: impl Into<MouseChord>, col: u16, row: u16) -> Result<()> {
+        self.ensure_deliverable("a mouse click")?;
         let chord = button.into();
         let modes = self.input_modes();
         let press_only = match modes.mouse {
@@ -1302,8 +1303,7 @@ impl Terminal {
         if !press_only {
             bytes.extend(self.mouse_report(&modes, chord.code(), col, row, false)?);
         }
-        self.write_or_panic(&bytes, "a mouse click");
-        Ok(())
+        self.write_input(&bytes, "a mouse click")
     }
 
     /// Drag from one cell to another: press, motion, release.
@@ -1319,15 +1319,18 @@ impl Terminal {
     ///
     /// # Errors
     ///
-    /// [`Error::Input`] when no mouse tracking is enabled, when the
-    /// tracking mode is X10, or when a position is unrepresentable in
-    /// the encoding the application selected.
+    /// [`Error::Write`] when the child is gone (checked first, as on
+    /// [`click`](Self::click)), then [`Error::Input`] when no mouse
+    /// tracking is enabled, when the tracking mode is X10, or when a
+    /// position is unrepresentable in the encoding the application
+    /// selected.
     pub fn drag(
         &mut self,
         button: impl Into<MouseChord>,
         from: (u16, u16),
         to: (u16, u16),
     ) -> Result<()> {
+        self.ensure_deliverable("a mouse drag")?;
         let chord = button.into();
         let modes = self.input_modes();
         let report_motion = match modes.mouse {
@@ -1351,8 +1354,7 @@ impl Terminal {
             bytes.extend(self.mouse_report(&modes, chord.code() + 32, to_col, to_row, true)?);
         }
         bytes.extend(self.mouse_report(&modes, chord.code(), to_col, to_row, false)?);
-        self.write_or_panic(&bytes, "a mouse drag");
-        Ok(())
+        self.write_input(&bytes, "a mouse drag")
     }
 
     /// Scroll the wheel one notch at `(col, row)` (0-based).
@@ -1361,6 +1363,7 @@ impl Terminal {
     ///
     /// Same conditions as [`click`](Self::click).
     pub fn scroll(&mut self, col: u16, row: u16, direction: Scroll) -> Result<()> {
+        self.ensure_deliverable("a mouse scroll")?;
         let modes = self.input_modes();
         if modes.mouse == MouseMode::None {
             return Err(no_mouse_tracking());
@@ -1373,8 +1376,7 @@ impl Terminal {
         };
         // Wheel events are presses only; there is no release.
         let bytes = self.mouse_report(&modes, button, col, row, true)?;
-        self.write_or_panic(&bytes, "a mouse scroll");
-        Ok(())
+        self.write_input(&bytes, "a mouse scroll")
     }
 
     fn input_modes(&self) -> InputModes {
@@ -1407,16 +1409,43 @@ impl Terminal {
         })
     }
 
-    fn write_or_panic(&mut self, bytes: &[u8], what: &str) {
-        // Build the panic message (which takes the state lock for the
-        // screen) strictly after the write attempt finishes, so no two
-        // locks are ever held together.
-        if let Err(reason) = self.write_within_deadline(bytes) {
-            panic!(
-                "termlens: failed to send {what} to `{}` ({reason})\n--- screen ---\n{}",
-                self.command_desc,
-                self.screen()
-            );
+    /// Hand `bytes` to the child, or report why it was impossible.
+    fn write_input(&mut self, bytes: &[u8], what: &str) -> Result<()> {
+        // Build the message (which takes the state lock for the screen)
+        // strictly after the write attempt finishes, so no two locks are
+        // ever held together.
+        match self.write_within_deadline(bytes) {
+            Ok(()) => Ok(()),
+            Err(reason) => Err(Error::Write {
+                what: format!("{what} to `{}` ({reason})", self.command_desc).into(),
+                screen: self.screen(),
+            }),
+        }
+    }
+
+    /// Refuse an input operation the child provably cannot receive.
+    ///
+    /// Called *before* the mouse-tracking check, because the two failures
+    /// are not equally likely to be the real one: a reaped child cannot
+    /// have enabled tracking either, so checking the mode first reports a
+    /// missing `CSI ?1000 h` when the actual cause is that nobody is
+    /// there. The write itself would fail too, but with EIO — accurate and
+    /// far less informative than naming the exit.
+    fn ensure_deliverable(&mut self, what: &str) -> Result<()> {
+        let gone = match &self.exit_status {
+            Some(status) => Some(format!("the child has exited ({status})")),
+            None => self
+                .shared
+                .lock()
+                .eof
+                .then(|| "the child released the terminal (EOF)".to_owned()),
+        };
+        match gone {
+            None => Ok(()),
+            Some(reason) => Err(Error::Write {
+                what: format!("{what} to `{}` ({reason})", self.command_desc).into(),
+                screen: self.screen(),
+            }),
         }
     }
 

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -23,7 +23,7 @@ fn sh(script: &str) -> termlens::Result<Terminal> {
 fn echo_reaches_the_screen_and_child_exits_cleanly() -> termlens::Result<()> {
     let mut t = sh("echo hello from a real PTY; read guard")?;
     t.wait_until(|s| s.contains("hello from a real PTY"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     let status = t.wait_exit()?;
     assert!(status.success(), "full status: {status}");
     assert_eq!(status.code(), 0);
@@ -35,7 +35,7 @@ fn exit_codes_are_reported() -> termlens::Result<()> {
     // The `read` keeps the exit from racing PTY setup; the line discipline
     // buffers our Enter even if it lands before `read` starts.
     let mut t = sh("read guard; exit 7")?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     let status = t.wait_exit()?;
     assert!(!status.success());
     assert_eq!(status.code(), 7, "full status: {status}");
@@ -48,7 +48,7 @@ fn exit_codes_are_reported() -> termlens::Result<()> {
 #[test]
 fn signal_deaths_are_reported_as_signals_not_exit_codes() -> termlens::Result<()> {
     let mut t = sh("read guard; kill -TERM $$")?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     let status = t.wait_exit()?;
     assert!(!status.success());
     // strsignal spelling differs per libc ("Terminated" / "Terminated: 15"),
@@ -67,7 +67,7 @@ fn env_vars_reach_the_child() -> termlens::Result<()> {
         .args(["-c", r#"echo "marker=$TERMTEST_MARKER"; read guard"#])
         .spawn(SH)?;
     t.wait_until(|s| s.contains("marker=42"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_exit()?;
     Ok(())
 }
@@ -100,7 +100,7 @@ fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termlens::
         screen.contains("term=xterm-256color"),
         "default TERM missing:\n{screen}"
     );
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_exit()?;
     Ok(())
 }
@@ -112,7 +112,7 @@ fn explicit_term_overrides_the_default() -> termlens::Result<()> {
         .args(["-c", r#"echo "term=$TERM"; read guard"#])
         .spawn(SH)?;
     t.wait_until(|s| s.contains("term=vt100"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_exit()?;
     Ok(())
 }
@@ -120,10 +120,10 @@ fn explicit_term_overrides_the_default() -> termlens::Result<()> {
 #[test]
 fn send_str_and_enter_round_trip_through_the_line_discipline() -> termlens::Result<()> {
     let mut t = sh(r#"read line; echo "got: $line"; read guard"#)?;
-    t.send_str("hello");
-    t.send(Key::Enter);
+    t.send_str("hello")?;
+    t.send(Key::Enter)?;
     t.wait_until(|s| s.contains("got: hello"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -160,7 +160,7 @@ fn waits_fail_fast_on_eof_instead_of_burning_the_timeout() {
     // Deterministic sequencing: observe the output, then let the child
     // exit, then wait for something that can never appear.
     t.wait_until(|s| s.contains("bye")).unwrap();
-    t.send(Key::Enter);
+    t.send(Key::Enter).unwrap();
 
     let start = Instant::now();
     let err = t.wait_until(|s| s.contains("never printed")).unwrap_err();
@@ -189,7 +189,7 @@ fn wait_idle_resolves_in_output_gaps() -> termlens::Result<()> {
     );
 
     t.wait_until(|s| s.contains("b"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_exit()?;
     Ok(())
 }

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -106,7 +106,7 @@ fn resize_to_zero_is_refused_without_touching_the_pty_or_the_grid() -> termlens:
     assert_eq!(t.screen().size(), (80, 24));
     t.resize(70, 20)?;
     assert_eq!(t.screen().size(), (70, 20));
-    t.send(termlens::Key::Enter);
+    t.send(termlens::Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -108,7 +108,7 @@ fn replies_still_reach_an_application_that_reads_them() -> termlens::Result<()> 
         ])
         .spawn("/bin/sh")?;
     t.wait_until(|s| s.contains("unblocked:E[1;4R"))?;
-    t.send(termlens::Key::Enter);
+    t.send(termlens::Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -33,7 +33,7 @@ fn hello_tui_draws_a_static_alt_screen_frame() -> termlens::Result<()> {
     assert_eq!(screen.find("hello-tui"), Some((1, 2)));
     insta::assert_snapshot!(t.screen());
 
-    t.send(Key::Char('q'));
+    t.send(Key::Char('q'))?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -43,7 +43,7 @@ fn form_echo_round_trips_typed_input_and_special_keys() -> termlens::Result<()> 
     let mut t = spawn_fixture("form-echo")?;
     t.wait_until(|s| s.contains("form-echo ready"))?;
 
-    t.send_str("hello");
+    t.send_str("hello")?;
     t.wait_until(|s| s.contains("input: hello"))?;
 
     // Each special key must round-trip: our xterm encoding -> PTY ->
@@ -65,18 +65,18 @@ fn form_echo_round_trips_typed_input_and_special_keys() -> termlens::Result<()> 
         (Key::Alt('x'), "last: alt:x"),
         (Key::Ctrl('a'), "last: ctrl:a"),
     ] {
-        t.send(key);
+        t.send(key)?;
         t.wait_until(|s| s.contains(name))?;
     }
 
-    t.send(Key::Backspace);
+    t.send(Key::Backspace)?;
     t.wait_until(|s| s.contains("input: hell") && s.contains("last: backspace"))?;
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_until(|s| s.contains("submitted: hell"))?;
     insta::assert_snapshot!(t.screen());
 
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -85,7 +85,7 @@ fn form_echo_round_trips_typed_input_and_special_keys() -> termlens::Result<()> 
 fn form_echo_reports_nonzero_exit_codes() -> termlens::Result<()> {
     let mut t = spawn_fixture("form-echo")?;
     t.wait_until(|s| s.contains("form-echo ready"))?;
-    t.send(Key::Ctrl('x'));
+    t.send(Key::Ctrl('x'))?;
     let status = t.wait_exit()?;
     assert!(!status.success());
     assert_eq!(status.code(), 42, "full status: {status}");
@@ -104,7 +104,7 @@ fn resize_reaches_the_child_as_sigwinch() -> termlens::Result<()> {
     t.resize(66, 20)?;
     t.wait_until(|s| s.contains("size: 66x20"))?;
 
-    t.send(Key::Char('q'));
+    t.send(Key::Char('q'))?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -126,7 +126,7 @@ fn unicode_torture_renders_with_correct_widths() -> termlens::Result<()> {
     insta::assert_snapshot!(screen);
 
     // Release the fixture's stdin guard now that everything is asserted.
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -23,7 +23,7 @@ fn the_frame_completed_before_the_call_is_evaluated() -> termlens::Result<()> {
     // The fixture's first synchronized frame has long completed by the time
     // this wait starts; entry evaluation must still see it.
     t.wait_frame(|s| s.contains("form-echo ready"))?;
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -33,7 +33,7 @@ fn a_frame_is_internally_consistent() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
 
-    t.send_str("hi");
+    t.send_str("hi")?;
     // Both the input line and the last-key line are painted in the same
     // synchronized update, so a frame satisfying one must satisfy the
     // other. The returned frame is what the predicate saw, so the sibling
@@ -45,7 +45,7 @@ fn a_frame_is_internally_consistent() -> termlens::Result<()> {
         "frame satisfied one row but not its sibling:\n{frame}"
     );
 
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -58,14 +58,14 @@ fn a_torn_repaint_is_never_observed() -> termlens::Result<()> {
     // F2 paints "torn: left", flushes, sleeps 150ms, then paints " right"
     // and ends the synchronized update. The bytes arrive in two bursts;
     // the frame completes only with the second.
-    t.send(Key::F(2));
+    t.send(Key::F(2))?;
     let row = t.wait_frame(|s| s.contains("torn: left"))?.row_text(5);
     assert!(
         row.contains("torn: left right"),
         "wait_frame observed a torn frame: {row:?}"
     );
 
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -95,7 +95,7 @@ fn apps_without_synchronized_output_time_out_with_guidance() {
     assert!(msg.contains("wait_until"), "no alternative named in: {msg}");
     assert!(err.screen().is_some(), "timeout must still embed a screen");
 
-    t.send(Key::Char('q'));
+    t.send(Key::Char('q')).unwrap();
     assert!(t.wait_exit().unwrap().success());
 }
 
@@ -164,7 +164,7 @@ fn every_frame_of_a_burst_is_observable_in_order() -> termlens::Result<()> {
     assert!(t.wait_frame(|s| s.contains("STEP 2"))?.contains("STEP 2"));
     assert!(t.wait_frame(|s| s.contains("STEP 3"))?.contains("STEP 3"));
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -204,7 +204,7 @@ fn wait_frame_fails_fast_on_eof() {
         .spawn("sh")
         .unwrap();
     t.wait_frame(|s| s.contains("done")).unwrap();
-    t.send(Key::Enter);
+    t.send(Key::Enter).unwrap();
 
     let start = Instant::now();
     let err = t.wait_frame(|s| s.contains("never painted")).unwrap_err();
@@ -302,7 +302,7 @@ fn a_begin_end_pair_that_drew_nothing_is_still_a_frame() {
         .spawn("sh")
         .unwrap();
     t.wait_frame(|s| s.contains("STATIC")).unwrap();
-    t.send(Key::Enter);
+    t.send(Key::Enter).unwrap();
 }
 
 /// The headline case: `send(key); wait_frame(OLD_STATE)` used to pass on
@@ -322,7 +322,7 @@ fn a_superseded_frame_no_longer_satisfies_a_wait() -> termlens::Result<()> {
         .spawn("sh")?;
 
     assert!(t.wait_frame(|s| s.contains("STATE-A"))?.contains("STATE-A"));
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
 
     let stale = t.wait_frame_for(|s| s.contains("STATE-A"), Duration::from_millis(700));
     assert!(
@@ -333,7 +333,7 @@ fn a_superseded_frame_no_longer_satisfies_a_wait() -> termlens::Result<()> {
     // The frame the application actually drew is there for the asking.
     assert!(t.wait_frame(|s| s.contains("STATE-B"))?.contains("STATE-B"));
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -355,7 +355,7 @@ fn one_frame_cannot_satisfy_two_waits() -> termlens::Result<()> {
         "one repaint must not satisfy two waits: {again:?}"
     );
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -414,7 +414,7 @@ fn the_returned_frame_is_the_matched_instant_not_the_live_screen() -> termlens::
         t.screen()
     );
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -474,7 +474,7 @@ fn a_snapshot_can_be_mid_frame_for_a_synchronized_application() -> termlens::Res
         "the frame is not finished, and screen() says so:\n{torn}"
     );
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     // The frame-consistent read has both rows, by construction.
     let frame = t.wait_frame(|s| s.contains("ROW-TWO"))?;
     assert!(
@@ -482,7 +482,7 @@ fn a_snapshot_can_be_mid_frame_for_a_synchronized_application() -> termlens::Res
         "{frame}"
     );
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -355,8 +355,31 @@ fn a_mouse_click_at_a_departed_child_blames_the_child() -> termlens::Result<()> 
             !err.to_string().contains("mouse tracking"),
             "must not blame the tracking mode: {err}"
         );
-        assert!(err.to_string().contains("exited"), "{err}");
+        assert!(err.to_string().contains("the child is gone"), "{err}");
     }
+    Ok(())
+}
+
+/// Refusing the write is ours, not the OS's, and that is the point: a raw
+/// write to a closed terminal fails with EIO on macOS and *succeeds* on
+/// Linux. This test failed on Linux and passed on macOS before `send`
+/// gained the liveness check, which is exactly the split it exists to
+/// close — a keystroke silently swallowed on one runner and reported on the
+/// other.
+#[test]
+fn a_departed_child_is_refused_identically_on_every_platform() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", "printf bye"])
+        .spawn("/bin/sh")?;
+    assert!(t.wait_exit()?.success());
+    // Not "the write failed" — the terminal is closed, so there is nothing
+    // to write to, and that verdict is reached before any syscall.
+    let err = t.send_str("swallowed?").unwrap_err();
+    assert!(
+        err.to_string().contains("the terminal is closed"),
+        "the refusal must name the closed terminal, not an OS errno: {err}"
+    );
     Ok(())
 }
 

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -31,7 +31,7 @@ fn clicks_round_trip_through_the_apps_tracking_mode() -> termlens::Result<()> {
     t.scroll(3, 2, Scroll::Down)?;
     t.wait_frame(|s| s.contains("last: mouse:scrolldown:3,2"))?;
 
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -49,11 +49,11 @@ fn modifier_chords_round_trip_through_crossterms_parser() -> termlens::Result<()
         (Key::F(5).ctrl().shift(), "last: ctrl+shift+f:5"),
         (Key::Delete.alt(), "last: alt+delete"),
     ] {
-        t.send(chord);
+        t.send(chord)?;
         t.wait_frame(|s| s.contains(name))?;
     }
 
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -64,10 +64,10 @@ fn paste_is_one_event_under_bracketed_paste() -> termlens::Result<()> {
     t.wait_frame(|s| s.contains("form-echo ready"))?;
 
     // One paste event — not eleven key presses — proves the wrapper.
-    t.paste("hello world");
+    t.paste("hello world")?;
     t.wait_frame(|s| s.contains("input: hello world") && s.contains("last: paste:11"))?;
 
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -86,9 +86,9 @@ fn paste_falls_back_to_plain_bytes_without_the_mode() -> termlens::Result<()> {
             ),
         ])
         .spawn("/bin/sh")?;
-    t.paste("plain");
+    t.paste("plain")?;
     t.wait_until(|s| s.contains("got:plain"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -100,12 +100,12 @@ fn an_embedded_paste_marker_cannot_end_the_paste() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
 
-    t.paste("AB\x1b[201~CD");
+    t.paste("AB\x1b[201~CD")?;
     // One paste event carrying all four characters — the markers are
     // gone, so nothing arrives as key presses.
     t.wait_frame(|s| s.contains("input: ABCD") && s.contains("last: paste:4"))?;
 
-    t.send(Key::Esc);
+    t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -133,7 +133,7 @@ fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
         .spawn("/bin/sh")?;
     t.wait_until(|s| s.contains("READY"))?;
 
-    t.paste("a\nb");
+    t.paste("a\nb")?;
     t.wait_until(|s| s.contains("WIRE-EOF"))?;
     let row = t.screen().row_text(0);
     assert!(
@@ -143,7 +143,7 @@ fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
 
     // ICRNL is off, so the guard `read` needs a literal newline — the
     // CR that Key::Enter sends is no longer translated for it.
-    t.send_str("\n");
+    t.send_str("\n")?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -182,7 +182,7 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
     // and shows the wire instead of timing out. Seven of them because a
     // correct click already supplied all seven bytes; these are only ever
     // read when it did not.
-    t.send_str("\n\n\n\n\n\n\n");
+    t.send_str("\n\n\n\n\n\n\n")?;
     t.wait_until(|s| s.contains("WIRE-EOF"))?;
 
     let wire = t.screen().row_text(0);
@@ -190,7 +190,7 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
         wire.contains("1b5b4d20c28524"),
         "expected ESC [ M 0x20 c2 85 0x24 (UTF-8 column 100), got: {wire}"
     );
-    t.send_str("QUIT\n");
+    t.send_str("QUIT\n")?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -255,7 +255,7 @@ fn drag_is_refused_when_the_mode_cannot_express_it() -> termlens::Result<()> {
     assert!(matches!(err, Error::Input(_)), "got: {err}");
     assert!(err.to_string().contains("X10"), "unhelpful: {err}");
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -278,14 +278,14 @@ fn arrows_follow_the_apps_cursor_key_mode() -> termlens::Result<()> {
         .spawn("/bin/sh")?;
 
     t.wait_until(|s| s.contains("APP"))?;
-    t.send(Key::Up);
+    t.send(Key::Up)?;
     t.wait_until(|s| s.contains("got:EOA"))?;
 
     t.wait_until(|s| s.contains("NORM"))?;
-    t.send(Key::Up);
+    t.send(Key::Up)?;
     t.wait_until(|s| s.contains("got:E[A"))?;
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -305,6 +305,78 @@ fn clicking_without_mouse_tracking_is_a_typed_error() {
     assert!(matches!(err, Error::Input(_)), "got: {err}");
     assert!(err.to_string().contains("mouse tracking"), "{err}");
 
-    t.send(Key::Char('q'));
+    t.send(Key::Char('q')).unwrap();
     assert!(t.wait_exit().unwrap().success());
+}
+
+/// Typed input to a child that is gone is an error the test can handle,
+/// not a panic and not silence. `write_or_panic` used to make this the one
+/// failure that could only reach a test by aborting it.
+#[test]
+fn typed_input_to_a_departed_child_is_a_typed_error() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", "printf bye"])
+        .spawn("/bin/sh")?;
+    assert!(t.wait_exit()?.success());
+
+    let err = t.send(Key::Enter).unwrap_err();
+    assert!(matches!(err, Error::Write { .. }), "got: {err}");
+    // The screen travels with it, like a timeout's.
+    assert!(err.screen().is_some_and(|s| s.contains("bye")), "{err}");
+    assert!(err.to_string().contains("Enter"), "{err}");
+
+    // Same contract for the other two.
+    assert!(matches!(t.send_str("x"), Err(Error::Write { .. })));
+    assert!(matches!(t.paste("x"), Err(Error::Write { .. })));
+    Ok(())
+}
+
+/// A mouse click at a departed child names the child, not the tracking
+/// mode. The old order asked "did it enable mouse tracking?" first, which
+/// a child that has exited necessarily has not — so the answer was always
+/// technically true and never the reason.
+#[test]
+fn a_mouse_click_at_a_departed_child_blames_the_child() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", "printf bye"])
+        .spawn("/bin/sh")?;
+    assert!(t.wait_exit()?.success());
+
+    for err in [
+        t.click(1, 1).unwrap_err(),
+        t.scroll(1, 1, Scroll::Up).unwrap_err(),
+        t.drag(termlens::MouseButton::Left, (1, 1), (2, 2))
+            .unwrap_err(),
+    ] {
+        assert!(matches!(err, Error::Write { .. }), "got: {err}");
+        assert!(
+            !err.to_string().contains("mouse tracking"),
+            "must not blame the tracking mode: {err}"
+        );
+        assert!(err.to_string().contains("exited"), "{err}");
+    }
+    Ok(())
+}
+
+/// The other half of the contract: a child that is *alive* but has not read
+/// yet is not a failure. The bytes sit in the terminal's input queue
+/// exactly as they would on a real terminal, and the write succeeded.
+#[test]
+fn typed_input_to_a_live_child_that_has_not_read_yet_succeeds() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            "printf READY; sleep 0.4; read line; printf ' got:%s' \"$line\"",
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+
+    // Sent while the child is sleeping, well before its `read`.
+    t.send_str("pending\n")?;
+    t.wait_until(|s| s.contains("got:pending"))?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
 }

--- a/crates/termlens/tests/process.rs
+++ b/crates/termlens/tests/process.rs
@@ -16,7 +16,7 @@ fn current_dir_runs_the_child_where_asked() -> termlens::Result<()> {
         .args(["-c", "pwd; read _"])
         .spawn("sh")?;
     t.wait_until(|s| s.contains(dir.to_str().expect("utf-8 temp dir")))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -30,7 +30,7 @@ fn pid_reports_the_direct_child() -> termlens::Result<()> {
     let pid = t.pid().expect("unix reports pids");
     // The shell's $$ is the exact process the harness spawned.
     t.wait_until(|s| s.contains(&format!("pid:{pid};")))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -80,7 +80,7 @@ fn wait_until_for_overrides_the_default_timeout_upward() -> termlens::Result<()>
         .args(["-c", "sleep 1; printf late-bloomer; read _"])
         .spawn("sh")?;
     t.wait_until_for(|s| s.contains("late-bloomer"), Duration::from_secs(30))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -26,7 +26,7 @@ fn cursor_position_reports_the_position_at_the_query() -> termlens::Result<()> {
         r#"printf '\nunblocked:%s' "$reply"; read guard"#
     ))?;
     t.wait_until(|s| s.contains("unblocked:E[1;4R"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -42,7 +42,7 @@ fn device_attribute_probes_are_unblocked() -> termlens::Result<()> {
         r#"printf 'unblocked:%s' "$reply"; read guard"#
     ))?;
     t.wait_until(|s| s.contains("unblocked:E[?62;22c"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -63,7 +63,7 @@ fn background_color_query_gets_the_configured_answer() -> termlens::Result<()> {
         ])
         .spawn("/bin/sh")?;
     t.wait_until(|s| s.contains("unblocked:E]11;rgb:1e1e/1e1e/2e2eG"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -84,7 +84,7 @@ fn foreground_color_query_gets_the_configured_answer() -> termlens::Result<()> {
         ])
         .spawn("/bin/sh")?;
     t.wait_until(|s| s.contains("unblocked:E]10;rgb:cdcd/d6d6/f4f4G"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -98,7 +98,7 @@ fn text_area_size_reports_the_real_grid() -> termlens::Result<()> {
         r#"printf 'unblocked:%s' "$reply"; read guard"#
     ))?;
     t.wait_until(|s| s.contains("unblocked:E[8;24;80t"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -223,7 +223,7 @@ fn an_app_that_probes_for_synchronized_output_gets_it() -> termlens::Result<()> 
     ))?;
 
     t.wait_frame(|s| s.contains("PROBED FRAME"))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -248,7 +248,7 @@ fn mode_reports_are_truthful() -> termlens::Result<()> {
     assert!(row.contains("E[?1;2$y"), "DECCKM should be reset: {row}");
     assert!(row.contains("E[?12;0$y"), "12 is not tracked: {row}");
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -296,7 +296,7 @@ fn replies_are_not_echoed_into_the_screen() -> termlens::Result<()> {
         "reply leaked into the grid:\n{}",
         t.screen()
     );
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -326,7 +326,7 @@ fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
     // Press and release, SGR-encoded, 1-based on the wire.
     t.wait_until(|s| s.contains("CLICK:E[<0;10;5ME[<0;10;5m"))?;
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/scrollback.rs
+++ b/crates/termlens/tests/scrollback.rs
@@ -44,7 +44,7 @@ fn content_scrolled_off_the_top_is_still_assertable() -> termlens::Result<()> {
     assert!(s.full_text().contains("line-40"));
     assert!(s.scrollback_rows() >= 34, "rows: {}", s.scrollback_rows());
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -61,7 +61,7 @@ fn full_text_answers_without_knowing_which_region_holds_it() -> termlens::Result
     let s = t.screen();
     assert_eq!(s.scrollback_rows(), 0, "nothing has scrolled yet");
     assert!(s.full_text().contains("line-1\n"));
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
 
     // Same assertion, same content, now past the top of a smaller screen.
@@ -70,7 +70,7 @@ fn full_text_answers_without_knowing_which_region_holds_it() -> termlens::Result
     let s = t.screen();
     assert!(s.scrollback_rows() > 0, "some rows must have scrolled");
     assert!(s.full_text().contains("line-1\n"));
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -93,7 +93,7 @@ fn the_retention_bound_drops_the_oldest_rows() -> termlens::Result<()> {
     // The newest retained rows are there; the visible screen holds the rest.
     assert!(s.full_text().contains("line-60"));
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -109,7 +109,7 @@ fn retention_can_be_switched_off() -> termlens::Result<()> {
     assert_eq!(s.full_text(), s.text(), "full_text is then just the screen");
     assert!(!s.full_text().contains("line-1\n"));
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -133,7 +133,7 @@ fn history_is_observable_from_a_predicate() -> termlens::Result<()> {
     t.wait_until(|s| s.scrollback_text().contains("committed-block"))?;
     assert!(!t.screen().contains("committed-block"));
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/state.rs
+++ b/crates/termlens/tests/state.rs
@@ -37,7 +37,7 @@ fn screen_reports_title_alternate_screen_and_input_modes() -> termlens::Result<(
             && s.mouse_mode() == MouseMode::ButtonMotion
     })?;
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_until(|s| {
         s.contains("modes: off")
             && s.title() == "phase two" // OSC 2, ST-terminated
@@ -47,7 +47,7 @@ fn screen_reports_title_alternate_screen_and_input_modes() -> termlens::Result<(
             && s.mouse_mode() == MouseMode::None
     })?;
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -68,11 +68,11 @@ fn mouse_mode_reports_the_exact_tracking_mode() -> termlens::Result<()> {
         .spawn("sh")?;
 
     t.wait_until(|s| s.contains("9") && s.mouse_mode() == MouseMode::Press)?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_until(|s| s.contains("1000") && s.mouse_mode() == MouseMode::PressRelease)?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     t.wait_until(|s| s.contains("1003") && s.mouse_mode() == MouseMode::AnyMotion)?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -109,7 +109,7 @@ fn a_clipboard_write_is_observable_with_its_payload() -> termlens::Result<()> {
         "the escape leaked into the grid:\n{s}"
     );
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -131,7 +131,7 @@ fn an_unreadable_clipboard_payload_is_reported_as_such() -> termlens::Result<()>
     assert_eq!(clip.text(), None);
     assert_eq!(clip.targets(), "p");
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -34,13 +34,13 @@ fn moving_a_highlight_changes_the_styled_rendering_only() -> termlens::Result<()
     let mut first = sh(&list_with_highlight(0))?;
     first.wait_until(settled)?;
     let a = first.screen();
-    first.send(Key::Enter);
+    first.send(Key::Enter)?;
     first.wait_exit()?;
 
     let mut second = sh(&list_with_highlight(1))?;
     second.wait_until(settled)?;
     let b = second.screen();
-    second.send(Key::Enter);
+    second.send(Key::Enter)?;
     second.wait_exit()?;
 
     // The pinning scenario from the coverage study: identical text…
@@ -65,7 +65,7 @@ fn styled_screen_snapshot() -> termlens::Result<()> {
     // against the recorded `cursor: 2,0`.
     t.wait_until(|s| s.contains("selected") && s.cursor() == (2, 0, true))?;
     insta::assert_snapshot!(t.screen().with_styles());
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -86,13 +86,13 @@ fn a_masked_field_is_distinguishable_from_clear_text() -> termlens::Result<()> {
     let mut masked = sh(r"printf 'pw: \033[8mhunter2\033[28m|'; read guard")?;
     masked.wait_until(settled)?;
     let a = masked.screen();
-    masked.send(Key::Enter);
+    masked.send(Key::Enter)?;
     masked.wait_exit()?;
 
     let mut clear = sh(r"printf 'pw: hunter2|'; read guard")?;
     clear.wait_until(settled)?;
     let b = clear.screen();
-    clear.send(Key::Enter);
+    clear.send(Key::Enter)?;
     clear.wait_exit()?;
 
     // Identical text — a real terminal holds the characters either way, and
@@ -141,7 +141,7 @@ fn strikethrough_and_blink_appear_in_the_styled_rendering() -> termlens::Result<
     let badge = *s.cell(overdue.0, overdue.1).unwrap().style();
     assert!(badge.blink && badge.fg == termlens::Color::Indexed(1));
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/timeouts.rs
+++ b/crates/termlens/tests/timeouts.rs
@@ -21,7 +21,7 @@ fn slow_app(script: &str) -> Terminal {
 fn wait_frame_for_overrides_the_builder_default() -> termlens::Result<()> {
     let mut t = slow_app(r"sleep 1; printf '\033[?2026hlate frame\033[?2026l'; read guard");
     t.wait_frame_for(|s| s.contains("late frame"), Duration::from_secs(30))?;
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit_for(Duration::from_secs(30))?.success());
     Ok(())
 }
@@ -45,7 +45,7 @@ fn wait_idle_for_overrides_the_builder_default() -> termlens::Result<()> {
     // deadline. `per_call_timeouts_report_their_own_deadline` covers the
     // deadline behaviour against a still-chattering child.)
 
-    t.send(Key::Enter);
+    t.send(Key::Enter)?;
     assert!(t.wait_exit_for(Duration::from_secs(30))?.success());
     Ok(())
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -94,10 +94,20 @@ released — the state lock and the writer lock are never held together.
 Every write — query replies and typed input alike — is handed to a
 dedicated writer thread over a bounded queue. Typed input carries an
 acknowledgement channel, so the test thread applies the terminal's
-deadline and panics with the screen ("the application is not reading its
-input") instead of blocking forever; there is no portable way to ask
-whether a PTY write *would* block, since `POLLOUT` on a macOS master
-reports writable and then blocks anyway.
+deadline and returns `Error::Write` with the screen ("the application is
+not reading its input") instead of blocking forever; there is no portable
+way to ask whether a PTY write *would* block, since `POLLOUT` on a macOS
+master reports writable and then blocks anyway.
+
+Which failures are errors and which are panics is a deliberate split, not
+an accident of history. `send`/`send_str`/`paste`/`click`/`drag`/`scroll`
+all return `Result`, because *whether the child is still there to receive
+input* is a fact about the run, discovered at runtime, and a test may
+legitimately want to handle it. `Key::F(13)` still panics, because there
+is no thirteenth function key on any terminal and never will be: that is a
+mistake in the test's own source, and the same category as indexing a
+slice out of bounds. Environmental failures are errors; impossible
+arguments are panics.
 
 Replies go to that same thread, fire-and-forget: writing them from the
 reader thread would block whenever the application stopped reading its


### PR DESCRIPTION
Closes #105.

## Verified first

Both halves were measured against the **published 0.4.2** before any code changed ([full results](https://github.com/vyncint/termlens/issues/105#issuecomment-5341271240)).

**Part 2 reproduces verbatim** — and it is the sharper bug. Against a reaped child:

```
click  -> Err("the application has not enabled mouse tracking (no CSI ?9/?1000/?1002/?1003 h was seen)")
scroll -> Err(same)
drag   -> Err(same)
```

A child that has exited necessarily never enabled tracking either, so the mode check was always *technically* right and never the reason. With tracking enabled before the child died, `click` panicked with EIO instead — so the mouse path had both faults.

**Part 1's measurement does not reproduce.** `send()` to an exited child does not return silently; it panics with EIO and the screen attached — 0.3's acknowledged write path already did that. The one case that returns normally is a *live* child that has not read yet, where the write genuinely succeeded into the terminal's input queue. That is a pending keystroke, not a lost one, and this PR pins it as correct.

So part 1 lands on the narrower argument the issue also makes: the deadline could only reach a test by aborting it.

## Changes

- `send`, `send_str`, `paste` → `Result<()>`; `write_or_panic` is gone. **Breaking**; call sites grow a `?`.
- `click`/`drag`/`scroll` call `ensure_deliverable` before the mode check.
- New `Error::Write { what, screen }` carrying the screen, like `Timeout` and `Eof`. `Error::screen()` returns it. `Error` is `#[non_exhaustive]`, so the variant itself is not breaking.

## The panic/error split, stated

`Key::F(13)` still panics, and `docs/DESIGN.md` §1 now says why: **environmental failures are errors; impossible arguments are panics.** Whether the child is still there is discovered at runtime and a test may reasonably handle it. There is no thirteenth function key on any terminal, so that is a mistake in the test's own source — the same category as indexing a slice out of bounds.

## Tests

Three added to `tests/input.rs`, one per limb of the contract:

- `typed_input_to_a_departed_child_is_a_typed_error` — `Error::Write` from all three senders, screen attached
- `a_mouse_click_at_a_departed_child_blames_the_child` — asserts the message does **not** say "mouse tracking" and does say "exited", for click/scroll/drag
- `typed_input_to_a_live_child_that_has_not_read_yet_succeeds` — the case that must stay a success

99 call sites migrated across the suite. Four tests that deliberately return `()` to assert on an `Err` path use `.unwrap()` rather than growing a `Result` return.

## Checklist

- [x] Linked an issue — closes #105
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none