### PR TITLE
feat(screen): observe repaints, bells and graphics payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,40 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- **`Screen::repaints`** — how many synchronized updates the application has
+  completed, as of this observation. It counts *repaints, not changes*, so a
+  Begin/End pair that drew nothing still counts, which is exactly the
+  property an amplification test needs: "one wheel notch produced four
+  repaints" is invisible to every content predicate, because each
+  intermediate frame shows correct content.
+- **`Screen::bells`** — how many times the application rang `BEL`. The bell
+  is often the only feedback a rejected input produces, so "an invalid key
+  does nothing" and "an invalid key is refused with a bell" used to be the
+  same screen. A count, not a flag, so twice differs from once; and only a
+  `BEL` in ground state counts, since the one terminating an `OSC` string is
+  punctuation and one inside a DCS-class string is payload.
+- **`Screen::graphics`** and **`GraphicsSeen`** — kitty (`APC G … ST`) and
+  sixel (`DCS q … ST`) payloads transmitted, by protocol, with total bytes.
+  The assertion this exists for is as often the negative one —
+  `assert!(s.graphics().is_empty())`, "this must render as text in every
+  terminal and never go out as an image" — so `is_empty` is a method rather
+  than something to spell out. Observing is not rendering and claims
+  nothing: DA1 still declines both protocols.
+- **The kitty graphics query is diagnosed.** `APC _G…a=q…ST` was swallowed
+  whole — no answer *and* no mention in the timeout note, alone among the
+  startup probes, because `string_final` inspected only `+q`/`$q` and an APC
+  matches neither. An application blocked on it now gets the same one-line
+  diagnosis `^[[?u` and `^[P+q…` already got. Only an explicit `a=q` counts
+  as a question: a transmission is an instruction, and treating one as a
+  query would put "the application queried the terminal" into the next
+  timeout of every application that draws.
 - **`Error::Write`**, carrying the screen at the moment of the failed
   write, the way `Error::Timeout` and `Error::Eof` already do.
   `Error::screen()` returns it.
+- **`Screen` is 40 bytes instead of 80**, with all out-of-band state behind
+  one `Arc`. A `Screen` is embedded in every `Error`, so this shrinks every
+  `Result` in the crate, and a clone — taken on each wait evaluation — is
+  now one refcount bump rather than a field-by-field copy.
 
 ### Documented
 
@@ -111,13 +142,6 @@ whose gates all passed.*
   diagnostics set.
 
 ### Documented
-
-- **What a large grid costs**, on `TerminalBuilder::size`: a snapshot holds
-  one entry per cell and is rebuilt on every state change, so cost is
-  O(cells) and shape-independent, while repeat reads of an unchanged screen
-  are cached and free. The table gives release *and* debug figures, because
-  `cargo test` builds unoptimized by default and the two differ by 16-29x —
-  the debug column is the one most suites actually see.
 
 - **The crate-level docs describe 0.4, not 0.2.** The docs.rs landing page
   never mentioned `wait_frame`, retained scrollback, per-call deadlines or

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -20,7 +20,7 @@
 
 use std::sync::Arc;
 
-use crate::screen::Clipboard;
+use crate::screen::{Clipboard, GraphicsSeen};
 
 /// OSC strings are captured whole (titles must not truncate), but bounded:
 /// a buggy or hostile stream must not grow memory without limit. No real
@@ -199,6 +199,30 @@ pub(crate) struct SeqTracker {
     title: Arc<str>,
     /// The most recent `OSC 52` clipboard write, decoded.
     clipboard: Option<Arc<Clipboard>>,
+    /// Bells rung in ground state. A `BEL` closing an OSC string is a
+    /// terminator and one inside a DCS-class string is payload; neither is
+    /// a bell, and both are handled by the state machine rather than here.
+    bells: u64,
+    /// Inline graphics payloads transmitted.
+    graphics: GraphicsSeen,
+    /// Which introducer opened the current DCS-class string: `P` (DCS),
+    /// `X` (SOS), `^` (PM) or `_` (APC). Sixel and kitty graphics differ
+    /// only by this, so consuming all four alike — which is all the tracker
+    /// needed before — cannot tell them apart.
+    dcs_introducer: u8,
+    /// Final byte of the current DCS header, 0 until seen. Sixel's is `q`
+    /// with no intermediate; XTGETTCAP and DECRQSS reach `q` through `+`
+    /// and `$`, which is what keeps them from being counted as pictures.
+    dcs_final: u8,
+    /// Intermediate byte in the current DCS header (`+` or `$` in practice).
+    dcs_intermediate: u8,
+    /// Payload bytes after the header, so a payload's size is reportable
+    /// without keeping the payload.
+    dcs_data_len: u64,
+    /// The opening bytes of a DCS-class payload, enough to read a kitty
+    /// control block (`G` plus `key=value` pairs up to the first `;`).
+    dcs_head: [u8; 48],
+    dcs_head_len: u8,
 }
 
 impl SeqTracker {
@@ -222,6 +246,14 @@ impl SeqTracker {
             osc_truncated: false,
             title: Arc::from(""),
             clipboard: None,
+            bells: 0,
+            graphics: GraphicsSeen::default(),
+            dcs_introducer: 0,
+            dcs_final: 0,
+            dcs_intermediate: 0,
+            dcs_data_len: 0,
+            dcs_head: [0; 48],
+            dcs_head_len: 0,
         }
     }
 
