### PR TITLE
feat(builder): answer pixel geometry and let a test declare graphics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,23 @@ listed under a **Changed** or **Removed** heading.
   as a question: a transmission is an instruction, and treating one as a
   query would put "the application queried the terminal" into the next
   timeout of every application that draws.
+- **`TerminalBuilder::cell_size`** — pixels per character cell, which is the
+  one number every layout decision in an image-drawing application rests on.
+  `CSI 16 t` then answers `CSI 6 ; h ; w t`, `CSI 14 t` answers the window
+  size in pixels, and `TIOCGWINSZ` carries the same geometry instead of
+  contradicting it; a `resize` recomputes all three. Opt-in: unset, the two
+  reports stay unanswered and the ioctl reports zero pixels — which is what a
+  real terminal reports when it has none, so the default is not a lie and no
+  existing suite moves onto a pixel branch.
+- **`TerminalBuilder::graphics` and `Graphics`** — declare the inline-graphics
+  support of the terminal being simulated. `Graphics::Sixel` adds `4` to the
+  DA1 reply; `Graphics::Kitty` answers the `a=q` capability probe with
+  `APC _G i=<id> ; OK ST`, echoing the id the probe named. Default unchanged:
+  nothing claimed. This is not the harness lying — it is the test author
+  stating which terminal is simulated, the way `background_rgb` states a
+  background — and it matters because for an application that *probes first*
+  the pixel path is not merely unasserted, it is unreachable: the code never
+  runs, so nothing about it is testable.
 - **`Terminal::focus_in` / `Terminal::focus_out`** and
   **`Screen::focus_events`** — focus reporting (mode 1004). The unfocused
   branch of a UI was not merely unasserted, it was **unreachable**: no input

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -142,11 +142,37 @@ pub(crate) enum Query {
     /// this truthfully lets an application that *probes* before using a
     /// mode (synchronized output above all) turn it on against termlens.
     RequestMode(u32),
+    /// Window size in pixels: `CSI 14 t`.
+    WindowSizePixels,
+    /// Character cell size in pixels: `CSI 16 t`.
+    CellSizePixels,
+    /// The kitty graphics capability probe (`APC _G … a=q … ST`), carrying
+    /// the image id it named so a reply can echo it back.
+    ///
+    /// Classified rather than refused outright: whether it is answerable
+    /// depends on what the test declared the terminal supports, and that is
+    /// policy, which lives with the caller.
+    KittyGraphics {
+        /// The `i=` value, if the probe gave one.
+        id: Option<u32>,
+        /// Printable rendering, for the timeout note when unanswered.
+        shape: String,
+    },
     /// Recognized as a question, but one termlens has no answer for
     /// (XTGETTCAP, kitty `CSI ? u`, DECRQSS, `OSC 4`/`OSC 52`, other
     /// DSR/DA/XTWINOPS reports, …). Carries a printable rendering for
     /// diagnostics.
     Unanswerable(String),
+}
+
+/// The numeric value of `key` in a kitty control block (`i=3,a=q`), if it
+/// carries one. Keys are comma-separated `name=value` pairs.
+fn kitty_key(control: &[u8], key: &[u8]) -> Option<u32> {
+    control
+        .split(|&b| b == b',')
+        .find_map(|pair| pair.strip_prefix(key))
+        .and_then(|digits| std::str::from_utf8(digits).ok())
+        .and_then(|digits| digits.parse().ok())
 }
 
 /// Render a captured escape sequence printably (`ESC` becomes `^[`).
