### PR TITLE
fix(screen): fold needles to NFC so a match no longer depends on spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ listed under a **Changed** or **Removed** heading.
   predicate — a transposed `.size()` turned a sub-second test into a wedged
   one with no hint of why. `resize` is held to the same limit.
 
+- **`Screen::contains` and `Screen::find` fold both sides to NFC**, so a
+  needle finds text the application normalized the other way. A terminal
+  draws `caf\u{e9}` and `cafe\u{301}` identically — and so do the failure
+  output and the diff, which is what made the mismatch a trap rather than a
+  limitation: an author types NFC (what editors produce) while text from a
+  filesystem path, a git author name or macOS input is frequently NFD.
+  Unconditional, and no escape hatch is needed because the raw form is never
+  taken away: `text`, `row_text`, `rect_text`, `cell` and `title` all still
+  return exactly the codepoints the application sent. One consequence worth
+  knowing: matching is grapheme-shaped, so on a screen showing `caf\u{e9}`,
+  `contains("cafe")` is now false — the screen does not show `cafe`.
+
 ### Added
 
 - **`Error::Write`**, carrying the screen at the moment of the failed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "libc",
  "portable-pty",
  "thiserror 2.0.20",
+ "unicode-normalization",
  "unicode-width",
  "vt100",
 ]
@@ -550,10 +551,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ portable-pty = "0.9"
 vt100 = "0.16"
 thiserror = "2"
 unicode-width = "0.2"
+# Needle matching folds both sides to NFC. Terminals draw NFC and NFD
+# identically, so without this a test author's needle silently misses text
+# the application happened to normalize the other way — a false negative
+# invisible in the terminal, in the failure output, and in the diff.
+unicode-normalization = "0.1"
 # Already in the tree transitively (portable-pty); used directly for one
 # kill(2) call behind Terminal::signal.
 libc = "0.2"

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -24,6 +24,7 @@ insta = ["dep:insta"]
 portable-pty.workspace = true
 vt100.workspace = true
 thiserror.workspace = true
+unicode-normalization.workspace = true
 insta = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -8,6 +8,8 @@ use std::fmt;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
+use unicode_normalization::UnicodeNormalization;
+
 /// A terminal color, as reported by the emulator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Color {