@@ -251,6 +283,24 @@ impl SeqTracker {
     /// until the application sets one).
     pub(crate) fn title(&self) -> Arc<str> {
         Arc::clone(&self.title)
+    }
+
+    /// Bells rung in ground state so far.
+    pub(crate) fn bells(&self) -> u64 {
+        self.bells
+    }
+
+    /// Inline graphics payloads transmitted so far.
+    pub(crate) fn graphics(&self) -> GraphicsSeen {
+        self.graphics
+    }
+
+    fn reset_dcs_scanner(&mut self, introducer: u8) {
+        self.dcs_introducer = introducer;
+        self.dcs_final = 0;
+        self.dcs_intermediate = 0;
+        self.dcs_data_len = 0;
+        self.dcs_head_len = 0;
     }
 
     fn reset_csi_scanner(&mut self) {
@@ -465,6 +515,33 @@ impl SeqTracker {
                 }
             }
         }
+        // An APC opening with `G` is the kitty graphics protocol.
+        if self.dcs_introducer == b'_' && self.dcs_head.first() == Some(&b'G') {
+            let control = self.dcs_control_block();
+            // Count the payload either way: "did this go out as an image?"
+            // and, more often, "did it *not*?" are the assertions, and a
+            // query carries no picture but is still traffic worth seeing.
+            let is_query = control.windows(3).any(|w| w == b"a=q");
+            if !is_query {
+                self.graphics.record(true, self.dcs_data_len);
+            }
+            if is_query {
+                // Only an explicit `a=q` is a question. A transmission is an
+                // instruction, and classifying one as a query would put "the
+                // application queried the terminal" into the next timeout of
+                // every application that draws — a false diagnosis, and a
+                // loud one.
+                return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
+            }
+            return SeqEvent::None;
+        }
+        // Sixel: `DCS <params> q <data> ST`, with no intermediate byte. The
+        // intermediate is the whole distinction from the two DCS questions
+        // below, which reach the same `q` final through `+` and `$`.
+        if self.dcs_introducer == b'P' && self.dcs_final == b'q' && self.dcs_intermediate == 0 {
+            self.graphics.record(false, self.dcs_data_len);
+            return SeqEvent::None;
+        }
         // DCS questions: XTGETTCAP (`ESC P + q … ST`) and DECRQSS
         // (`ESC P $ q … ST`, "what is the current setting of …?").
         let body = &self.seq_buf[..usize::from(self.seq_len)];
@@ -472,6 +549,43 @@ impl SeqTracker {
             return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
         }
         SeqEvent::None
+    }
+
+    /// The captured head of a DCS-class payload, cut at the first `;`.
+    ///
+    /// A kitty payload is `G <key=value>,… ; <base64>`; only the control
+    /// block before the `;` is worth reading, and stopping there keeps a
+    /// base64 blob from being scanned for keys it cannot contain.
+    fn dcs_control_block(&self) -> &[u8] {
+        let head = &self.dcs_head[..usize::from(self.dcs_head_len)];
+        match head.iter().position(|&b| b == b';') {
+            Some(sep) => &head[..sep],
+            None => head,
+        }
+    }
+
+    /// Consume one byte of a DCS-class string: header first, then payload.
+    fn push_dcs(&mut self, b: u8) {
+        // Every byte between the introducer and the terminator, for both
+        // protocols alike — a sixel's parameters and a kitty control block
+        // are a handful of bytes against an image's thousands, and counting
+        // them uniformly is easier to reason about than two rules.
+        self.dcs_data_len += 1;
+        if self.dcs_introducer != b'_' && self.dcs_final == 0 {
+            match b {
+                // Parameter and private bytes stay in the header.
+                0x30..=0x3f => {}
+                // Intermediates: `+` (XTGETTCAP) and `$` (DECRQSS).
+                0x20..=0x2f => self.dcs_intermediate = b,
+                // Final byte closes the header; the rest is payload.
+                0x40..=0x7e => self.dcs_final = b,
+                _ => {}
+            }
+        }
+        if usize::from(self.dcs_head_len) < self.dcs_head.len() {
+            self.dcs_head[usize::from(self.dcs_head_len)] = b;
+            self.dcs_head_len += 1;
+        }
     }
 
     /// Feed one byte: capture it if it belongs to a sequence, then run