@@ -460,6 +486,11 @@ impl SeqTracker {
             (0, b'c') if params_empty || single(0) => Some(Query::PrimaryDa),
             (b'>', b'c') if params_empty || single(0) => Some(Query::SecondaryDa),
             (0, b't') if single(18) => Some(Query::TextAreaSize),
+            // Pixel geometry. Arithmetic, not rendering: answering claims
+            // nothing the emulator cannot do, and DA1 goes on declining
+            // graphics either way.
+            (0, b't') if single(14) => Some(Query::WindowSizePixels),
+            (0, b't') if single(16) => Some(Query::CellSizePixels),
             // Questions we can recognize but not answer.
             (_, b'n') | (b'=', b'c') => Some(Query::Unanswerable(self.seq_printable())),
             (b'?', b'u') if params_empty => {
@@ -469,7 +500,7 @@ impl SeqTracker {
                 Some(Query::Unanswerable(self.seq_printable()))
             }
             (0, b't')
-                if matches!(self.csi_first_param, 11 | 13 | 14 | 16 | 19 | 20 | 21)
+                if matches!(self.csi_first_param, 11 | 13 | 19 | 20 | 21)
                     && self.csi_param_count == 1 =>
             {
                 Some(Query::Unanswerable(self.seq_printable()))
@@ -556,16 +587,20 @@ impl SeqTracker {
             let is_query = control.windows(3).any(|w| w == b"a=q");
             if !is_query {
                 self.graphics.record(true, self.dcs_data_len);
+                return SeqEvent::None;
             }
-            if is_query {
-                // Only an explicit `a=q` is a question. A transmission is an
-                // instruction, and classifying one as a query would put "the
-                // application queried the terminal" into the next timeout of
-                // every application that draws — a false diagnosis, and a
-                // loud one.
-                return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
-            }
-            return SeqEvent::None;
+            // Only an explicit `a=q` is a question. A transmission is an
+            // instruction, and classifying one as a query would put "the
+            // application queried the terminal" into the next timeout of
+            // every application that draws — a false diagnosis, and a loud
+            // one.
+            // The control block is `G` followed by the comma-separated
+            // keys, so the keys start one byte in.
+            let id = kitty_key(&control[1..], b"i=");
+            return SeqEvent::Query(Query::KittyGraphics {
+                id,
+                shape: self.seq_printable(),
+            });
         }
         // Sixel: `DCS <params> q <data> ST`, with no intermediate byte. The
         // intermediate is the whole distinction from the two DCS questions
@@ -833,9 +868,11 @@ mod tests {
         assert!(
             events.iter().any(|e| matches!(
                 e,
-                SeqEvent::Query(Query::Unanswerable(q)) if q.contains("_G")
+                SeqEvent::Query(Query::KittyGraphics { id: Some(1), shape })
+                    if shape.contains("_G")
             )),
-            "the query must be named for the timeout note: {events:?}"
+            "the query must be classified, with its id, for a reply or a \
+             timeout note: {events:?}"
         );
         // A query carries no picture, so it is not counted as one.
         assert!(t.graphics().is_empty());
@@ -1111,12 +1148,40 @@ mod tests {
         );
     }
 
+    /// The pixel reports used to be lumped in with the whole `CSI t` family
+    /// as unanswerable. They are arithmetic, so they are now their own
+    /// questions — while the rest of the family stays declined.
+    #[test]
+    fn pixel_geometry_queries_are_classified_apart_from_the_rest() {
+        assert_eq!(queries_of(b"\x1b[14t"), vec![Query::WindowSizePixels]);
+        assert_eq!(queries_of(b"\x1b[16t"), vec![Query::CellSizePixels]);
+        assert_eq!(queries_of(b"\x1b[18t"), vec![Query::TextAreaSize]);
+        for shape in [&b"\x1b[11t"[..], b"\x1b[13t", b"\x1b[19t", b"\x1b[20t"] {
+            assert!(
+                matches!(queries_of(shape).as_slice(), [Query::Unanswerable(_)]),
+                "still declined: {shape:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_kitty_probe_without_an_id_still_classifies() {
+        assert_eq!(
+            queries_of(b"\x1b_Ga=q;\x1b\\"),
+            vec![Query::KittyGraphics {
+                id: None,
+                shape: "^[_Ga=q;^[\\".into()
+            }]
+        );
+    }
+
     #[test]
     fn recognizes_unanswerable_questions_with_their_shape() {
         let q = queries_of(b"\x1b[?u");
         assert_eq!(q, vec![Query::Unanswerable("^[[?u".into())]);
-        let q = queries_of(b"\x1b[14t");
-        assert_eq!(q, vec![Query::Unanswerable("^[[14t".into())]);
+        // 14t and 16t are classified in their own right now; 13t is not.
+        let q = queries_of(b"\x1b[13t");
+        assert_eq!(q, vec![Query::Unanswerable("^[[13t".into())]);
         let q = queries_of(b"\x1bP+q544e\x1b\\"); // XTGETTCAP
         assert_eq!(q, vec![Query::Unanswerable("^[P+q544e^[\\".into())]);
         let q = queries_of(b"\x1b[=c"); // DA3

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -84,7 +84,9 @@ pub use keys::{Chord, Input, Key};
 pub use screen::{Cell, Clipboard, Color, GraphicsSeen, MouseMode, Screen, Style};
 #[cfg(unix)]
 pub use terminal::Signal;
-pub use terminal::{ExitStatus, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder};
+pub use terminal::{
+    ExitStatus, Graphics, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder,
+};
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by
 /// default), so [`assert_screen_snapshot!`] always agrees with the `insta`

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -130,6 +130,36 @@ fn dup_writer(_master: &dyn portable_pty::MasterPty) -> Option<std::fs::File> {
     None
 }
 
+/// Inline-graphics support a test declares the simulated terminal has.
+///
+/// Default [`None`](Graphics::None): termlens claims nothing it cannot
+/// render, so an application that probes is told there is no graphics
+/// support and correctly takes its text path.
+///
+/// That default is right, and it has a consequence worth separating from
+/// mere unassertability: for an application that **asks first**, the pixel
+/// path is not just unasserted, it is **unreachable** — the code never runs,
+/// so nothing about it is testable, well-behaved or not. Declaring support
+/// is not the harness lying; it is the test author stating which terminal is
+/// being simulated, exactly as
+/// [`background_rgb`](TerminalBuilder::background_rgb) states a background.
+///
+/// One terminal is simulated at a time. Pair this with
+/// [`cell_size`](TerminalBuilder::cell_size): an application that draws
+/// pixels needs to know how big a cell is before it can lay anything out.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Graphics {
+    /// Nothing claimed. DA1 reports `?62;22c` and the kitty probe goes
+    /// unanswered — the default, and the honest one.
+    #[default]
+    None,
+    /// Sixel: DA1 gains `4`, so a probing application sees the capability.
+    Sixel,
+    /// Kitty graphics: the `a=q` capability probe is answered `OK`.
+    Kitty,
+}
+
 /// Scroll-wheel direction for [`Terminal::scroll`].
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -395,6 +425,11 @@ struct EmuState {
     /// Background color reported to OSC 11 queries.
     background: (u8, u8, u8),
     foreground: (u8, u8, u8),
+    /// Pixels per character cell, as the test declared them. `None` leaves
+    /// `CSI 14 t` / `CSI 16 t` unanswered.
+    cell_size: Option<(u16, u16)>,
+    /// Inline-graphics support the test declared the terminal has.
+    graphics: Graphics,
     /// Distinct queries that went unanswered, in first-seen order, each
     /// with the read it most recently arrived in — timeout errors surface
     /// these so a blocked probe is diagnosable.
@@ -416,6 +451,8 @@ impl EmuState {
         respond: bool,
         background: (u8, u8, u8),
         foreground: (u8, u8, u8),
+        cell_size: Option<(u16, u16)>,
+        graphics: Graphics,
     ) -> Self {
         Self {
             emu,
@@ -428,6 +465,8 @@ impl EmuState {
             respond,
             background,
             foreground,
+            cell_size,
+            graphics,
             unanswered: Vec::new(),
             unanswered_overflow: 0,
             replies_dropped: 0,
@@ -482,13 +521,55 @@ impl EmuState {
                 format!("\x1b[{prefix}{};{}R", row + 1, col + 1).into_bytes()
             }
             Query::OperatingStatus => b"\x1b[0n".to_vec(),
-            // VT220 with ANSI color: honest — nothing claimed (sixel,
-            // kitty, …) that the emulator cannot render.
-            Query::PrimaryDa => b"\x1b[?62;22c".to_vec(),
+            // VT220 with ANSI color. By default nothing is claimed that the
+            // emulator cannot render; `4` (sixel) appears only when a test
+            // declared it, which is the author stating which terminal is
+            // being simulated rather than the harness inventing a claim.
+            Query::PrimaryDa => match self.graphics {
+                Graphics::Sixel => b"\x1b[?62;4;22c".to_vec(),
+                _ => b"\x1b[?62;22c".to_vec(),
+            },
             Query::SecondaryDa => b"\x1b[>1;10;0c".to_vec(),
             Query::TextAreaSize => {
                 let screen = self.emu.snapshot();
                 format!("\x1b[8;{};{}t", screen.rows(), screen.cols()).into_bytes()
+            }
+            // Pixel geometry, answered only from a declared cell size.
+            // Unconfigured, these stay unanswered and named in the next
+            // timeout: zero is what a real terminal reports when it has no
+            // pixel geometry, and applications are written to read that as
+            // "unknown" — so silence keeps an existing suite on the path it
+            // takes today instead of moving it onto a pixel branch.
+            Query::CellSizePixels => match self.cell_size {
+                Some((w, h)) => format!("\x1b[6;{h};{w}t").into_bytes(),
+                None => {
+                    self.note_unanswered(query_shape(query));
+                    return None;
+                }
+            },
+            Query::WindowSizePixels => match self.cell_size {
+                Some((w, h)) => {
+                    let screen = self.emu.snapshot();
+                    let height = u32::from(screen.rows()) * u32::from(h);
+                    let width = u32::from(screen.cols()) * u32::from(w);
+                    format!("\x1b[4;{height};{width}t").into_bytes()
+                }
+                None => {
+                    self.note_unanswered(query_shape(query));
+                    return None;
+                }
+            },
+            // The kitty capability probe. Answered only when a test declared
+            // kitty support; otherwise it stays a named-but-unanswered query,
+            // which is what it was before there was any way to declare.
+            Query::KittyGraphics { id, shape } => {
+                if self.graphics == Graphics::Kitty {
+                    let id = id.unwrap_or(0);
+                    format!("\x1b_Gi={id};OK\x1b\\").into_bytes()
+                } else {
+                    self.note_unanswered(shape.clone());
+                    return None;
+                }
             }
             Query::OscColor {
                 code: 11,
@@ -639,6 +720,8 @@ pub struct TerminalBuilder {
     background: (u8, u8, u8),
     foreground: (u8, u8, u8),
     scrollback: usize,
+    cell_size: Option<(u16, u16)>,
+    graphics: Graphics,
 }
 
 impl Default for TerminalBuilder {
@@ -655,6 +738,8 @@ impl Default for TerminalBuilder {
             background: (0, 0, 0),
             foreground: (0xff, 0xff, 0xff),
             scrollback: DEFAULT_SCROLLBACK,
+            cell_size: None,
+            graphics: Graphics::None,
         }
     }
 }
@@ -830,6 +915,52 @@ impl TerminalBuilder {
         self
     }
 
+    /// Pixels per character cell, which is the one number every layout
+    /// decision in an image-drawing application rests on.
+    ///
+    /// Unset by default, and then `CSI 14 t` (window size in pixels) and
+    /// `CSI 16 t` (cell size in pixels) stay unanswered and named in the next
+    /// timeout, while `TIOCGWINSZ` reports zero pixels. That is not a gap
+    /// dressed up as a default: zero is exactly what a real terminal reports
+    /// when it has no pixel geometry to give, and applications are written to
+    /// read it as "unknown". Leaving it unset also keeps an existing suite on
+    /// the path its application takes today rather than moving it onto a
+    /// pixel branch.
+    ///
+    /// Setting it makes all three agree — the two escape replies and the
+    /// ioctl — and a [`resize`](Terminal::resize) recomputes them:
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// let mut t = termlens::Terminal::builder()
+    ///     .size(80, 24)
+    ///     .cell_size(10, 20)                       // px per cell
+    ///     .graphics(termlens::Graphics::Sixel)     // and a way to draw
+    ///     .spawn("./my-app")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This is arithmetic, not rendering: answering claims nothing the
+    /// emulator cannot do, and DA1 goes on declining graphics unless
+    /// [`graphics`](Self::graphics) says otherwise.
+    #[must_use]
+    pub fn cell_size(mut self, width: u16, height: u16) -> Self {
+        self.cell_size = Some((width, height));
+        self
+    }
+
+    /// Declare the inline-graphics support the simulated terminal has.
+    /// Defaults to [`Graphics::None`] — nothing claimed.
+    ///
+    /// See [`Graphics`] for why declaring is not the harness lying, and pair
+    /// it with [`cell_size`](Self::cell_size).
+    #[must_use]
+    pub fn graphics(mut self, graphics: Graphics) -> Self {
+        self.graphics = graphics;
+        self
+    }
+
     /// Reject configurations that cannot produce a working terminal.
     ///
     /// These are all programming errors in the test, and each has a
@@ -899,8 +1030,11 @@ impl TerminalBuilder {
             .openpty(PtySize {
                 rows: self.rows,
                 cols: self.cols,
-                pixel_width: 0,
-                pixel_height: 0,
+                // So TIOCGWINSZ agrees with the escape replies instead of
+                // contradicting them. Zero when no cell size was declared,
+                // which is what a real terminal reports when it has none.
+                pixel_width: pixel_span(self.cols, self.cell_size.map(|(w, _)| w)),
+                pixel_height: pixel_span(self.rows, self.cell_size.map(|(_, h)| h)),
             })
             .map_err(|e| Error::Pty(format!("openpty failed: {e}")))?;
 
@@ -939,6 +1073,8 @@ impl TerminalBuilder {
             self.answer_queries,
             self.background,
             self.foreground,
+            self.cell_size,
+            self.graphics,
         )));
         let writer: SharedWriter = Arc::new(Mutex::new(Some(writer)));
 
@@ -1004,6 +1140,7 @@ impl TerminalBuilder {
             exit_status: None,
             command_desc,
             frame_cursor: 0,
+            cell_size: self.cell_size,
         })
     }
 }
@@ -1034,6 +1171,13 @@ fn strip_paste_markers(text: &str) -> String {
 /// 5000x5000 was accepted and turned the first wait into a 16-second
 /// timeout that blamed the predicate.
 const MAX_DIMENSION: u16 = 1000;
+
+/// `cells * per_cell` for `TIOCGWINSZ`, saturating, and 0 when no cell size
+/// was declared — the value a real terminal reports when it has no pixel
+/// geometry.
+fn pixel_span(cells: u16, per_cell: Option<u16>) -> u16 {
+    per_cell.map_or(0, |px| cells.saturating_mul(px))
+}
 
 /// Reject a terminal size that cannot work, or cannot work usefully.
 ///
@@ -1091,6 +1235,9 @@ fn query_shape(query: &Query) -> String {
         Query::PrimaryDa => "^[[c".into(),
         Query::SecondaryDa => "^[[>c".into(),
         Query::TextAreaSize => "^[[18t".into(),
+        Query::WindowSizePixels => "^[[14t".into(),
+        Query::CellSizePixels => "^[[16t".into(),
+        Query::KittyGraphics { shape, .. } => shape.clone(),
         Query::OscColor { code, .. } => format!("^[]{code};?"),
         Query::RequestMode(mode) => format!("^[[?{mode}$p"),
         Query::Unanswerable(shape) => shape.clone(),
@@ -1208,6 +1355,9 @@ pub struct Terminal {
     /// satisfy two waits. Advanced by a resize too: a frame drawn at the
     /// old size is not the repaint that answers the new one.
     frame_cursor: u64,
+    /// Declared pixels per cell, kept so a resize can recompute the PTY's
+    /// pixel geometry rather than silently dropping it.
+    cell_size: Option<(u16, u16)>,
 }
 
 impl Terminal {
@@ -2209,8 +2359,8 @@ impl Terminal {
             .resize(PtySize {
                 rows,
                 cols,
-                pixel_width: 0,
-                pixel_height: 0,
+                pixel_width: pixel_span(cols, self.cell_size.map(|(w, _)| w)),
+                pixel_height: pixel_span(rows, self.cell_size.map(|(_, h)| h)),
             })
             .map_err(|e| Error::Pty(format!("resize failed: {e}")))?;
         // A frame drawn at the old size cannot be the repaint that answers

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -377,3 +377,145 @@ fn decrqm_answers_for_focus_reporting() -> termlens::Result<()> {
     }
     Ok(())
 }
+
+/// Pixel geometry: unset it stays unanswered and named, set it makes the
+/// two escape replies and `TIOCGWINSZ` agree instead of contradicting.
+#[test]
+fn cell_size_answers_the_pixel_reports_and_the_ioctl() -> termlens::Result<()> {
+    // Unset: no reply, and the query is named in the next timeout.
+    let mut mute = Terminal::builder()
+        .size(80, 6)
+        .timeout(Duration::from_millis(700))
+        .args([
+            "-c",
+            r"stty -icanon -echo; printf '\033[16t'; printf MARK; read g",
+        ])
+        .spawn("/bin/sh")?;
+    let err = mute
+        .wait_until(|s| s.contains("NEVER"))
+        .expect_err("must time out");
+    assert!(err.to_string().contains("^[[16t"), "named: {err}");
+    mute.send(Key::Enter)?;
+
+    // Declared: both reports answer from it.
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .cell_size(10, 20)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                // `min 0 time 20` so a read returns on a 2s timer instead of
+                // blocking on a byte count guessed wrong.
+                r"stty -icanon -echo min 0 time 20; ",
+                r"printf '\033[16t'; a=$(dd bs=1 count=32 2>/dev/null | tr -d '\033'); ",
+                r"printf '\033[14t'; b=$(dd bs=1 count=32 2>/dev/null | tr -d '\033'); ",
+                r#"printf 'cell[%s] win[%s] DONE' "$a" "$b"; read g"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let row = t.screen().row_text(0);
+    // CSI 6 ; height ; width t   and   CSI 4 ; rows*h ; cols*w t
+    assert!(row.contains("cell[[6;20;10t]"), "{row:?}");
+    assert!(row.contains("win[[4;480;800t]"), "{row:?}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The ioctl must agree with the escape replies, and a resize must move
+/// both — otherwise an application gets two different answers to the same
+/// question depending on how it asks.
+#[test]
+fn tiocgwinsz_agrees_with_the_declared_cell_size() -> termlens::Result<()> {
+    let read_winsize = r#"python3 -c 'import fcntl,struct,sys,termios; b=fcntl.ioctl(0,termios.TIOCGWINSZ,b"\0"*8); r,c,xp,yp=struct.unpack("HHHH",b); print(f"{c}x{r} px {xp}x{yp}", flush=True)'"#;
+    let script = format!("{read_winsize}; read a; {read_winsize}; printf DONE; read b");
+
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .cell_size(10, 20)
+        .timeout(Duration::from_secs(20))
+        .args(["-c", &script])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("px"))?;
+    assert!(
+        t.screen().contains("80x24 px 800x480"),
+        "the ioctl must carry the declared geometry:\n{}",
+        t.screen()
+    );
+
+    t.resize(40, 12)?;
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    assert!(
+        t.screen().contains("40x12 px 400x240"),
+        "a resize must recompute it:\n{}",
+        t.screen()
+    );
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Declaring graphics support is how an application that probes first can
+/// reach its pixel path at all. The default claims nothing, which is what
+/// makes the declaration meaningful.
+#[test]
+fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
+    // Default: DA1 has no `4`, and the kitty probe goes unanswered.
+    let mut plain = Terminal::builder()
+        .size(80, 6)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            r"stty -icanon -echo; printf '\033[c'; head -c 9 | tr -d '\033'; printf ' DONE'; read g",
+        ])
+        .spawn("/bin/sh")?;
+    plain.wait_until(|s| s.contains("DONE"))?;
+    let row = plain.screen().row_text(0);
+    assert!(
+        row.contains("[?62;22c"),
+        "nothing claimed by default: {row:?}"
+    );
+    assert!(!row.contains(";4;"), "no sixel by default: {row:?}");
+    plain.send(Key::Enter)?;
+
+    // Sixel declared: DA1 gains `4`, so a probing application sees it.
+    let mut sixel = Terminal::builder()
+        .size(80, 6)
+        .graphics(termlens::Graphics::Sixel)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            r"stty -icanon -echo; printf '\033[c'; head -c 11 | tr -d '\033'; printf ' DONE'; read g",
+        ])
+        .spawn("/bin/sh")?;
+    sixel.wait_until(|s| s.contains("DONE"))?;
+    assert!(
+        sixel.screen().row_text(0).contains("[?62;4;22c"),
+        "{:?}",
+        sixel.screen().row_text(0)
+    );
+    sixel.send(Key::Enter)?;
+
+    // Kitty declared: the a=q probe is answered OK, echoing the id.
+    let mut kitty = Terminal::builder()
+        .size(80, 6)
+        .graphics(termlens::Graphics::Kitty)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            r"stty -icanon -echo; printf '\033_Gi=7,a=q;\033\\'; head -c 9 | tr -d '\033'; printf ' DONE'; read g",
+        ])
+        .spawn("/bin/sh")?;
+    kitty.wait_until(|s| s.contains("DONE"))?;
+    assert!(
+        kitty.screen().row_text(0).contains("_Gi=7;OK"),
+        "the reply echoes the id the probe named: {:?}",
+        kitty.screen().row_text(0)
+    );
+    kitty.send(Key::Enter)?;
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -71,6 +71,24 @@ would close a loop on itself: the application concludes the terminal has
 no mouse, never enables tracking, and `click` then refuses, blaming the
 application for a decision we caused.
 
+Two answers are **declared rather than derived**, and they are the exception
+that shows where the honesty rule actually points. A cell size in pixels
+(`cell_size`, answering `CSI 14 t` and `CSI 16 t`, and filling the PTY's
+pixel fields so `TIOCGWINSZ` agrees) and inline-graphics support
+(`graphics`, adding `4` to DA1 or answering kitty's `a=q`) are facts about a
+terminal, not about an emulator, so there is nothing for us to be truthful
+*about* until a test says which terminal it is simulating. Both default to
+claiming nothing, which keeps every existing suite where it was.
+
+What makes the declaration legitimate rather than a lie is the failure it
+removes. An application that **asks before drawing** is told no, correctly
+takes its text path, and its pixel branch then never executes — so the branch
+is not unasserted, it is unreachable, and no test can say anything about code
+that does not run. That is the same shape as the `?2026` finding: one
+unrecognized query was the difference between an unmodified binary being
+untestable-by-frame and fully frame-testable. Declining by default is right;
+having no way to decline differently was not.
+
 `OSC 52` is the one sequence we **capture** rather than answer. A write
 (`OSC 52 ; targets ; base64`) is not a question, and the only evidence a
 test could otherwise see is the application's own toast — which proves the


### PR DESCRIPTION
Closes #116, closes #118.

One PR because the two issues are one story, and say so themselves: an application that draws pixels needs **both** a way to draw and a cell size to lay out against. Either alone leaves the round trip untestable — reachable but invisible, or visible but never reached.

## Verified

Against the published 0.4.2:

| query | before |
|---|---|
| `CSI 14 t` | no reply (whole `CSI t` report family classified unanswerable) |
| `CSI 16 t` | no reply |
| `TIOCGWINSZ` | `rows=6 cols=80 xpixel=0 ypixel=0` |
| DA1 | `ESC[?62;22c` |
| kitty `a=q` | no reply |

## `cell_size` — #116

`CSI 16 t` → `CSI 6 ; h ; w t`, `CSI 14 t` → `CSI 4 ; rows*h ; cols*w t`, and the PTY's pixel fields carry the same geometry so **`TIOCGWINSZ` agrees with the escape replies** instead of contradicting them. `resize` recomputes all three.

## `graphics(Graphics::…)` — #118

`Graphics::Sixel` adds `4` to DA1. `Graphics::Kitty` answers `a=q` with `APC _G i=<id> ; OK ST`, **echoing the id the probe named** — which meant carrying that id through classification, so the kitty query became its own `Query` variant rather than an opaque `Unanswerable`.

## Why both are opt-in, and why that is not a dodge

The usual default-on argument is fidelity: real terminals always answer. Two things outweigh it here.

**Zero is a truthful answer.** A real terminal with no pixel geometry reports zero, and applications are written to read that as *unknown* — mossaic does exactly this (`cell unknown → text`). So the default is not a gap dressed up as a default.

**Defaulting on would move existing suites.** A cell size gates a whole pixel branch. Silence keeps every application on the path it takes today.

**And what makes declaring legitimate is the failure it removes.** An application that asks before drawing is told no, correctly takes its text path, and its pixel branch then never executes — so the branch is not unasserted, it is **unreachable**, and no test can say anything about code that does not run. That is the same shape as the `?2026` finding the coverage study called the highest-leverage change across three studies: one unrecognized query was the difference between an unmodified binary being untestable-by-frame and fully frame-testable. Declining by default was right; having no way to decline differently was not.

`docs/DESIGN.md` §1 now records this as the one place an answer is **declared rather than derived**, and why that stays inside the honesty rule: a cell size and a graphics protocol are facts about a *terminal*, not about an emulator, so there is nothing to be truthful about until a test says which terminal it is simulating.

## Scope discipline

The pixel reports are classified apart from the rest of the `CSI t` family, and `11t`, `13t`, `19t`, `20t` are **pinned as still unanswered** so this did not widen by accident.

## Tests

- `cell_size_answers_the_pixel_reports_and_the_ioctl` — unset stays unanswered *and named in the timeout*; set gives `[6;20;10t` and `[4;480;800t`
- `tiocgwinsz_agrees_with_the_declared_cell_size` — `80x24 px 800x480`, then a resize to `40x12 px 400x240`
- `declared_graphics_support_reaches_the_probe` — default DA1 has no `4`; sixel gains it; kitty answers `_Gi=7;OK` echoing the id
- `pixel_geometry_queries_are_classified_apart_from_the_rest`, `a_kitty_probe_without_an_id_still_classifies`

One existing unit test moved from asserting `14t` is unanswerable to asserting `13t` is — the same guarantee, on a report that is still declined.

## Checklist

- [x] Linked an issue — closes #116, #118
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none