@@ -461,9 +463,38 @@ impl Screen {
     /// The **visible screen only** — like every other query on this type.
     /// For content that may already have scrolled off, use
     /// [`full_text`](Self::full_text).
+    ///
+    /// # Normalization
+    ///
+    /// Both sides are folded to **NFC** before comparing, so a needle finds
+    /// text the application normalized the other way. A terminal draws
+    /// `caf\u{e9}` and `cafe\u{301}` identically, and so does the failure
+    /// output and the diff — which is what made the mismatch a trap rather
+    /// than a limitation. A test author types NFC (that is what editors
+    /// produce); text from a filesystem path, a git author name, or macOS
+    /// input is frequently NFD.
+    ///
+    /// Folding is unconditional here and needs no escape hatch, because the
+    /// raw form is never taken away: [`text`](Self::text),
+    /// [`row_text`](Self::row_text), [`rect_text`](Self::rect_text),
+    /// [`cell`](Self::cell) and [`title`](Self::title) all return exactly
+    /// the codepoints the application sent, so a test that means to assert
+    /// on normalization compares those directly. A snapshot is an
+    /// observation; only the search over it is forgiving.
+    ///
+    /// Note that this makes matching grapheme-shaped rather than
+    /// byte-shaped: on a screen showing `caf\u{e9}`, `contains("cafe")` is
+    /// **false**, because the screen does not show `cafe`.
+    ///
+    /// Text pulled out as a `String` and matched with `str` methods —
+    /// `full_text().contains(..)` — is byte-exact, since the comparison is
+    /// then `std`'s and not ours.
     #[must_use]
     pub fn contains(&self, needle: &str) -> bool {
-        self.text().contains(needle)
+        if self.is_ascii() && needle.is_ascii() {
+            return self.text().contains(needle);
+        }
+        self.nfc_text().contains(&nfc(needle))
     }
 
     /// Locate the first occurrence of `needle` scanning rows top to bottom;
@@ -477,16 +508,23 @@ impl Screen {
     ///
     /// Columns account for double-width characters: a match after a CJK
     /// character reports the real terminal column.
+    ///
+    /// Matching folds both sides to NFC, exactly as
+    /// [`contains`](Self::contains) does and for the same reasons — a needle
+    /// is found here precisely when `contains` is true. The reported column
+    /// is the real one: folding happens per cell, so the byte-to-column map
+    /// stays exact even where a composition shortened the text.
     #[must_use]
     pub fn find(&self, needle: &str) -> Option<(u16, u16)> {
         if needle.is_empty() {
             return Some((0, 0));
         }
+        let needle = &self.fold(needle);
         if !needle.contains('\n') {
             for row in 0..self.rows {
-                let text = self.row_text(row);
-                if let Some(byte_off) = text.find(needle) {
-                    return Some((row, self.col_of_byte(row, byte_off)?));
+                let (text, cols) = self.searchable_row(row);
+                if let Some(byte_off) = text.find(needle.as_str()) {
+                    return Some((row, cols.get(byte_off).copied()?));
                 }
             }
             return None;
@@ -498,13 +536,13 @@ impl Screen {
         let segments: Vec<&str> = needle.split('\n').collect();
         let extra = u16::try_from(segments.len() - 1).ok()?;
         for row in 0..self.rows.checked_sub(extra)? {
-            let first_line = self.row_text(row);
+            let (first_line, cols) = self.searchable_row(row);
             let first = first_line.trim_end();
             if !first.ends_with(segments[0]) {
                 continue;
             }
             let tail_matches = segments[1..].iter().enumerate().all(|(i, seg)| {
-                let line = self.row_text(row + 1 + i as u16);
+                let (line, _) = self.searchable_row(row + 1 + i as u16);
                 let line = line.trim_end();
                 if i as u16 == extra - 1 {
                     line.starts_with(seg) // last segment: prefix
@@ -521,7 +559,7 @@ impl Screen {
             return match segments.iter().position(|s| !s.is_empty()) {
                 Some(0) => {
                     let byte_off = first.len() - segments[0].len();
-                    Some((row, self.col_of_byte(row, byte_off)?))
+                    Some((row, cols.get(byte_off).copied()?))
                 }
                 Some(k) => Some((row + u16::try_from(k).ok()?, 0)),
                 None => Some((row + extra, 0)),
@@ -627,26 +665,73 @@ impl Screen {
         None
     }
 
-    /// Map a byte offset within `row_text(row)` back to the column of the
-    /// cell that contributed that byte (wide characters span two columns
-    /// but contribute their bytes once).
-    fn col_of_byte(&self, row: u16, byte_off: usize) -> Option<u16> {
-        let mut acc = 0usize;
-        for col in 0..self.cols {
-            let cell = self.cell(row, col)?;
-            let len = if cell.is_wide_continuation() {
-                0
-            } else if cell.contents().is_empty() {
-                1 // rendered as a space
-            } else {
-                cell.contents().len()
-            };
-            if len > 0 && byte_off < acc + len {
-                return Some(col);
-            }
-            acc += len;
+    /// True when every cell holds only ASCII, so normalization is the
+    /// identity and the search helpers can skip it. This is the shape of
+    /// virtually every screen, which is what keeps `contains` — evaluated
+    /// on every wait wake-up — as cheap as it was.
+    fn is_ascii(&self) -> bool {
+        self.cells.iter().all(|c| c.contents().is_ascii())
+    }
+
+    /// `needle` in the form the search helpers compare against.
+    fn fold(&self, needle: &str) -> String {
+        if self.is_ascii() && needle.is_ascii() {
+            needle.to_owned()
+        } else {
+            nfc(needle)
         }
-        None
+    }
+
+    /// The whole grid in searchable form: rows joined with `\n`, trailing
+    /// whitespace stripped per row, each row folded the same way
+    /// [`searchable_row`](Self::searchable_row) folds it — so `contains` and
+    /// `find` can never disagree about what matches.
+    fn nfc_text(&self) -> String {
+        let mut out = String::new();
+        for row in 0..self.rows {
+            if row > 0 {
+                out.push('\n');
+            }
+            let (line, _) = self.searchable_row(row);
+            out.push_str(line.trim_end());
+        }
+        out
+    }
+
+    /// One row in searchable form, plus the column that produced each byte.
+    ///
+    /// Folding is **per cell**, not over the joined string, and that is the
+    /// load-bearing detail: a cell holds a base character together with its
+    /// combining marks (vt100 appends them to the cell being written), so
+    /// folding cell by cell composes exactly what the terminal draws in one
+    /// cell and can never compose across a cell boundary. It also keeps the
+    /// byte-to-column map exact, which is what [`find`](Self::find) reports.
+    fn searchable_row(&self, row: u16) -> (String, Vec<u16>) {
+        let ascii = self.is_ascii();
+        let mut text = String::with_capacity(usize::from(self.cols));
+        let mut cols = Vec::with_capacity(usize::from(self.cols));
+        for col in 0..self.cols {
+            let Some(cell) = self.cell(row, col) else {
+                break;
+            };
+            if cell.is_wide_continuation() {
+                continue;
+            }
+            let before = text.len();
+            if cell.contents().is_empty() {
+                text.push(' ');
+            } else if ascii {
+                text.push_str(cell.contents());
+            } else {
+                text.extend(cell.contents().nfc());
+            }
+            cols.resize(text.len(), col);
+            debug_assert!(text.len() > before || cell.is_wide_continuation());
+        }
+        // One extra entry, so a match at the very end of the row maps to
+        // the last column instead of falling off the map.
+        cols.push(self.cols.saturating_sub(1));
+        (text, cols)
     }
 
     /// This screen rendered **with its styles**: the normal
@@ -668,6 +753,11 @@ impl Screen {
     pub fn with_styles(&self) -> ScreenWithStyles<'_> {
         ScreenWithStyles { screen: self }
     }
+}
+
+/// `s` folded to NFC.
+fn nfc(s: &str) -> String {
+    s.nfc().collect()
 }
 
 /// Clamp any range expression to `0..len`, as `(start, end)` exclusive.
@@ -835,6 +925,18 @@ mod tests {
             let mut row_cells: Vec<Cell> = Vec::new();
             if let Some(line) = lines.get(r) {
                 for ch in line.chars() {
+                    // A zero-width combining mark joins the cell it modifies,
+                    // which is what vt100 does: it appends combining
+                    // characters to the cell currently being written rather
+                    // than advancing. Modelling that here matters, because
+                    // needle folding is per cell.
+                    if ch.width().unwrap_or(1) == 0 {
+                        if let Some(last) = row_cells.last_mut() {
+                            let joined = format!("{}{ch}", last.contents());
+                            *last = Cell::new(joined, *last.style(), last.is_wide(), false);
+                            continue;
+                        }
+                    }
                     let wide = ch.width().unwrap_or(1) == 2;
                     let style = Style {
                         bold: ch == '*',
@@ -876,6 +978,54 @@ mod tests {
         assert!(s.contains("hello"));
         assert!(s.contains("hello\nworld"));
         assert!(!s.contains("hello world"));
+    }
+
+    /// The trap: NFC and NFD render identically, so a needle that misses
+    /// looks like content that is absent. Both directions, because the
+    /// author's needle and the application's output can each be either.
+    #[test]
+    fn needles_match_across_normalization_forms() {
+        let nfc = "caf\u{e9}";
+        let nfd = "cafe\u{301}";
+
+        let on_nfd = screen(10, 1, &[nfd]);
+        assert!(on_nfd.contains(nfc), "NFC needle must find NFD text");
+        assert!(on_nfd.contains(nfd));
+        assert_eq!(on_nfd.find(nfc), Some((0, 0)));
+        assert_eq!(on_nfd.find(nfd), Some((0, 0)));
+
+        let on_nfc = screen(10, 1, &[nfc]);
+        assert!(on_nfc.contains(nfd), "NFD needle must find NFC text");
+        assert!(on_nfc.contains(nfc));
+        assert_eq!(on_nfc.find(nfd), Some((0, 0)));
+
+        // The grid still holds what the application sent: an observation is
+        // not rewritten, and a test that means to assert on the form can.
+        assert_eq!(on_nfd.text(), nfd);
+        assert_eq!(on_nfc.text(), nfc);
+        assert_ne!(on_nfd.text(), on_nfc.text());
+    }
+
+    /// Matching is grapheme-shaped once folding applies: the screen shows
+    /// `caf\u{e9}`, so it does not show `cafe`.
+    #[test]
+    fn a_folded_match_does_not_split_a_composed_character() {
+        let on_nfd = screen(10, 1, &["cafe\u{301}"]);
+        assert!(!on_nfd.contains("cafe"), "the screen shows caf\u{e9}");
+        assert!(on_nfd.contains("caf"));
+    }
+
+    /// Columns must survive folding: NFD text is longer in bytes than its
+    /// NFC form, so a naive offset would land in the wrong cell.
+    #[test]
+    fn folded_matches_still_report_real_columns() {
+        // "e" + combining acute in cell 0, then a marker further along.
+        let s = screen(10, 1, &["e\u{301}xyMARK"]);
+        assert_eq!(s.find("MARK"), Some((0, 3)));
+        assert_eq!(s.find("x"), Some((0, 1)));
+        // Wide characters and folding together.
+        let wide = screen(10, 1, &["\u{6c49}e\u{301}Z"]);
+        assert_eq!(wide.find("Z"), Some((0, 3)));
     }
 
     #[test]

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -109,6 +109,54 @@ fn resize_reaches_the_child_as_sigwinch() -> termlens::Result<()> {
     Ok(())
 }
 
+/// Normalization folding against real vt100 output rather than a
+/// hand-built grid — one form on screen, the other in the needle, so the
+/// match can only come from folding.
+///
+/// The forms are spelled with explicit escapes, so this file's own encoding
+/// can never change the bytes. Before folding, the needle a test author
+/// would type — NFC, which is what editors produce — silently missed NFD
+/// text, and nothing about the miss was visible: not in the terminal, not
+/// in the failure output, not in a diff.
+#[test]
+fn a_needle_finds_text_in_the_other_normalization_form() -> termlens::Result<()> {
+    // "Tiếng" composed, and the same word decomposed.
+    let nfc = "Ti\u{1ebf}ng";
+    let nfd = "Tie\u{302}\u{301}ng";
+
+    for (on_screen, needle, label) in [
+        (nfd, nfc, "NFD screen, NFC needle"),
+        (nfc, nfd, "NFC screen, NFD needle"),
+    ] {
+        let mut t = Terminal::builder()
+            .size(40, 4)
+            .timeout(Duration::from_secs(10))
+            .args(["-c", &format!("printf '{on_screen} MARK'; read guard")])
+            .spawn("/bin/sh")?;
+        t.wait_until(|s| s.contains("MARK"))?;
+        let s = t.screen();
+
+        assert!(s.contains(needle), "{label}: folded match failed:\n{s}");
+        assert!(
+            s.contains(on_screen),
+            "{label}: exact match must still work"
+        );
+        assert_eq!(s.find(needle), Some((0, 0)), "{label}: real column");
+
+        // The grid keeps exactly what the application sent — an observation
+        // is not rewritten, so a test that means to assert on the form can.
+        assert!(s.row_text(0).contains(on_screen), "{label}: raw form kept");
+        assert!(
+            !s.row_text(0).contains(needle),
+            "{label}: the other form must NOT be in the grid"
+        );
+
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+    }
+    Ok(())
+}
+
 #[test]
 fn unicode_torture_renders_with_correct_widths() -> termlens::Result<()> {
     let mut t = spawn_fixture("unicode-torture")?;


### PR DESCRIPTION
Closes #103.

## Verified

Reproduced against the published 0.4.2, both directions, exactly as the issue tabulates:

| screen holds | needle `caf\u{e9}` (NFC) | needle `cafe\u{301}` (NFD) |
|---|---|---|
| `cafe\u{301}` (NFD) | **false**, `find` → `None` | true |
| `caf\u{e9}` (NFC) | true | **false** |

## The design decisions the issue asked to settle

**Unconditional, no opt-out flag.** Folding matches what an author means, and no escape hatch needs inventing because the raw form is never taken away — `text`, `row_text`, `rect_text`, `cell` and `title` all still return exactly the codepoints the application sent. A test that means to assert on normalization compares those directly. A snapshot is an observation; only the search over it is forgiving.

**Folding is per cell, not over the joined row**, and that is what keeps `find` column-exact. I verified that vt100 appends combining marks to the cell being written — a decomposed `e`+U+0301 lives in **one** cell, reported as `[3]="e\u{301}"` — so per-cell folding composes exactly what the terminal draws in one cell and can never compose across a cell boundary. `contains` and `find` are built on the same folded text, so they cannot disagree about what matches.

**An all-ASCII screen with an all-ASCII needle skips folding entirely.** `contains` runs on every wait wake-up, so the hot path stays as cheap as it was. Note the fast path needs *both* sides ASCII: on a screen holding `e`+U+0301, raw matching says `contains("e")` is true while folded matching says false, and the folded answer is the right one.

## One consequence worth knowing

Matching is now grapheme-shaped. On a screen showing `caf\u{e9}`, `contains("cafe")` is **false** — the screen does not show `cafe`. Documented on `contains`, and pinned by `a_folded_match_does_not_split_a_composed_character`.

## A bug in the test helper, found on the way

The unit-test `screen()` helper put a combining mark in **its own cell**, which vt100 never does. My first three tests failed against it, and the helper was the thing that was wrong. It now models the emulator, which is what makes those unit tests mean anything — and an integration test through a real PTY pins the property end to end, one form on screen and the other in the needle, so the match can only come from folding.

## The new dependency

`unicode-normalization` (plus `tinyvec`), MIT/Apache, `cargo deny check licenses` clean. There is no honest shortcut here — folding needs the Unicode data, and comparing grapheme clusters would not fold the two forms. The bug is a silent false negative in the crate's most-used predicate, hit by a real study against a real application, which is exactly the class of failure this crate exists to prevent.

## Tests

- `needles_match_across_normalization_forms` — both directions, and the grid still differs
- `a_folded_match_does_not_split_a_composed_character` — the grapheme-shaped consequence
- `folded_matches_still_report_real_columns` — including a wide character before a folded one
- `a_needle_finds_text_in_the_other_normalization_form` — real vt100 through a PTY, one form on screen

## Checklist

- [x] Linked an issue — closes #103
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none