@@ -501,6 +615,12 @@ impl SeqTracker {
                     self.utf8_remaining = 0;
                     State::Esc
                 } else {
+                    // Only here is a BEL a bell. Inside OSC it terminates
+                    // the string and inside a DCS-class string it is data,
+                    // and both of those are other states.
+                    if b == BEL && self.utf8_remaining == 0 {
+                        self.bells = self.bells.saturating_add(1);
+                    }
                     self.track_utf8(b);
                     State::Ground
                 }
@@ -516,7 +636,10 @@ impl SeqTracker {
                     State::Osc
                 }
                 // DCS, SOS, PM, APC — string sequences terminated by ST.
-                b'P' | b'X' | b'^' | b'_' => State::Dcs,
+                b'P' | b'X' | b'^' | b'_' => {
+                    self.reset_dcs_scanner(b);
+                    State::Dcs
+                }
                 0x20..=0x2f => State::EscIntermediate,
                 ESC => State::Esc,
                 CAN | SUB => State::Ground,
@@ -557,7 +680,10 @@ impl SeqTracker {
             State::Dcs => match b {
                 ESC => State::DcsEsc,
                 CAN | SUB => State::Ground,
-                _ => State::Dcs, // BEL is data inside DCS-class strings
+                _ => {
+                    self.push_dcs(b);
+                    State::Dcs // BEL is data inside DCS-class strings
+                }
             },
             State::OscEsc => match b {
                 b'\\' => {
@@ -610,6 +736,94 @@ mod tests {
         let mut t = SeqTracker::new();
         t.feed(bytes);
         t
+    }
+
+    /// Every event a `BEL` byte can be, and only one of them is a bell.
+    #[test]
+    fn only_a_bel_in_ground_state_is_a_bell() {
+        assert_eq!(fed(b"a\x07b").bells(), 1);
+        assert_eq!(fed(b"\x07\x07\x07").bells(), 3, "a count, not a flag");
+        assert_eq!(fed(b"plain").bells(), 0);
+
+        // Terminating an OSC string: punctuation, not a bell. And the title
+        // must still arrive, which is the thing that would break if the BEL
+        // were intercepted before the state machine saw it.
+        let t = fed(b"\x1b]0;my app\x07");
+        assert_eq!(t.bells(), 0);
+        assert_eq!(&*t.title(), "my app");
+
+        // Payload inside a DCS-class string.
+        assert_eq!(fed(b"\x1bPq\x07\x07\x1b\\").bells(), 0);
+        // A bell after a sequence closes still counts.
+        assert_eq!(fed(b"\x1b]0;t\x07\x07").bells(), 1);
+    }
+
+    /// Kitty and sixel payloads, and the two DCS *questions* that share
+    /// sixel's `q` final byte and must not be counted as pictures.
+    #[test]
+    fn graphics_payloads_are_counted_by_protocol() {
+        let kitty = fed(b"\x1b_Gf=24,s=1,v=1,a=T;AAAABBBB\x1b\\");
+        assert_eq!(kitty.graphics().kitty(), 1);
+        assert_eq!(kitty.graphics().sixel(), 0);
+        // Everything between the introducer and the terminator.
+        assert_eq!(kitty.graphics().bytes(), 26);
+        assert_eq!(fed(b"\x1bPq~~\x1b\\").graphics().bytes(), 3, "q~~");
+
+        let sixel = fed(b"\x1bPq#0;2;0;0;0#0~~-~~\x1b\\");
+        assert_eq!(sixel.graphics().sixel(), 1);
+        assert_eq!(sixel.graphics().kitty(), 0);
+
+        // Sixel with parameters before the `q`.
+        assert_eq!(fed(b"\x1bP0;1;0q~~\x1b\\").graphics().sixel(), 1);
+
+        // Neither of these is a picture: both reach `q` through an
+        // intermediate byte, which is the whole distinction.
+        assert!(fed(b"\x1bP+q544e\x1b\\").graphics().is_empty(), "XTGETTCAP");
+        assert!(fed(b"\x1bP$qm\x1b\\").graphics().is_empty(), "DECRQSS");
+
+        // Two of each accumulate.
+        let both = fed(b"\x1b_Ga=T;AA\x1b\\\x1bPq~\x1b\\\x1b_Ga=T;BB\x1b\\");
+        assert_eq!((both.graphics().kitty(), both.graphics().sixel()), (2, 1));
+        assert_eq!(both.graphics().total(), 3);
+    }
+
+    /// The kitty graphics *query* was the one probe of the startup set that
+    /// got neither an answer nor a diagnosis: `string_final` looked only at
+    /// `+q`/`$q`, which an APC never matches, so `note_unanswered` never saw
+    /// it and the timeout said nothing.
+    #[test]
+    fn the_kitty_graphics_query_is_classified() {
+        let mut t = SeqTracker::new();
+        let mut events = Vec::new();
+        for &b in b"\x1b_Gi=1,a=q;\x1b\\" {
+            events.push(t.step(b));
+        }
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                SeqEvent::Query(Query::Unanswerable(q)) if q.contains("_G")
+            )),
+            "the query must be named for the timeout note: {events:?}"
+        );
+        // A query carries no picture, so it is not counted as one.
+        assert!(t.graphics().is_empty());
+    }
+
+    /// A transmission is an instruction, not a question. Classifying one as
+    /// a query would put "the application queried the terminal" into the
+    /// next timeout of every application that draws.
+    #[test]
+    fn a_kitty_transmission_is_not_treated_as_a_query() {
+        let mut t = SeqTracker::new();
+        let mut events = Vec::new();
+        for &b in b"\x1b_Gf=24,a=T;QUJD\x1b\\" {
+            events.push(t.step(b));
+        }
+        assert!(
+            !events.iter().any(|e| matches!(e, SeqEvent::Query(_))),
+            "a transmit is not a question: {events:?}"
+        );
+        assert_eq!(t.graphics().kitty(), 1);
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -169,6 +169,10 @@ impl Emulator for Vt100Emulator {
             application_cursor: screen.application_cursor(),
             mouse: convert_mouse(screen.mouse_protocol_mode()),
             clipboard: self.tracker.clipboard(),
+            bells: self.tracker.bells(),
+            graphics: self.tracker.graphics(),
+            // Filled in by the terminal, which owns the frame count.
+            repaints: 0,
             scrollback: self.history.iter().cloned().collect(),
         };
         Screen::from_parts(

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -81,7 +81,7 @@ mod wait;
 
 pub use error::{Error, Result};
 pub use keys::{Chord, Input, Key};
-pub use screen::{Cell, Clipboard, Color, MouseMode, Screen, Style};
+pub use screen::{Cell, Clipboard, Color, GraphicsSeen, MouseMode, Screen, Style};
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{ExitStatus, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder};

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -82,6 +82,71 @@ pub enum MouseMode {
     AnyMotion,
 }
 
+/// Inline graphics payloads the application transmitted, as counted at one
+/// snapshot.
+///
+/// Read it from a snapshot via [`Screen::graphics`]. Counting is not
+/// rendering and not a claim of support: DA1 still declines both protocols,
+/// which is exactly why an application that emits them anyway is worth
+/// catching.
+///
+/// The assertion this exists for is as often the negative one — "this must
+/// render as text and **never** be transmitted as an image, so it looks the
+/// same in every terminal" — which is why [`is_empty`](Self::is_empty) is a
+/// method rather than something to spell out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct GraphicsSeen {
+    kitty: u32,
+    sixel: u32,
+    bytes: u64,
+}
+
+impl GraphicsSeen {
+    /// Kitty graphics payloads (`APC G … ST`) seen so far.
+    #[must_use]
+    pub fn kitty(&self) -> u32 {
+        self.kitty
+    }
+
+    /// Sixel payloads (`DCS q … ST`) seen so far.
+    #[must_use]
+    pub fn sixel(&self) -> u32 {
+        self.sixel
+    }
+
+    /// Payloads of either protocol.
+    #[must_use]
+    pub fn total(&self) -> u32 {
+        self.kitty + self.sixel
+    }
+
+    /// True when the application has transmitted no inline graphics at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.total() == 0
+    }
+
+    /// Total payload bytes across both protocols: everything between the
+    /// introducer and the terminator, counted the same way for each.
+    ///
+    /// A size rather than the data itself: a test asserts that an image was
+    /// or was not sent, and how big it was — not what it depicted, which
+    /// nothing here can decode.
+    #[must_use]
+    pub fn bytes(&self) -> u64 {
+        self.bytes
+    }
+
+    pub(crate) fn record(&mut self, kitty: bool, bytes: u64) {
+        if kitty {
+            self.kitty += 1;
+        } else {
+            self.sixel += 1;
+        }
+        self.bytes += bytes;
+    }
+}
+
 /// What an application copied with `OSC 52`, as observed at one snapshot.
 ///
 /// Read it from a snapshot via [`Screen::clipboard`]. A toast on screen
