### PR TITLE
fix(builder): refuse a terminal size that can only look like a hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ listed under a **Changed** or **Removed** heading.
   old order reported a missing `CSI ?1000 h` for a terminal whose
   application was simply gone. The tracking-mode error is unchanged for a
   live application that really has not enabled it.
-
 - **`ExitStatus::code` returns `Option<u32>`**, `None` when a signal killed
   the child. A signalled process has no exit status — POSIX gives one or
   the other — and the OS placeholder (1) that filled the slot made
@@ -45,12 +44,26 @@ listed under a **Changed** or **Removed** heading.
   panics: a backwards literal range is a mistake in the calling source, not
   a fact about the terminal. Out-of-range bounds are a different thing and
   stay clamped.
+- **An implausible terminal size is refused**, at most 1000 per axis, with
+  the limit named. `5000x5000` used to spawn happily and then spend 16
+  seconds inside the first wait before timing out with a message about the
+  predicate — a transposed `.size()` turned a sub-second test into a wedged
+  one with no hint of why. `resize` is held to the same limit.
 
 ### Added
 
 - **`Error::Write`**, carrying the screen at the moment of the failed
   write, the way `Error::Timeout` and `Error::Eof` already do.
   `Error::screen()` returns it.
+
+### Documented
+
+- **What a large grid costs**, on `TerminalBuilder::size`: a snapshot holds
+  one entry per cell and is rebuilt on every state change, so the cost is
+  O(cells) and shape-independent, while repeat reads of an unchanged screen
+  are cached and free. The table gives release *and* debug figures, because
+  `cargo test` builds unoptimized by default and the two differ by 16-29x —
+  the debug column is the one most suites actually see.
 
 ## [0.4.2] - 2026-08-19
 
@@ -86,6 +99,13 @@ whose gates all passed.*
   diagnostics set.
 
 ### Documented
