### PR TITLE
fix(screen)!: stop two accessors answering when they have nothing to say

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ listed under a **Changed** or **Removed** heading.
   application was simply gone. The tracking-mode error is unchanged for a
   live application that really has not enabled it.
 
+- **`ExitStatus::code` returns `Option<u32>`**, `None` when a signal killed
+  the child. A signalled process has no exit status — POSIX gives one or
+  the other — and the OS placeholder (1) that filled the slot made
+  `assert_eq!(status.code(), 1)` pass on a `SIGTERM` path, which would keep
+  passing if the application later started exiting 1 for a real reason.
+  `Display` no longer prints the invented `(code 1)` tail either. Mirrors
+  `std::process::ExitStatus::code`.
+- **`Screen::rect_text` panics on a backwards range** instead of returning
+  `""` or a bare `"\n"`, and both axes now behave identically — they did
+  not. It reads as "this pane is empty", a plausible assertion outcome, so
+  a call with its arguments swapped passed for the wrong reason and kept
+  passing. A panic rather than an error for the same reason `&slice[3..0]`
+  panics: a backwards literal range is a mistake in the calling source, not
+  a fact about the terminal. Out-of-range bounds are a different thing and
+  stay clamped.
+
 ### Added
 
 - **`Error::Write`**, carrying the screen at the moment of the failed

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -550,10 +550,29 @@ impl Screen {
     /// Cells contribute as in [`Screen::row_text`]: blanks render as
     /// spaces, and a wide character contributes where its leading cell
     /// sits — even when the rectangle cuts it in half.
+    ///
+    /// # Panics
+    ///
+    /// If either range runs backwards (`3..0`). Note the argument order:
+    /// this is the one API in the crate that takes **columns first**, to
+    /// match [`TerminalBuilder::size`](crate::TerminalBuilder::size), while
+    /// every cell address elsewhere is `(row, col)`. Swapping the two is
+    /// therefore the mistake to expect, and a swap can invert a range.
+    ///
+    /// A panic rather than an error, deliberately, and for the same reason
+    /// `&slice[3..0]` panics: a backwards range is not a fact about the
+    /// terminal discovered at runtime, it is a mistake in the calling
+    /// source. Returned quietly it read as `""` — "this pane is empty",
+    /// a perfectly plausible assertion outcome — so a mis-ordered call
+    /// passed for the wrong reason and kept passing. Clippy's
+    /// `reversed_empty_ranges` already refuses a written-out `3..0`; this
+    /// covers the computed bounds it cannot see. Out-of-*range* bounds are
+    /// different and stay clamped: asking for more screen than exists is a
+    /// reasonable thing to do.
     #[must_use]
     pub fn rect_text(&self, cols: impl RangeBounds<u16>, rows: impl RangeBounds<u16>) -> String {
-        let (col_start, col_end) = clamp_range(&cols, self.cols);
-        let (row_start, row_end) = clamp_range(&rows, self.rows);
+        let (col_start, col_end) = clamp_range(&cols, self.cols, "column");
+        let (row_start, row_end) = clamp_range(&rows, self.rows, "row");
         let mut out = String::new();
         for row in row_start..row_end {
             if row > row_start {
@@ -652,7 +671,12 @@ impl Screen {
 }
 
 /// Clamp any range expression to `0..len`, as `(start, end)` exclusive.
-fn clamp_range(range: &impl RangeBounds<u16>, len: u16) -> (u16, u16) {
+///
+/// # Panics
+///
+/// If the range runs backwards, naming the axis. See [`Screen::rect_text`]
+/// for why this is a panic and not an error.
+fn clamp_range(range: &impl RangeBounds<u16>, len: u16, axis: &str) -> (u16, u16) {
     let start = match range.start_bound() {
         Bound::Included(&s) => s,
         Bound::Excluded(&s) => s.saturating_add(1),
@@ -663,6 +687,13 @@ fn clamp_range(range: &impl RangeBounds<u16>, len: u16) -> (u16, u16) {
         Bound::Excluded(&e) => e,
         Bound::Unbounded => len,
     };
+    // Checked on what the caller wrote, before clamping, so the message
+    // quotes their numbers. Clamping cannot create an inversion: both
+    // bounds are clamped to the same `len`.
+    assert!(
+        start <= end,
+        "rect_text: {axis} range starts at {start} but ends at {end}"
+    );
     (start.min(len), end.min(len))
 }
 
@@ -897,6 +928,40 @@ mod tests {
         assert_eq!(s.rect_text(0..3, 5..9), ""); // rows clamp to nothing
         assert_eq!(s.rect_text(20..30, ..1), ""); // cols clamp to nothing
         assert_eq!(s.rect_text(.., ..), s.text()); // the whole screen
+    }
+
+    /// Both axes, because they used to disagree: a reversed column range
+    /// returned a bare "\n" and a reversed row range returned "", and
+    /// neither said anything was wrong.
+    ///
+    /// The bounds come from variables on purpose. A *literal* `3..0` is
+    /// already caught by clippy's `reversed_empty_ranges`, so the case that
+    /// reaches a running test is the computed one — which is also the shape
+    /// a swapped-argument mistake actually takes.
+    #[test]
+    #[should_panic(expected = "column range starts at 3 but ends at 0")]
+    fn a_reversed_column_range_panics() {
+        let s = screen(10, 3, &["0123456789", "abcdefghij", "xyz"]);
+        let (from, to) = (3, 0);
+        let _ = s.rect_text(from..to, 0..2);
+    }
+
+    #[test]
+    #[should_panic(expected = "row range starts at 2 but ends at 0")]
+    fn a_reversed_row_range_panics() {
+        let s = screen(10, 3, &["0123456789", "abcdefghij", "xyz"]);
+        let (from, to) = (2, 0);
+        let _ = s.rect_text(0..3, from..to);
+    }
+
+    /// Out-of-range is not the same mistake and stays clamped: asking for
+    /// more screen than exists is reasonable, asking backwards is not.
+    #[test]
+    fn out_of_range_bounds_still_clamp() {
+        let s = screen(10, 3, &["0123456789", "abcdefghij", "xyz"]);
+        assert_eq!(s.rect_text(8..99, ..1), "89");
+        assert_eq!(s.rect_text(.., 1..99), "abcdefghij\nxyz");
+        assert_eq!(s.rect_text(5..5, ..), "\n\n"); // empty but not inverted
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -297,17 +297,21 @@ impl Signal {
 /// Exit status of the child process.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExitStatus {
-    code: u32,
+    code: Option<u32>,
     success: bool,
     signal: Option<Box<str>>,
 }
 
 impl ExitStatus {
     fn from_pty(status: &portable_pty::ExitStatus) -> Self {
+        let signal = status.signal().map(Box::<str>::from);
         Self {
-            code: status.exit_code(),
+            // A signalled process has no exit status: POSIX gives you one
+            // or the other. The OS reports a placeholder (1) in that slot
+            // and reporting it back would invent a value.
+            code: signal.is_none().then(|| status.exit_code()),
             success: status.success(),
-            signal: status.signal().map(Into::into),
+            signal,
         }
     }
 
@@ -317,11 +321,21 @@ impl ExitStatus {
         self.success
     }
 
-    /// The raw exit code as reported by the OS. Note that a signal-killed
-    /// child has no real exit code — the OS reports a placeholder (1);
-    /// check [`signal`](Self::signal) to tell the two cases apart.
+    /// The exit code, or `None` when a signal killed the child.
+    ///
+    /// POSIX gives a process *either* an exit status *or* a terminating
+    /// signal, never both, so `None` is the honest answer rather than a
+    /// gap in the API. The OS does put a placeholder (1) in the code slot
+    /// for a signalled child, and returning it made
+    /// `assert_eq!(status.code(), 1)` pass on a `SIGTERM` path — which
+    /// would keep passing if the application later started exiting 1 for a
+    /// real reason, a different event entirely.
+    ///
+    /// Mirrors [`std::process::ExitStatus::code`], which is `Option` for
+    /// the same reason. [`signal`](Self::signal) has the answer when this
+    /// is `None`, and [`Display`](fmt::Display) prints whichever applies.
     #[must_use]
-    pub fn code(&self) -> u32 {
+    pub fn code(&self) -> Option<u32> {
         self.code
     }
 
@@ -331,7 +345,7 @@ impl ExitStatus {
     /// Distinguishing "the app exited 1" from "something killed the app" is
     /// the difference between a failing test and a failing test *harness* —
     /// always assert with the full status in the message, e.g.
-    /// `assert_eq!(status.code(), 7, "status: {status}")`.
+    /// `assert_eq!(status.code(), Some(7), "status: {status}")`.
     #[must_use]
     pub fn signal(&self) -> Option<&str> {
         self.signal.as_deref()
@@ -340,9 +354,14 @@ impl ExitStatus {
 
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.signal {
-            Some(signal) => write!(f, "killed by signal: {signal} (code {})", self.code),
-            None => write!(f, "exit code {}", self.code),
+        match (&self.signal, self.code) {
+            // No "(code 1)" tail: that number is the OS placeholder, not a
+            // status the process ever returned.
+            (Some(signal), _) => write!(f, "killed by signal: {signal}"),
+            (None, Some(code)) => write!(f, "exit code {code}"),
+            // Neither: not reachable through `from_pty`, but the type
+            // allows it, so say so rather than printing a made-up code.
+            (None, None) => write!(f, "exited with no status reported"),
         }
     }
 }

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -26,7 +26,7 @@ fn echo_reaches_the_screen_and_child_exits_cleanly() -> termlens::Result<()> {
     t.send(Key::Enter)?;
     let status = t.wait_exit()?;
     assert!(status.success(), "full status: {status}");
-    assert_eq!(status.code(), 0);
+    assert_eq!(status.code(), Some(0));
     Ok(())
 }
 
@@ -38,7 +38,7 @@ fn exit_codes_are_reported() -> termlens::Result<()> {
     t.send(Key::Enter)?;
     let status = t.wait_exit()?;
     assert!(!status.success());
-    assert_eq!(status.code(), 7, "full status: {status}");
+    assert_eq!(status.code(), Some(7), "full status: {status}");
 
     // Idempotent: a second wait returns the cached status.
     assert_eq!(t.wait_exit()?, status);

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -88,7 +88,7 @@ fn form_echo_reports_nonzero_exit_codes() -> termlens::Result<()> {
     t.send(Key::Ctrl('x'))?;
     let status = t.wait_exit()?;
     assert!(!status.success());
-    assert_eq!(status.code(), 42, "full status: {status}");
+    assert_eq!(status.code(), Some(42), "full status: {status}");
     Ok(())
 }
 

--- a/crates/termlens/tests/process.rs
+++ b/crates/termlens/tests/process.rs
@@ -49,7 +49,7 @@ fn signal_term_exercises_the_graceful_shutdown_path() -> termlens::Result<()> {
     t.signal(Signal::Term)?;
     t.wait_until(|s| s.contains("got-term"))?;
     let status = t.wait_exit()?;
-    assert_eq!(status.code(), 7, "status: {status}");
+    assert_eq!(status.code(), Some(7), "status: {status}");
     assert_eq!(status.signal(), None, "trapped, not killed: {status}");
     Ok(())
 }
@@ -105,4 +105,52 @@ fn wait_until_for_overrides_the_default_timeout_downward() {
         other => panic!("expected a timeout, got: {other}"),
     }
     // Drop kills the parked child.
+}
+
+/// A signalled child has no exit code, and `code()` now says so. It used to
+/// report the OS placeholder (1) alongside the true signal, so
+/// `assert_eq!(status.code(), 1)` passed on a SIGTERM path — and would have
+/// kept passing if the application later began exiting 1 for a real reason.
+#[test]
+#[cfg(unix)]
+fn a_signalled_child_reports_no_exit_code() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", "printf READY; read guard"])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+
+    t.signal(termlens::Signal::Term)?;
+    let status = t.wait_exit()?;
+
+    assert!(!status.success(), "status: {status}");
+    assert_eq!(
+        status.code(),
+        None,
+        "a signalled child has no code: {status}"
+    );
+    assert!(
+        status.signal().is_some(),
+        "the signal is the answer: {status}"
+    );
+    // The Display no longer carries the invented number either.
+    let shown = status.to_string();
+    assert!(shown.starts_with("killed by signal"), "{shown}");
+    assert!(!shown.contains("code"), "{shown}");
+    Ok(())
+}
+
+/// The normal path is unchanged: a real exit code is still reported, now
+/// wrapped in `Some`.
+#[test]
+fn a_normally_exited_child_still_reports_its_code() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args(["-c", "exit 7"])
+        .spawn("/bin/sh")?;
+    let status = t.wait_exit()?;
+    assert_eq!(status.code(), Some(7), "status: {status}");
+    assert_eq!(status.signal(), None);
+    assert_eq!(status.to_string(), "exit code 7");
+    Ok(())
 }

--- a/crates/termlens/tests/timeouts.rs
+++ b/crates/termlens/tests/timeouts.rs
@@ -54,7 +54,7 @@ fn wait_idle_for_overrides_the_builder_default() -> termlens::Result<()> {
 fn wait_exit_for_overrides_the_builder_default() -> termlens::Result<()> {
     let mut t = slow_app("sleep 1; exit 3");
     let status = t.wait_exit_for(Duration::from_secs(30))?;
-    assert_eq!(status.code(), 3, "status: {status}");
+    assert_eq!(status.code(), Some(3), "status: {status}");
     Ok(())
 }
 


### PR DESCRIPTION
Closes #110, closes #109.

Two accessors that returned a confident value where they had none. Both measurements reproduce exactly against the published 0.4.2.

## `ExitStatus::code()` — #110

```
success=false  code=1  signal=Some("Terminated: 15")
```

after `signal(Signal::Term)`. The `1` is the OS placeholder for a slot a signalled process never filled; POSIX gives a process an exit code **or** a terminating signal, never both.

`code()` is now `Option<u32>`, `None` when signalled — matching `std::process::ExitStatus::code`, which is `Option` for exactly this reason. `Display` drops the invented `(code 1)` tail too, since that number was the same lie in a second place.

The trap this closes: `assert_eq!(status.code(), 1)` passed on a SIGTERM path today, and would have gone on passing if the application later started exiting 1 for a real reason — a different event entirely.

## `rect_text` with a backwards range — #109

```rust
s.rect_text(0..3, 0..2)   // "abc\ndef"   correct
s.rect_text(3..0, 0..2)   // "\n"         reversed columns
s.rect_text(0..3, 2..0)   // ""           reversed rows
```

Both now panic, naming the axis and the caller's own numbers, before clamping.

**Why a panic and not the typed error the issue proposed.** `&slice[3..0]` panics, and this is the same category: a backwards range is a mistake in the calling source, not a fact about the terminal discovered at runtime. That is the split #105 established in `docs/DESIGN.md` §2 — environmental failures are errors, impossible arguments are panics — and `Key::F(13)` already sits on the same side. A `Result` here would also mean changing the signature of the common case for the benefit of the broken one.

**A detail found while writing the tests, and it strengthens the case:** clippy's `reversed_empty_ranges` already refuses a written-out `3..0` — it fired on my own test and failed the build. So the case that reaches a *running* test is always the computed one, which is also the shape a swapped-argument mistake takes. The tests now build their bounds from variables, and the rustdoc records the division of labour.

Out-of-*range* bounds are a different mistake and stay clamped; `out_of_range_bounds_still_clamp` pins that they were not caught in the crossfire.

## Tests

- `a_reversed_column_range_panics`, `a_reversed_row_range_panics` — one per axis, since the axes disagreed
- `out_of_range_bounds_still_clamp` — the valid cases are unchanged
- `a_signalled_child_reports_no_exit_code` — `None` code, a signal, and a `Display` with no number in it
- `a_normally_exited_child_still_reports_its_code` — `Some(7)`, unchanged

Five existing `assert_eq!(status.code(), N)` call sites migrated to `Some(N)`.

## Checklist

- [x] Linked an issue — closes #110, #109
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none