@@ -129,6 +194,13 @@ impl Clipboard {
 /// Out-of-band terminal state captured with each snapshot. Deliberately
 /// invisible in the text rendering (existing snapshot files stay valid);
 /// exposed through the accessors on [`Screen`].
+///
+/// Held behind a single [`Arc`] on [`Screen`], for two reasons that pull the
+/// same way. `Screen` is embedded in every [`Error`](crate::Error), so its
+/// size is load-bearing — enough scalars here and `Result<T>` grows past
+/// what clippy's `result_large_err` will accept. And a `Screen` clone then
+/// bumps one refcount instead of copying every field, which matters because
+/// a clone happens on each wait evaluation.
 #[derive(Debug, Clone)]
 pub(crate) struct TermState {
     pub(crate) title: Arc<str>,
@@ -139,6 +211,14 @@ pub(crate) struct TermState {
     /// Behind an `Arc` deliberately: `Screen` is embedded in every
     /// `Error` and cloned on every wait, so its size is load-bearing.
     pub(crate) clipboard: Option<Arc<Clipboard>>,
+    /// Bells rung in ground state (a `BEL` terminating an OSC string is a
+    /// terminator, not a bell).
+    pub(crate) bells: u64,
+    /// Inline graphics payloads transmitted.
+    pub(crate) graphics: GraphicsSeen,
+    /// Completed synchronized updates. Filled in by the terminal rather
+    /// than the emulator, which does not own the frame count.
+    pub(crate) repaints: u64,
     /// Rows that have scrolled off the top, oldest first, as text.
     ///
     /// Text rather than cells, deliberately: a thousand rows of styled
@@ -157,6 +237,9 @@ impl Default for TermState {
             application_cursor: false,
             mouse: MouseMode::None,
             clipboard: None,
+            bells: 0,
+            graphics: GraphicsSeen::default(),
+            repaints: 0,
             scrollback: Arc::from([] as [Arc<str>; 0]),
         }
     }
@@ -230,7 +313,7 @@ pub struct Screen {
     cursor_col: u16,
     cursor_visible: bool,
     cells: Arc<[Cell]>,
-    state: TermState,
+    state: Arc<TermState>,
 }
 
 impl Screen {
@@ -251,8 +334,20 @@ impl Screen {
             cursor_col,
             cursor_visible,
             cells: cells.into(),
-            state,
+            state: Arc::new(state),
         }
+    }
+
+    /// Stamp the repaint count onto a freshly built snapshot.
+    ///
+    /// The count lives on the terminal, not the emulator: it is the same
+    /// counter `wait_frame`'s cursor is built on, and a second one in the
+    /// emulator could drift from it.
+    pub(crate) fn with_repaints(mut self, repaints: u64) -> Self {
+        // Called on a snapshot nobody else holds yet, so `make_mut` mutates
+        // in place rather than cloning.
+        Arc::make_mut(&mut self.state).repaints = repaints;
+        self
     }
 
     /// Number of columns (the screen's width).
@@ -352,6 +447,79 @@ impl Screen {
     #[must_use]
     pub fn clipboard(&self) -> Option<&Clipboard> {
         self.state.clipboard.as_deref()
+    }
+
+    /// How many times the application has **completed a repaint** — a DEC
+    /// 2026 synchronized update begun and ended — as of this observation.
+    ///
+    /// Monotonic, so the natural use is a delta around an action:
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// let before = t.screen().repaints();
+    /// t.scroll(0, 0, termlens::Scroll::Down)?;
+    /// let frame = t.wait_frame(|s| s.contains("row 2"))?;
+    /// // One wheel notch must not become five repaints.
+    /// assert_eq!(frame.repaints() - before, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// **It counts repaints, not changes.** A Begin/End pair that altered no
+    /// cell still counts, exactly as [`wait_frame`](crate::Terminal::wait_frame)
+    /// treats it — and that is the property an amplification test depends
+    /// on. "One input produced four repaints" is invisible to any content
+    /// predicate, because every intermediate frame shows correct content.
+    /// Only the count sees it.
+    ///
+    /// Zero for an application that never emits synchronized updates; there
+    /// is nothing to count, not even its redraws.
+    #[must_use]
+    pub fn repaints(&self) -> u64 {
+        self.state.repaints
+    }
+
+    /// How many times the application has rung the bell (`BEL`, `0x07`) as
+    /// of this observation.
+    ///
+    /// A count rather than a flag, so "rang twice" is distinguishable from
+    /// "rang once", and monotonic like [`repaints`](Self::repaints) so a test
+    /// can take a delta around one action.
+    ///
+    /// The bell is often the *only* feedback a rejected input produces:
+    /// "pressing an invalid key does nothing" and "pressing an invalid key is
+    /// refused with a bell" are different behaviours, and without this they
+    /// are the same screen.
+    ///
+    /// Only a `BEL` in ground state counts. The one that terminates an
+    /// `OSC` string is punctuation, not a bell, and a `BEL` inside a
+    /// DCS-class string is payload.
+    #[must_use]
+    pub fn bells(&self) -> u64 {
+        self.state.bells
+    }
+
+    /// Inline graphics payloads the application has transmitted — kitty
+    /// (`APC G … ST`) and sixel (`DCS q … ST`) — as of this observation.
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.wait_until(|s| s.contains("diagram"))?;
+    /// // A diagram must render as box art in every terminal, so it must
+    /// // never go out as an image.
+    /// assert!(t.screen().graphics().is_empty());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Observing is not rendering, and not a claim of support: DA1 goes on
+    /// declining both protocols, which is precisely why an application that
+    /// transmits one anyway is worth catching.
+    #[must_use]
+    pub fn graphics(&self) -> GraphicsSeen {
+        self.state.graphics
     }
 
     /// The cell at `(row, col)`, or `None` when out of bounds.
@@ -1234,6 +1402,14 @@ mod tests {
             application_cursor: true,
             mouse: MouseMode::AnyMotion,
             clipboard: Some(Arc::new(Clipboard::new("c", Some("copied".into())))),
+            bells: 3,
+            graphics: {
+                let mut g = GraphicsSeen::default();
+                g.record(true, 120);
+                g.record(false, 40);
+                g
+            },
+            repaints: 9,
             scrollback: Arc::from([Arc::from("scrolled away")]),
         };
         let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
@@ -1244,6 +1420,14 @@ mod tests {
         let clip = s.clipboard().expect("captured");
         assert_eq!((clip.targets(), clip.text()), ("c", Some("copied")));
         assert_eq!(s.scrollback_rows(), 1);
+        assert_eq!(s.bells(), 3);
+        assert_eq!(s.repaints(), 9);
+        assert_eq!(s.graphics().kitty(), 1);
+        assert_eq!(s.graphics().sixel(), 1);
+        assert_eq!(s.graphics().total(), 2);
+        assert_eq!(s.graphics().bytes(), 160);
+        assert!(!s.graphics().is_empty());
+        assert!(GraphicsSeen::default().is_empty());
         assert_eq!(s.scrollback_text(), "scrolled away");
         assert_eq!(s.full_text(), "scrolled away\nx");
         // Out-of-band state never leaks into the text format — including

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -528,9 +528,14 @@ impl EmuState {
                 return screen.clone();
             }
         }
-        let screen = self.emu.snapshot();
+        let screen = self.build_snapshot();
         self.snapshot_cache = Some((self.generation, screen.clone()));
         screen
+    }
+
+    /// Build a snapshot and stamp on the state the emulator does not own.
+    fn build_snapshot(&self) -> Screen {
+        self.emu.snapshot().with_repaints(self.frames_seen)
     }
 
     /// One-line diagnosis when a query went unanswered, appended to every
@@ -600,7 +605,7 @@ impl EmuState {
                 return screen.clone();
             }
         }
-        self.emu.snapshot()
+        self.build_snapshot()
     }
 }
 