+
+- **What a large grid costs**, on `TerminalBuilder::size`: a snapshot holds
+  one entry per cell and is rebuilt on every state change, so cost is
+  O(cells) and shape-independent, while repeat reads of an unchanged screen
+  are cached and free. The table gives release *and* debug figures, because
+  `cargo test` builds unoptimized by default and the two differ by 16-29x —
+  the debug column is the one most suites actually see.
 
 - **The crate-level docs describe 0.4, not 0.2.** The docs.rs landing page
   never mentioned `wait_frame`, retained scrollback, per-call deadlines or

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -657,9 +657,30 @@ impl Default for TerminalBuilder {
 impl TerminalBuilder {
     /// Terminal size as columns × rows. Defaults to 80×24.
     ///
-    /// Both dimensions must be non-zero; [`spawn`](Self::spawn) rejects a
-    /// zero with [`Error::Input`] rather than letting the emulator meet a
-    /// size no terminal can have.
+    /// Both dimensions must be non-zero and at most **1000**;
+    /// [`spawn`](Self::spawn) rejects anything else with [`Error::Input`]
+    /// rather than letting the emulator meet a size no terminal can have,
+    /// or one it can only serve slowly enough to look broken.
+    ///
+    /// # What a large grid costs
+    ///
+    /// A snapshot holds one entry per cell and is taken afresh on every
+    /// state change, so the cost is O(cells) — the same for `1000x100` as
+    /// for `100x1000`. Repeat reads of an unchanged screen are served from
+    /// a cache and are free. Measured, first snapshot after a change:
+    ///
+    /// | size | cells | release | debug |
+    /// |---|---|---|---|
+    /// | 80x24 | 1.9k | 47µs | 0.8ms |
+    /// | 200x60 | 12k | 0.3ms | 4.7ms |
+    /// | 500x500 | 250k | 3.7ms | 72ms |
+    /// | 1000x1000 | 1M | 10ms | 297ms |
+    ///
+    /// The debug column is the one most suites see, since `cargo test`
+    /// builds unoptimized by default. Ordinary terminal sizes are free in
+    /// either; a deliberately huge grid is a known trade-off rather than a
+    /// surprise, and past 1000 per axis it stops being a trade-off — hence
+    /// the limit.
     #[must_use]
     pub fn size(mut self, cols: u16, rows: u16) -> Self {
         self.cols = cols;
@@ -998,7 +1019,18 @@ fn strip_paste_markers(text: &str) -> String {
     }
 }
 
-/// Reject a zero terminal dimension.
+/// Widest and tallest terminal `spawn`/`resize` will accept, per axis.
+///
+/// Ten times a normal terminal on each side, so no real test is anywhere
+/// near it, and low enough that the worst case stays bounded: a snapshot
+/// costs O(cells), so 1000x1000 is a million cells — about 10ms per
+/// snapshot in release and 300ms in debug, which `cargo test` builds by
+/// default. Past this the numbers stop being slow and start being a wedge:
+/// 5000x5000 was accepted and turned the first wait into a 16-second
+/// timeout that blamed the predicate.
+const MAX_DIMENSION: u16 = 1000;
+
+/// Reject a terminal size that cannot work, or cannot work usefully.
 ///
 /// A terminal has at least one row and one column. Letting a zero reach
 /// the emulator is not a graceful degradation: in debug builds vt100
@@ -1010,11 +1042,25 @@ fn strip_paste_markers(text: &str) -> String {
 /// green. Zeroes arrive from ordinary arithmetic (`resize(cols - 1, …)`
 /// in a loop), so this must be a typed error, not a panic in a
 /// dependency.
+///
+/// The upper bound exists for the mirror-image reason. Nothing rejected an
+/// implausible size, and a snapshot costs O(cells), so a transposed or
+/// fat-fingered `.size()` did not fail — it went quiet. `5000x5000` spawned
+/// happily and then spent 16 seconds inside the first wait before timing
+/// out, with a message about the predicate and no hint that the size was
+/// the problem. A named error at the call site is the whole fix.
 fn check_size(cols: u16, rows: u16) -> Result<()> {
     if cols == 0 || rows == 0 {
         return Err(Error::Input(format!(
             "a terminal needs at least one column and one row, got {cols}x{rows} \
              (columns x rows)"
+        )));
+    }
+    if cols > MAX_DIMENSION || rows > MAX_DIMENSION {
+        return Err(Error::Input(format!(
+            "{cols}x{rows} (columns x rows) is past the {MAX_DIMENSION}-per-axis \
+             limit; a snapshot costs one entry per cell, so a grid this large \
+             makes every wait slow enough to look like a hang"
         )));
     }
     Ok(())

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -130,3 +130,49 @@ fn a_missing_program_still_reports_the_underlying_search_failure() {
         "the empty-name guard must not swallow real search failures: {message}"
     );
 }
+
+/// An implausible size used to be accepted, and the consequence appeared
+/// nowhere near the cause: 5000x5000 spawned fine, then the first wait
+/// spent 16 seconds building snapshots before timing out with a message
+/// about the predicate.
+#[test]
+fn an_implausible_size_is_refused_with_the_limit_named() {
+    for (cols, rows) in [(5000, 5000), (1001, 24), (80, 1001), (u16::MAX, u16::MAX)] {
+        let err = Terminal::builder()
+            .size(cols, rows)
+            .args(["-c", "true"])
+            .spawn("/bin/sh")
+            .expect_err("a terminal this large is refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("1000"),
+            "the limit belongs in the message: {msg}"
+        );
+        assert!(
+            msg.contains(&format!("{cols}x{rows}")),
+            "the offending size belongs in the message: {msg}"
+        );
+    }
+}
+
+/// The boundary itself is legal, and a resize is held to the same limit —
+/// `resize` is where a computed dimension is most likely to go wrong.
+#[test]
+fn the_limit_is_inclusive_and_resize_honours_it() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(1000, 1000)
+        .timeout(Duration::from_secs(20))
+        .args(["-c", "printf READY; read guard"])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+    assert_eq!(t.screen().size(), (1000, 1000));
+
+    let err = t.resize(1001, 1000).expect_err("past the limit");
+    assert!(err.to_string().contains("1000"), "{err}");
+    // Refused without disturbing the grid, like the zero case.
+    assert_eq!(t.screen().size(), (1000, 1000));
+
+    t.send_str("\n")?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}


### PR DESCRIPTION
Closes #106.

## Verified, and the numbers moved

Reproduced against the published 0.4.2: `5000x5000` spawns happily, then the first wait spends **16.2 s** building snapshots before timing out with a message about the predicate. A transposed `.size()` turns a sub-second test into a wedged one with no hint of the cause. That is the sharp case, and part 1 fixes it.

While measuring part 2 I found the issue's cost table is a **debug** build. Release is 16–29× faster across the range:

| size | cells | release | debug |
|---|---|---|---|
| 80x24 | 1.9k | 47µs | 0.8ms |
| 200x60 | 12k | 0.3ms | 4.7ms |
| 500x500 | 250k | 3.7ms | 72ms |
| 1000x1000 | 1M | **10ms** | 297ms |
| 2000x2000 | 4M | 43ms | — |

Also measured: cost is **O(cells) and shape-independent** — `1000x100`, `100x1000` and `316x316` all land within noise of each other. And the cache is as good as the issue says: a repeat read of an unchanged screen is sub-microsecond.

## Part 1 — the bound

`check_size` now caps each axis at **1000**, naming the limit and the offending size. `resize` is held to the same cap, since a computed dimension is where this goes wrong (`resize(cols * 2, …)` in a loop).

1000 is ten times a normal terminal on each side, so no real test is near it, and it bounds the worst case at 1M cells.

## Part 2 — not done, and the measurement is the reason

The issue offers `String`-per-cell as the cost driver and suggests storing the common case inline or skipping trailing blanks. I am declining it, and stating so rather than quietly leaving it out:

- With the axis capped at 1000, the **worst reachable case** is 10ms (release) / 297ms (debug). Ordinary sizes are 47µs / 0.8ms.
- Cost is O(cells), so the floor is one visit per cell regardless of what a `Cell` holds. The ceiling on any such optimisation is a small constant factor on a curve that no longer has a pathological end.

So there is no problem inside the reachable range for the optimisation to solve, and it would touch `Cell` — a public type — to buy that factor. If a future issue shows a real suite hurting at a legitimate size, the driver is identified and the change stays available.

What the issue asks for instead is satisfied: the cost curve is now **documented on `TerminalBuilder::size`**, with both columns, because `cargo test` builds unoptimized by default and the debug column is the one most suites actually see.

## Tests

- `an_implausible_size_is_refused_with_the_limit_named` — 5000x5000, 1001x24, 80x1001, `u16::MAX` squared; asserts the limit *and* the offending size are in the message
- `the_limit_is_inclusive_and_resize_honours_it` — 1000x1000 spawns, `resize(1001, 1000)` is refused, and the grid is untouched by the refusal, like the zero case

## Checklist

- [x] Linked an issue — closes #106
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none