### PR TITLE
feat(terminal): deliver focus events so the unfocused branch is reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,15 @@ listed under a **Changed** or **Removed** heading.
   as a question: a transmission is an instruction, and treating one as a
   query would put "the application queried the terminal" into the next
   timeout of every application that draws.
+- **`Terminal::focus_in` / `Terminal::focus_out`** and
+  **`Screen::focus_events`** — focus reporting (mode 1004). The unfocused
+  branch of a UI was not merely unasserted, it was **unreachable**: no input
+  existed that could enter it, so the code never ran. Mode-aware like every
+  other input — refused with a typed error when the application never enabled
+  1004, exactly as `click` is refused without mouse tracking. `DECRQM` now
+  answers for 1004 as well, since termlens tracks it exactly, which is the
+  honesty rule's precondition; it previously reported "not recognized" even
+  immediately after the application enabled it.
 - **`Error::Write`**, carrying the screen at the moment of the failed
   write, the way `Error::Timeout` and `Error::Eof` already do.
   `Error::screen()` returns it.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ the emulator knows which modes the app enabled. The same knowledge is
 readable from every `Screen`: the window title, the alternate-screen
 flag, the input modes and the last `OSC 52` clipboard write are plain
 accessors, so "did the app enter the alt screen?" and "did it copy the