--- a/crates/termlens/tests/observe.rs
+++ b/crates/termlens/tests/observe.rs
@@ -1,0 +1,174 @@
+//! Cumulative observations on a snapshot: repaints, bells, and inline
+//! graphics payloads. All three are counters an assertion can take a delta
+//! around, and all three describe behaviour that leaves the screen
+//! unchanged — which is why they were previously untestable.
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+fn sh(script: &str) -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .size(40, 6)
+        .timeout(Duration::from_secs(10))
+        .args(["-c", script])
+        .spawn("/bin/sh")
+}
+
+/// The amplification assertion: one input must not become N repaints. No
+/// content predicate can see this, because every intermediate frame shows
+/// correct content.
+#[test]
+fn repaints_count_completed_updates_not_changes() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf READY; read a; ",
+        // Three complete repaints, the middle one changing nothing at all.
+        r"printf '\033[?2026hone\033[?2026l'; ",
+        r"printf '\033[?2026h\033[?2026l'; ",
+        r"printf '\033[?2026htwo\033[?2026l'; ",
+        r"printf ' DONE'; read b"
+    ))?;
+    t.wait_until(|s| s.contains("READY"))?;
+    assert_eq!(t.screen().repaints(), 0, "nothing has repainted yet");
+
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    assert_eq!(
+        t.screen().repaints(),
+        3,
+        "a Begin/End pair that drew nothing is still a repaint"
+    );
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// An application that never brackets a repaint has nothing to count, and
+/// says zero rather than guessing from its redraws.
+#[test]
+fn an_app_without_synchronized_output_reports_no_repaints() -> termlens::Result<()> {
+    let mut t = sh(r"printf 'drew\n'; printf 'drew again\n'; printf DONE; read g")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    assert_eq!(t.screen().repaints(), 0);
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// "Pressing an invalid key does nothing visible" and "pressing an invalid
+/// key is refused with a bell" are different behaviours and the same screen.
+#[test]
+fn a_bell_is_observable_and_a_title_terminator_is_not_a_bell() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf READY; read a; ",
+        r"printf '\007'; printf '\033]0;set by osc\007'; printf '\007'; ",
+        r"printf ' DONE'; read b"
+    ))?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let before = t.screen().bells();
+    assert_eq!(before, 0);
+
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.bells() - before, 2, "two bells, not three: {s}");
+    // The OSC still did its job, which is what would break if the BEL were
+    // counted before the state machine saw it.
+    assert_eq!(s.title(), "set by osc");
+    // And nothing about the bells reached the grid, which is the point: the
+    // rows hold the marker and the echoed newline, and not one cell more.
+    assert_eq!(s.text().trim_end(), "READY\n DONE", "{s}");
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The negative assertion is the one that catches a regression: this content
+/// must render as text in every terminal, so it must never go out as an
+/// image.
+#[test]
+fn graphics_payloads_are_observable_and_absence_is_assertable() -> termlens::Result<()> {
+    let mut plain = sh(r"printf 'box art: +--+'; printf ' DONE'; read g")?;
+    plain.wait_until(|s| s.contains("DONE"))?;
+    assert!(
+        plain.screen().graphics().is_empty(),
+        "nothing was transmitted as an image"
+    );
+    plain.send(Key::Enter)?;
+    assert!(plain.wait_exit()?.success());
+
+    let mut drawing = sh(concat!(
+        r"printf 'text'; ",
+        r"printf '\033_Gf=24,s=1,v=1,a=T;QUJDREVG\033\\'; ",
+        r"printf '\033Pq#0;2;0;0;0#0~~-~~\033\\'; ",
+        r"printf ' DONE'; read g"
+    ))?;
+    drawing.wait_until(|s| s.contains("DONE"))?;
+    let g = drawing.screen().graphics();
+    assert_eq!(g.kitty(), 1, "one kitty payload");
+    assert_eq!(g.sixel(), 1, "one sixel payload");
+    assert_eq!(g.total(), 2);
+    assert!(!g.is_empty());
+    assert!(g.bytes() > 20, "payload size is reported: {}", g.bytes());
+    // A payload is swallowed, not drawn: the grid holds only the text.
+    assert!(
+        drawing.screen().contains("text DONE"),
+        "{}",
+        drawing.screen()
+    );
+
+    drawing.send(Key::Enter)?;
+    assert!(drawing.wait_exit()?.success());
+    Ok(())
+}
+
+/// The kitty graphics query used to escape the timeout note entirely: no
+/// answer *and* no diagnosis, alone among the startup probes.
+#[test]
+fn a_blocked_kitty_graphics_query_is_named_in_the_timeout() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(40, 4)
+        .timeout(Duration::from_millis(700))
+        .args([
+            "-c",
+            r"stty -icanon -echo; printf '\033_Gi=1,a=q;\033\\'; printf MARK; read g",
+        ])
+        .spawn("/bin/sh")?;
+    let err = t
+        .wait_until(|s| s.contains("NEVER-APPEARS"))
+        .expect_err("must time out");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("queried the terminal"),
+        "the probe must be diagnosed: {msg}"
+    );
+    assert!(msg.contains("_G"), "and named: {msg}");
+    t.send(Key::Enter)?;
+    Ok(())
+}
+
+/// A transmission is an instruction, not a question, so it must not put a
+/// query diagnosis into an unrelated timeout of an application that draws.
+#[test]
+fn a_kitty_transmission_does_not_pollute_the_timeout() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(40, 4)
+        .timeout(Duration::from_millis(700))
+        .args([
+            "-c",
+            r"printf '\033_Gf=24,a=T;QUJD\033\\'; printf MARK; read g",
+        ])
+        .spawn("/bin/sh")?;
+    let err = t
+        .wait_until(|s| s.contains("NEVER-APPEARS"))
+        .expect_err("must time out");
+    assert!(
+        !err.to_string().contains("queried the terminal"),
+        "a transmit is not a query: {err}"
+    );
+    assert_eq!(t.screen().graphics().kitty(), 1, "but it is counted");
+    t.send(Key::Enter)?;
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -404,6 +404,24 @@ Rules:
    assertions read as ordinary predicates:
    `wait_until(|s| s.alternate_screen())`.
 
+   The same slot holds three **cumulative counters**, for behaviour that by
+   definition leaves the grid unchanged: `Screen::repaints` (completed DEC
+   2026 updates — repaints, not changes, so one input becoming four
+   repaints is catchable), `Screen::bells` (a `BEL` in ground state; the one
+   closing an `OSC` string is punctuation and the one inside a DCS-class
+   string is payload), and `Screen::graphics` (kitty and sixel payloads
+   transmitted, by protocol and total bytes). Monotonic on purpose: a test
+   takes a delta around an action rather than resetting a gauge. Counting a
+   graphics payload is not rendering it and claims nothing — DA1 goes on
+   declining both protocols, which is why an application that transmits one
+   anyway is worth catching.
+
+   All of it lives behind one `Arc` on `Screen`. `Screen` is embedded in
+   every `Error`, so its size is load-bearing: the counters alone pushed
+   `Result<T>` past clippy's `result_large_err` threshold, and the `Arc`
+   took `Screen` from 80 bytes to 40 while making a clone one refcount bump
+   instead of a field-by-field copy.
+
 The `insta` feature (default) re-exports `insta` and ships
 `assert_screen_snapshot!` so the snapshotting insta version can't drift
 from the one the macro targets.


### PR DESCRIPTION
Closes #97, closes #99, closes #102, closes #117.