-right text?" are assertions, not inferences.
+right text?" are assertions, not inferences. Focus events go the other way:
+`focus_out()` reaches an application that enabled mode 1004, so the
+unfocused branch of a UI can be driven at all.
 
 **Scrollback is retained** (1000 rows by default), so an application that
 hands finished output *back* to the terminal — a pager, a log view, a TUI

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -46,6 +46,11 @@ pub(crate) struct InputModes {
     pub(crate) mouse_encoding: MouseEncoding,
     pub(crate) bracketed_paste: bool,
     pub(crate) application_cursor: bool,
+    /// Focus reporting (mode 1004). Lives here rather than behind a new
+    /// trait method: it is an input-affecting mode like the others, and the
+    /// `Emulator` surface is deliberately the narrowest the terminal loop
+    /// needs.
+    pub(crate) focus_events: bool,
 }
 
 /// How the application asked for mouse coordinates to be encoded. The

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -182,6 +182,11 @@ pub(crate) struct SeqTracker {
     csi_first_param: u32,
     csi_param_count: u8,
     csi_saw_2026: bool,
+    /// Set when the current CSI's parameter list contains 1004 (focus
+    /// reporting), the same trick `csi_saw_2026` uses — a mode can arrive
+    /// anywhere in a multi-mode list, so scanning for it beats assuming it
+    /// is the only parameter.
+    csi_saw_1004: bool,
     /// Raw capture of the current sequence (from ESC), for diagnostics
     /// and DCS query recognition. Bounded; long sequences truncate.
     seq_buf: [u8; 24],
@@ -205,6 +210,10 @@ pub(crate) struct SeqTracker {
     bells: u64,
     /// Inline graphics payloads transmitted.
     graphics: GraphicsSeen,
+    /// True while the application has focus reporting (mode 1004) enabled.
+    /// Tracked here because vt100 does not model 1004 at all — the same
+    /// reason the window title is tracked here.
+    focus_events: bool,
     /// Which introducer opened the current DCS-class string: `P` (DCS),
     /// `X` (SOS), `^` (PM) or `_` (APC). Sixel and kitty graphics differ
     /// only by this, so consuming all four alike — which is all the tracker
@@ -240,6 +249,7 @@ impl SeqTracker {
             csi_first_param: 0,
             csi_param_count: 0,
             csi_saw_2026: false,
+            csi_saw_1004: false,
             seq_buf: [0; 24],
             seq_len: 0,
             osc_buf: Vec::new(),
@@ -248,6 +258,7 @@ impl SeqTracker {
             clipboard: None,
             bells: 0,
             graphics: GraphicsSeen::default(),
+            focus_events: false,
             dcs_introducer: 0,
             dcs_final: 0,
             dcs_intermediate: 0,
@@ -295,6 +306,11 @@ impl SeqTracker {
         self.graphics
     }
 
+    /// True while the application has focus reporting (mode 1004) enabled.
+    pub(crate) fn focus_events(&self) -> bool {
+        self.focus_events
+    }
+
     fn reset_dcs_scanner(&mut self, introducer: u8) {
         self.dcs_introducer = introducer;
         self.dcs_final = 0;
@@ -313,6 +329,7 @@ impl SeqTracker {
         self.csi_first_param = 0;
         self.csi_param_count = 0;
         self.csi_saw_2026 = false;
+        self.csi_saw_1004 = false;
     }
 
     fn push_seq(&mut self, b: u8) {
@@ -338,6 +355,9 @@ impl SeqTracker {
     fn end_csi_param(&mut self) {
         if self.csi_param == 2026 {
             self.csi_saw_2026 = true;
+        }
+        if self.csi_param == 1004 {
+            self.csi_saw_1004 = true;
         }
         if self.csi_param_count == 0 {
             self.csi_first_param = self.csi_param;
@@ -393,6 +413,18 @@ impl SeqTracker {
                 (_, b'p' | b'y') => SeqEvent::Query(Query::Unanswerable(self.seq_printable())),
                 _ => SeqEvent::None,
             };
+        }
+
+        // DEC private mode 1004 (focus reporting). vt100 does not model it,
+        // so an application that enables it is invisible without this — and
+        // `focus_in`/`focus_out` refuse to send events the application never
+        // asked for, exactly as `click` refuses without mouse tracking.
+        if self.csi_prefix == b'?' && self.csi_saw_1004 {
+            match b {
+                b'h' => self.focus_events = true,
+                b'l' => self.focus_events = false,
+                _ => {}
+            }
         }
 
         // DEC private mode 2026 (synchronized output).

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -170,6 +170,7 @@ impl Emulator for Vt100Emulator {
             mouse: convert_mouse(screen.mouse_protocol_mode()),
             clipboard: self.tracker.clipboard(),
             bells: self.tracker.bells(),
+            focus_events: self.tracker.focus_events(),
             graphics: self.tracker.graphics(),
             // Filled in by the terminal, which owns the frame count.
             repaints: 0,
@@ -205,6 +206,7 @@ impl Emulator for Vt100Emulator {
             },
             bracketed_paste: screen.bracketed_paste(),
             application_cursor: screen.application_cursor(),
+            focus_events: self.tracker.focus_events(),
         }
     }
 
@@ -228,6 +230,9 @@ impl Emulator for Vt100Emulator {
             25 => on(!screen.hide_cursor()),
             47 | 1047 | 1049 => on(screen.alternate_screen()),
             2004 => on(screen.bracketed_paste()),
+            // Tracked by termlens itself, so the state is exact — which is
+            // what the honesty rule requires before answering.
+            1004 => on(self.tracker.focus_events()),
             1006 => on(matches!(
                 screen.mouse_protocol_encoding(),
                 ::vt100::MouseProtocolEncoding::Sgr

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -214,6 +214,8 @@ pub(crate) struct TermState {
     /// Bells rung in ground state (a `BEL` terminating an OSC string is a
     /// terminator, not a bell).
     pub(crate) bells: u64,
+    /// Whether the application enabled focus reporting (mode 1004).
+    pub(crate) focus_events: bool,
     /// Inline graphics payloads transmitted.
     pub(crate) graphics: GraphicsSeen,
     /// Completed synchronized updates. Filled in by the terminal rather
@@ -238,6 +240,7 @@ impl Default for TermState {
             mouse: MouseMode::None,
             clipboard: None,
             bells: 0,
+            focus_events: false,
             graphics: GraphicsSeen::default(),
             repaints: 0,
             scrollback: Arc::from([] as [Arc<str>; 0]),
@@ -412,6 +415,16 @@ impl Screen {
     #[must_use]
     pub fn application_cursor(&self) -> bool {
         self.state.application_cursor
+    }
+
+    /// True while the application has focus reporting (mode 1004) enabled.
+    /// [`Terminal::focus_in`](crate::Terminal::focus_in) and
+    /// [`Terminal::focus_out`](crate::Terminal::focus_out) consult the same
+    /// state, so a test can assert the application asked for focus events
+    /// before trying to deliver one.
+    #[must_use]
+    pub fn focus_events(&self) -> bool {
+        self.state.focus_events
     }
 
     /// Which mouse events the application asked to be reported —
@@ -1403,6 +1416,7 @@ mod tests {
             mouse: MouseMode::AnyMotion,
             clipboard: Some(Arc::new(Clipboard::new("c", Some("copied".into())))),
             bells: 3,
+            focus_events: true,
             graphics: {
                 let mut g = GraphicsSeen::default();
                 g.record(true, 120);
@@ -1421,6 +1435,7 @@ mod tests {
         assert_eq!((clip.targets(), clip.text()), ("c", Some("copied")));
         assert_eq!(s.scrollback_rows(), 1);
         assert_eq!(s.bells(), 3);
+        assert!(s.focus_events());
         assert_eq!(s.repaints(), 9);
         assert_eq!(s.graphics().kitty(), 1);
         assert_eq!(s.graphics().sixel(), 1);

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1331,6 +1331,64 @@ impl Terminal {
         }
     }
 
+    /// Tell the application the window **gained** focus (`ESC [ I`).
+    ///
+    /// Mode-aware in the way every other input is: sent only when the
+    /// application enabled focus reporting (`CSI ?1004 h`), and a typed
+    /// error when it did not. That is the same contract
+    /// [`click`](Self::click) uses for mouse tracking, and the same
+    /// reasoning — a real terminal does not send an application events it
+    /// never asked for, and bytes it did not ask for would be misparsed as
+    /// keys.
+    ///
+    /// Real TUIs use focus to pause animations, dim their chrome or drop a
+    /// cursor block, and without a way to deliver the event the unfocused
+    /// branch of that code is unreachable rather than merely unasserted.
+    /// [`Screen::focus_events`](crate::Screen::focus_events) reads the mode
+    /// back, so a test can assert the application asked in the first place.
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.wait_until(|s| s.focus_events())?;   // it asked
+    /// t.focus_out()?;
+    /// t.wait_until(|s| s.contains("paused"))?;
+    /// t.focus_in()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Write`] when the child is gone, then [`Error::Input`] when
+    /// the application has not enabled focus reporting.
+    pub fn focus_in(&mut self) -> Result<()> {
+        self.focus(true)
+    }
+
+    /// Tell the application the window **lost** focus (`ESC [ O`).
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`focus_in`](Self::focus_in).
+    pub fn focus_out(&mut self) -> Result<()> {
+        self.focus(false)
+    }
+
+    fn focus(&mut self, gained: bool) -> Result<()> {
+        let what = if gained { "focus-in" } else { "focus-out" };
+        self.ensure_deliverable(what)?;
+        if !self.input_modes().focus_events {
+            return Err(Error::Input(
+                "the application has not enabled focus reporting \
+                 (no CSI ?1004 h was seen)"
+                    .into(),
+            ));
+        }
+        let bytes: &[u8] = if gained { b"\x1b[I" } else { b"\x1b[O" };
+        self.write_input(bytes, what)
+    }
+
     /// Click the primary button at `(col, row)` (0-based, like
     /// [`Screen::cell`]). Sends a press — and, when the application's
     /// tracking mode reports them, a release — encoded exactly as the

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -309,6 +309,59 @@ fn clicking_without_mouse_tracking_is_a_typed_error() {
     assert!(t.wait_exit().unwrap().success());
 }
 
+/// Both focus states, through crossterm's own event stream. Before this the
+/// unfocused branch of a UI was not merely unasserted, it was **unreachable**
+/// — no input existed that could enter it, so the code never ran.
+#[test]
+fn focus_events_reach_the_application_in_both_directions() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    // Assert on the frame the wait returned rather than waiting again: the
+    // application has not repainted since, and a frame satisfies exactly one
+    // wait.
+    let ready = t.wait_frame(|s| s.contains("form-echo ready"))?;
+    // The application asked for focus reporting, and a test can see that it
+    // did before trying to deliver one.
+    assert!(ready.focus_events(), "form-echo enables mode 1004");
+    // A window starts focused, which is why the other branch needed an event.
+    assert!(ready.contains("window: focused"), "{ready}");
+
+    t.focus_out()?;
+    t.wait_frame(|s| s.contains("window: unfocused") && s.contains("last: focus:lost"))?;
+
+    t.focus_in()?;
+    t.wait_frame(|s| s.contains("window: focused") && s.contains("last: focus:gained"))?;
+
+    t.send(Key::Esc)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Focus events are refused when the application never asked for them, the
+/// same contract `click` has for mouse tracking — feeding an application
+/// events it did not request is not what a terminal does, and the bytes
+/// would be misparsed as keys.
+#[test]
+fn focus_events_are_refused_without_mode_1004() -> termlens::Result<()> {
+    // hello-tui enables the alternate screen and nothing else.
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .timeout(Duration::from_secs(10))
+        .env_clear()
+        .spawn(util::fixture_bin("hello-tui"))?;
+    t.wait_until(|s| s.contains("╯"))?;
+    assert!(!t.screen().focus_events());
+
+    for err in [t.focus_in().unwrap_err(), t.focus_out().unwrap_err()] {
+        assert!(matches!(err, Error::Input(_)), "got: {err}");
+        assert!(err.to_string().contains("focus reporting"), "{err}");
+        assert!(err.to_string().contains("1004"), "{err}");
+    }
+
+    t.send(Key::Char('q'))?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 /// Typed input to a child that is gone is an error the test can handle,
 /// not a panic and not silence. `write_or_panic` used to make this the one
 /// failure that could only reach a test by aborting it.

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -330,3 +330,50 @@ fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
     assert!(t.wait_exit()?.success());
     Ok(())
 }
+
+/// Mode 1004 is now answerable, because termlens tracks it exactly — the
+/// honesty rule's precondition. Before, an application probing for focus
+/// support was told "not recognized" even right after enabling it.
+#[test]
+fn decrqm_answers_for_focus_reporting() -> termlens::Result<()> {
+    // Reply values: 1 = set, 2 = reset, 0 = not recognized.
+    for (script, expect, label) in [
+        (
+            r"printf '\033[?1004$p'",
+            ";2$y",
+            "reset before the app enables it",
+        ),
+        (
+            r"printf '\033[?1004h\033[?1004$p'",
+            ";1$y",
+            "set after enabling",
+        ),
+        (
+            r"printf '\033[?1004h\033[?1004l\033[?1004$p'",
+            ";2$y",
+            "reset again after disabling",
+        ),
+    ] {
+        let mut t = Terminal::builder()
+            .size(80, 6)
+            .timeout(Duration::from_secs(10))
+            .args([
+                "-c",
+                &format!(
+                    "stty -icanon -echo; {script}; \
+                     head -c 11 | tr -d '\\033'; printf ' DONE'; read guard"
+                ),
+            ])
+            .spawn("/bin/sh")?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let row = t.screen().row_text(0);
+        assert!(row.contains(expect), "{label}: got {row:?}");
+        assert!(
+            !row.contains(";0$y"),
+            "{label}: must not report unrecognized"
+        );
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+    }
+    Ok(())
+}

--- a/crates/termlens/tests/snapshots/fixtures__form_echo_round_trips_typed_input_and_special_keys.snap
+++ b/crates/termlens/tests/snapshots/fixtures__form_echo_round_trips_typed_input_and_special_keys.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/termlens/tests/fixtures.rs
-assertion_line: 116
 expression: t.screen()
 ---
 size: 80x24  cursor: hidden
 form-echo ready
 input:
 last: enter
+window: focused
 submitted: hell

--- a/fixtures/form-echo/src/main.rs
+++ b/fixtures/form-echo/src/main.rs
@@ -18,8 +18,9 @@ use std::io::{self, Write};
 
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{
-    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-    Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind,
+    self, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+    EnableFocusChange, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+    MouseEvent, MouseEventKind,
 };
 use crossterm::style::Print;
 use crossterm::terminal::{
@@ -28,11 +29,24 @@ use crossterm::terminal::{
 };
 use crossterm::{execute, queue};
 
-#[derive(Default)]
 struct App {
     input: String,
     last: String,
     submitted: String,
+    /// A window starts focused, which is why the *unfocused* branch is the
+    /// one that needs an event to become reachable.
+    focused: bool,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            input: String::new(),
+            last: String::new(),
+            submitted: String::new(),
+            focused: true,
+        }
+    }
 }
 
 /// Stable, greppable one-token description of a key event.
@@ -99,6 +113,10 @@ fn draw(out: &mut impl Write, app: &App) -> io::Result<()> {
         "form-echo ready".to_string(),
         format!("input: {}", app.input),
         format!("last: {}", app.last),
+        format!(
+            "window: {}",
+            if app.focused { "focused" } else { "unfocused" }
+        ),
         format!("submitted: {}", app.submitted),
     ];
     for (row, line) in lines.iter().enumerate() {
@@ -133,6 +151,7 @@ fn cleanup(out: &mut impl Write) -> io::Result<()> {
     execute!(
         out,
         DisableBracketedPaste,
+        DisableFocusChange,
         DisableMouseCapture,
         Show,
         LeaveAlternateScreen
@@ -148,7 +167,8 @@ fn main() -> io::Result<()> {
         EnterAlternateScreen,
         Hide,
         EnableMouseCapture,
-        EnableBracketedPaste
+        EnableBracketedPaste,
+        EnableFocusChange
     )?;
 
     let mut app = App::default();
@@ -168,6 +188,22 @@ fn main() -> io::Result<()> {
                     app.last = description;
                     draw(&mut out, &app)?;
                 }
+                continue;
+            }
+            // A real TUI dims its chrome when the window loses focus. This
+            // one names the state instead, so a test can assert on either
+            // branch — the point being that without focus delivery only one
+            // of the two is ever reachable.
+            Event::FocusGained => {
+                app.focused = true;
+                app.last = "focus:gained".to_owned();
+                draw(&mut out, &app)?;
+                continue;
+            }
+            Event::FocusLost => {
+                app.focused = false;
+                app.last = "focus:lost".to_owned();
+                draw(&mut out, &app)?;
                 continue;
             }
             _ => continue,


### PR DESCRIPTION
Closes #101.

## Verified

Against the published 0.4.2: no API delivers a focus event, and `DECRQM` reports mode 1004 as **not recognized even immediately after the application enables it** —

```
DECRQM 1004            -> [?1004;0$y
DECRQM 1004 after ?1004h -> [?1004;0$y     <- still 0
DECRQM 2004 after ?2004h -> [?2004;1$y     <- for contrast
```

because vt100 does not model 1004 at all.

## Why this one is different from an unasserted feature

The unfocused branch of a UI was not merely unasserted, it was **unreachable**. No input existed that could enter it, so the code never ran — and a test can say nothing whatsoever about code that does not execute.

## Changes

- `Terminal::focus_in()` / `focus_out()` send `ESC [ I` / `ESC [ O`, **mode-aware** like every other input: a typed error when the application never enabled 1004, exactly as `click` is refused without mouse tracking. Same reasoning too — a real terminal does not send an application events it never asked for, and those bytes would be misparsed as keys.
- `Screen::focus_events()` reads the mode back, so a test asserts the application asked before trying to deliver one.
- `DECRQM` answers for 1004. The honesty rule permits it precisely because the state is now exact.

## Two placement decisions

**Mode 1004 is tracked in the sequence tracker**, for the same reason the window title is: vt100 does not expose it.

**It rides on `InputModes`, not a new `Emulator` trait method.** Focus reporting is an input-affecting mode like bracketed paste and DECCKM, and `docs/DESIGN.md` §4 states the trait is *seven* methods, "deliberately the narrowest surface the terminal loop needs". Growing that surface for a mode that fits an existing struct would make the document wrong for no gain.

## The fixture proves the round trip through crossterm

`form-echo` now enables `EnableFocusChange` and renders `window: focused` / `window: unfocused`, so both branches are driven through **crossterm's own event stream** (`Event::FocusGained` / `Event::FocusLost`) rather than hand-rolled bytes.

**Reviewed snapshot diff** — exactly one added line, nothing else:

```diff
 size: 80x24  cursor: hidden
 form-echo ready
 input:
 last: enter
+window: focused
 submitted: hell
```

## The 0.4 lesson, re-learned while writing the test

My first version called `wait_frame(|s| s.contains("window: focused"))` after the ready wait, and it burned the full 10s timeout — the application had not repainted since, and a frame satisfies exactly one wait. The error said so precisely:

> the application has not completed a repaint since the frame this terminal last returned (1 complete frame in total)

The fix is to assert on the `Screen` the first wait *returned*, which is what returning it is for. Noted in a comment at the call site.

## Tests

- `focus_events_reach_the_application_in_both_directions` — out then back in, each asserted
- `focus_events_are_refused_without_mode_1004` — both directions against `hello-tui`, which enables nothing
- `decrqm_answers_for_focus_reporting` — reset, set, and reset again, asserting the reply is never `;0$y`

## Checklist

- [x] Linked an issue — closes #101
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes were **reviewed** — the one-line diff is quoted above