Four issues in one PR because they are one mechanism: each describes behaviour that leaves the grid **identical** — which is why none of it was testable — and each lands in the sequence tracker and on the snapshot.

## What is now observable

| accessor | assertion it enables |
|---|---|
| `Screen::repaints()` | one input must not become N repaints |
| `Screen::bells()` | "does nothing" vs "is refused with a bell" |
| `Screen::graphics()` | this must **never** go out as an image |
| — | a blocked kitty graphics probe is diagnosed |

**`repaints` counts repaints, not changes.** A Begin/End pair that drew nothing still counts, matching what `wait_frame` already does — and that is precisely the property an amplification test depends on, since every intermediate frame of an over-painting burst shows *correct* content. Only the count sees it.

**`bells` only counts ground state.** The `BEL` closing an `OSC` string is punctuation and one inside a DCS-class string is payload. A test pins that the title still arrives, which is the thing that breaks if the byte is intercepted before the state machine sees it.

**`graphics().is_empty()` is a method** because the negative form is as often the one being written. Observing is not rendering and claims nothing: DA1 goes on declining both protocols, which is exactly why an application transmitting one anyway is worth catching.

## Two deviations, both deliberate

**#117 asked for every APC opening with `G` to be classified as a query. Only an explicit `a=q` is.** A transmission is an instruction, not a question, and classifying one as a query would put *"the application queried the terminal"* into the next timeout of every application that draws — a false diagnosis, and a loud one. Kitty's own protocol makes `a=q` the query action. Both cases are pinned: `a_blocked_kitty_graphics_query_is_named_in_the_timeout` and `a_kitty_transmission_does_not_pollute_the_timeout`.

**Byte counting is uniform**: everything between the introducer and the terminator, for both protocols. Counting "just the image data" would mean two different rules (skip sixel's params, skip kitty's control block), and those are a handful of bytes against an image's thousands.

## How sixel is told from the two DCS questions

By the **intermediate byte**. Sixel reaches its `q` final with none; XTGETTCAP arrives through `+` and DECRQSS through `$`. The tracker previously routed all four string introducers (`P X ^ _`) into one state and kept no header structure, so it could not distinguish an APC from a DCS at all — which is also why the kitty probe escaped the note.

## `Screen` is now 40 bytes instead of 80

Adding three counters tripped clippy's `result_large_err`, which is the reminder that `Screen` is embedded in **every** `Error`. Putting all out-of-band state behind one `Arc` fixes the lint and pays twice over:

```
Screen  80 -> 40 bytes
Error  >128 -> 80 bytes
```

Every `Result` in the crate got smaller, and a `Screen` clone — taken on each wait evaluation — is now one refcount bump rather than a field-by-field copy.

## A correction to my own earlier PR

While editing the changelog I found that my #106 script had inserted a `### Documented` entry into the **already published** 0.4.2 section as well as `[Unreleased]`. The shipped release notes never contained it. Removed, and verified: `extract-changelog.sh v0.4.2` now matches `gh release view v0.4.2` exactly.

## Tests

Unit (`seq.rs`), for the byte-level rules: `only_a_bel_in_ground_state_is_a_bell` (all four positions a `BEL` can occupy), `graphics_payloads_are_counted_by_protocol` (including both DCS questions staying uncounted), `the_kitty_graphics_query_is_classified`, `a_kitty_transmission_is_not_treated_as_a_query`.

End-to-end (`tests/observe.rs`, six tests through real PTYs), for the contracts: the drew-nothing repaint still counting, zero repaints for an app that never brackets one, two bells and not three across an `OSC` title, absence of graphics being assertable, and the two timeout-note cases.

## Checklist

- [x] Linked an issue — closes #97, #99, #102, #117
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none