### PR TITLE
feat(queries): answer XTGETTCAP, the last unanswered startup probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,17 @@ listed under a **Changed** or **Removed** heading.
   as a question: a transmission is an instruction, and treating one as a
   query would put "the application queried the terminal" into the next
   timeout of every application that draws.
+- **`XTGETTCAP` is answered** — the last of the common startup probes with no
+  reply. A capability termlens genuinely implements gets a truthful
+  `DCS 1 + r <name>=<value> ST`; anything else gets an explicit
+  `DCS 0 + r <name> ST`, which is the half that turns a hang into a decision:
+  the application learns the answer is no instead of waiting for one. The set
+  is `TN`/`name` (whatever `TERM` the child was actually given, so the two
+  cannot disagree), `Co`/`colors`, and the cursor, home/end, delete, page and
+  backspace keys — each the exact bytes `Key::encode` emits, checked against
+  the code that emits them rather than copied from a terminfo file. One reply
+  per requested capability, because the status flag is per-reply and a mixed
+  request cannot be answered in one frame without lying about half of it.
 - **`TerminalBuilder::cell_size`** — pixels per character cell, which is the
   one number every layout decision in an image-drawing application rests on.
   `CSI 16 t` then answers `CSI 6 ; h ; w t`, `CSI 14 t` answers the window

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -158,6 +158,15 @@ pub(crate) enum Query {
         /// Printable rendering, for the timeout note when unanswered.
         shape: String,
     },
+    /// XTGETTCAP: "what is capability `name`?" — `DCS + q <hex names> ST`,
+    /// carrying the hex-encoded names exactly as asked, since the reply must
+    /// echo each one back.
+    RequestTermcap {
+        /// Hex-encoded names, `;`-separated, as the application wrote them.
+        names: String,
+        /// Printable rendering, for the timeout note when unanswered.
+        shape: String,
+    },
     /// Recognized as a question, but one termlens has no answer for
     /// (XTGETTCAP, kitty `CSI ? u`, DECRQSS, `OSC 4`/`OSC 52`, other
     /// DSR/DA/XTWINOPS reports, …). Carries a printable rendering for
@@ -254,9 +263,13 @@ pub(crate) struct SeqTracker {
     /// Payload bytes after the header, so a payload's size is reportable
     /// without keeping the payload.
     dcs_data_len: u64,
-    /// The opening bytes of a DCS-class payload, enough to read a kitty
-    /// control block (`G` plus `key=value` pairs up to the first `;`).
-    dcs_head: [u8; 48],
+    /// The opening bytes of a DCS-class payload: enough for a kitty control
+    /// block (`G` plus `key=value` pairs up to the first `;`) and for an
+    /// XTGETTCAP name list, whose hex names run about six bytes each. A
+    /// longer list truncates, and the names that survive are still answered
+    /// — a partial answer beats none, and the ones we drop get no reply,
+    /// which is what an application already has to handle.
+    dcs_head: [u8; 128],
     dcs_head_len: u8,
 }
 
@@ -289,7 +302,7 @@ impl SeqTracker {
             dcs_final: 0,
             dcs_intermediate: 0,
             dcs_data_len: 0,
-            dcs_head: [0; 48],
+            dcs_head: [0; 128],
             dcs_head_len: 0,
         }
     }
@@ -609,8 +622,23 @@ impl SeqTracker {
             self.graphics.record(false, self.dcs_data_len);
             return SeqEvent::None;
         }
-        // DCS questions: XTGETTCAP (`ESC P + q … ST`) and DECRQSS
-        // (`ESC P $ q … ST`, "what is the current setting of …?").
+        // XTGETTCAP (`ESC P + q <hex names> ST`). The names are needed to
+        // answer, so they come out of the header capture rather than the
+        // 24-byte diagnostic buffer.
+        if self.dcs_introducer == b'P' && self.dcs_intermediate == b'+' && self.dcs_final == b'q' {
+            let head = &self.dcs_head[..usize::from(self.dcs_head_len)];
+            // `head` starts at `+`; the names follow the `q`.
+            let names = head
+                .iter()
+                .position(|&b| b == b'q')
+                .map(|at| String::from_utf8_lossy(&head[at + 1..]).into_owned())
+                .unwrap_or_default();
+            return SeqEvent::Query(Query::RequestTermcap {
+                names,
+                shape: self.seq_printable(),
+            });
+        }
+        // DECRQSS (`ESC P $ q … ST`, "what is the current setting of …?").
         let body = &self.seq_buf[..usize::from(self.seq_len)];
         if matches!(body.get(2..4), Some(b"+q" | b"$q")) {
             return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
@@ -1164,6 +1192,22 @@ mod tests {
         }
     }
 
+    /// The names must come out intact, since the reply has to echo each one
+    /// back — and they are longer than the 24-byte diagnostic buffer can
+    /// hold, which is why they come from the header capture instead.
+    #[test]
+    fn xtgettcap_carries_the_names_it_was_asked_for() {
+        // "TN" and "colors", hex-encoded, as xterm-style clients send them.
+        let q = queries_of(b"\x1bP+q544e;636f6c6f7273\x1b\\");
+        assert_eq!(
+            q,
+            vec![Query::RequestTermcap {
+                names: "544e;636f6c6f7273".into(),
+                shape: "^[P+q544e;636f6c6f7273^[\\".into(),
+            }]
+        );
+    }
+
     #[test]
     fn a_kitty_probe_without_an_id_still_classifies() {
         assert_eq!(
@@ -1182,8 +1226,9 @@ mod tests {
         // 14t and 16t are classified in their own right now; 13t is not.
         let q = queries_of(b"\x1b[13t");
         assert_eq!(q, vec![Query::Unanswerable("^[[13t".into())]);
-        let q = queries_of(b"\x1bP+q544e\x1b\\"); // XTGETTCAP
-        assert_eq!(q, vec![Query::Unanswerable("^[P+q544e^[\\".into())]);
+        // XTGETTCAP is answerable now; DECRQSS still is not.
+        let q = queries_of(b"\x1bP$qm\x1b\\"); // DECRQSS
+        assert_eq!(q, vec![Query::Unanswerable("^[P$qm^[\\".into())]);
         let q = queries_of(b"\x1b[=c"); // DA3
         assert_eq!(q, vec![Query::Unanswerable("^[[=c".into())]);
         let q = queries_of(b"\x1b]12;?\x07"); // cursor color

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -430,6 +430,9 @@ struct EmuState {
     cell_size: Option<(u16, u16)>,
     /// Inline-graphics support the test declared the terminal has.
     graphics: Graphics,
+    /// The `TERM` the child was given, reported back for XTGETTCAP's `TN`
+    /// so the two cannot disagree.
+    term_name: String,
     /// Distinct queries that went unanswered, in first-seen order, each
     /// with the read it most recently arrived in — timeout errors surface
     /// these so a blocked probe is diagnosable.
@@ -453,6 +456,7 @@ impl EmuState {
         foreground: (u8, u8, u8),
         cell_size: Option<(u16, u16)>,
         graphics: Graphics,
+        term_name: String,
     ) -> Self {
         Self {
             emu,
@@ -467,6 +471,7 @@ impl EmuState {
             foreground,
             cell_size,
             graphics,
+            term_name,
             unanswered: Vec::new(),
             unanswered_overflow: 0,
             replies_dropped: 0,
@@ -585,6 +590,17 @@ impl EmuState {
                 // `Emulator::mode_state`.
                 let value = self.emu.mode_state(*mode).report_value();
                 format!("\x1b[?{mode};{value}$y").into_bytes()
+            }
+            Query::RequestTermcap { names, shape } => {
+                match termcap_reply(names, &self.term_name) {
+                    Some(reply) => reply,
+                    None => {
+                        // Nothing in the request was even readable as a hex
+                        // name, so there is no cap to answer or decline.
+                        self.note_unanswered(shape.clone());
+                        return None;
+                    }
+                }
             }
             Query::Unanswerable(shape) => {
                 self.note_unanswered(shape.clone());
@@ -1046,6 +1062,13 @@ impl TerminalBuilder {
         if self.env_clear {
             cmd.env_clear();
         }
+        // Whatever the child is told TERM is, XTGETTCAP's `TN` reports the
+        // same string — an application must not be able to get two different
+        // answers to "which terminal is this?".
+        let term_name = self.envs.iter().find(|(k, _)| k == "TERM").map_or_else(
+            || "xterm-256color".to_owned(),
+            |(_, v)| v.to_string_lossy().into_owned(),
+        );
         if !self.envs.iter().any(|(k, _)| k == "TERM") {
             cmd.env("TERM", "xterm-256color");
         }
@@ -1075,6 +1098,7 @@ impl TerminalBuilder {
             self.foreground,
             self.cell_size,
             self.graphics,
+            term_name,
         )));
         let writer: SharedWriter = Arc::new(Mutex::new(Some(writer)));
 
@@ -1172,6 +1196,84 @@ fn strip_paste_markers(text: &str) -> String {
 /// timeout that blamed the predicate.
 const MAX_DIMENSION: u16 = 1000;
 
+/// The value termlens can truthfully report for a terminfo capability, or
+/// `None` to decline it.
+///
+/// Every entry is something the crate genuinely implements, checked against
+/// the code that implements it rather than copied from a terminfo file. The
+/// key capabilities are the exact bytes [`Key::encode`](crate::Key::encode)
+/// produces in default mode, so an application that reads them and then
+/// matches incoming input against them will match what we actually send.
+///
+/// Declining is the default for everything else, and it is not a shrug: a
+/// guessed capability is worse than an absent one, because the application
+/// will believe it.
+fn termcap_value(name: &str, term_name: &str) -> Option<String> {
+    Some(match name {
+        // The terminal name we told the child, so `TN` and `$TERM` agree.
+        "TN" | "name" => term_name.to_owned(),
+        // 256 indexed colours, which is what `xterm-256color` promises and
+        // what the emulator renders.
+        "Co" | "colors" => "256".to_owned(),
+        // Key capabilities: exactly what `Key::encode` emits.
+        "kbs" => "\u{7f}".to_owned(),
+        "kcuu1" => "\u{1b}[A".to_owned(),
+        "kcud1" => "\u{1b}[B".to_owned(),
+        "kcuf1" => "\u{1b}[C".to_owned(),
+        "kcub1" => "\u{1b}[D".to_owned(),
+        "khome" => "\u{1b}[H".to_owned(),
+        "kend" => "\u{1b}[F".to_owned(),
+        "kdch1" => "\u{1b}[3~".to_owned(),
+        "kpp" => "\u{1b}[5~".to_owned(),
+        "knp" => "\u{1b}[6~".to_owned(),
+        _ => return None,
+    })
+}
+
+/// Build the XTGETTCAP reply for a `;`-separated list of hex-encoded names.
+///
+/// One `DCS` per requested capability: the status flag is per-reply (`1` =
+/// known, `0` = unsupported), so a mixed request cannot be answered in a
+/// single frame without lying about one half of it. `None` when nothing in
+/// the request decoded as a name at all.
+fn termcap_reply(names: &str, term_name: &str) -> Option<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut decoded_any = false;
+    for hex_name in names.split(';').filter(|s| !s.is_empty()) {
+        let Some(name) = decode_hex(hex_name) else {
+            continue;
+        };
+        decoded_any = true;
+        match termcap_value(&name, term_name) {
+            Some(value) => out.extend_from_slice(
+                format!("\x1bP1+r{hex_name}={}\x1b\\", encode_hex(value.as_bytes())).as_bytes(),
+            ),
+            // Explicitly unsupported, which is the half of this that turns a
+            // hang into a decision: the application learns the answer is no
+            // instead of waiting for one.
+            None => {
+                out.extend_from_slice(format!("\x1bP0+r{hex_name}\x1b\\").as_bytes());
+            }
+        }
+    }
+    decoded_any.then_some(out)
+}
+
+/// Hex to text, or `None` if it is not an even-length hex string.
+fn decode_hex(hex: &str) -> Option<String> {
+    if hex.len() % 2 != 0 || hex.is_empty() {
+        return None;
+    }
+    let bytes: Option<Vec<u8>> = (0..hex.len() / 2)
+        .map(|i| u8::from_str_radix(hex.get(i * 2..i * 2 + 2)?, 16).ok())
+        .collect();
+    String::from_utf8(bytes?).ok()
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
 /// `cells * per_cell` for `TIOCGWINSZ`, saturating, and 0 when no cell size
 /// was declared — the value a real terminal reports when it has no pixel
 /// geometry.
@@ -1238,6 +1340,7 @@ fn query_shape(query: &Query) -> String {
         Query::WindowSizePixels => "^[[14t".into(),
         Query::CellSizePixels => "^[[16t".into(),
         Query::KittyGraphics { shape, .. } => shape.clone(),
+        Query::RequestTermcap { shape, .. } => shape.clone(),
         Query::OscColor { code, .. } => format!("^[]{code};?"),
         Query::RequestMode(mode) => format!("^[[?{mode}$p"),
         Query::Unanswerable(shape) => shape.clone(),

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -519,3 +519,103 @@ fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
     kitty.send(Key::Enter)?;
     Ok(())
 }
+
+/// XTGETTCAP was the last of the common startup probes with no reply. Both
+/// halves matter: a known capability is answered truthfully, and an unknown
+/// one is *explicitly* declined — which is what turns a hang into a decision.
+#[test]
+fn xtgettcap_answers_what_it_knows_and_declines_the_rest() -> termlens::Result<()> {
+    // TN=544e, colors=636f6c6f7273, and a made-up name that must be refused.
+    let mut t = Terminal::builder()
+        .size(120, 6)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo min 0 time 20; ",
+                r"printf '\033P+q544e;636f6c6f7273;7a7a7a7a\033\\'; ",
+                r"dd bs=1 count=200 2>/dev/null | tr -d '\033' | tr -s '\\' '|'; ",
+                r"printf ' DONE'; read g"
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let text = t.screen().text();
+
+    // TN -> "xterm-256color", hex 787465726d2d323536636f6c6f72
+    assert!(
+        text.contains("P1+r544e=787465726d2d323536636f6c6f72"),
+        "TN must report the TERM the child was given:\n{text}"
+    );
+    // colors -> "256", hex 323536
+    assert!(
+        text.contains("P1+r636f6c6f7273=323536"),
+        "colors must be answered:\n{text}"
+    );
+    // An unknown capability is declined with status 0, not ignored.
+    assert!(
+        text.contains("P0+r7a7a7a7a"),
+        "an unknown capability must be explicitly refused:\n{text}"
+    );
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// `TN` reports whatever `TERM` the child was actually given, so an
+/// application cannot get two different answers to "which terminal is this?".
+#[test]
+fn xtgettcap_tn_follows_the_configured_term() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(120, 6)
+        .env("TERM", "xterm")
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo min 0 time 20; ",
+                r"printf '\033P+q544e\033\\'; ",
+                r"dd bs=1 count=80 2>/dev/null | tr -d '\033' | tr -s '\\' '|'; ",
+                r#"printf ' term=%s DONE' "$TERM"; read g"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let text = t.screen().text();
+    // "xterm" is hex 787465726d
+    assert!(text.contains("P1+r544e=787465726d"), "{text}");
+    assert!(text.contains("term=xterm"), "{text}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// A key capability must be the bytes termlens actually sends, or an
+/// application that reads it and then matches input against it will not
+/// match what arrives.
+#[test]
+fn xtgettcap_key_capabilities_match_what_send_emits() -> termlens::Result<()> {
+    // kcuu1 = 6b63757531; the value must be ESC [ A = 1b5b41.
+    let mut t = Terminal::builder()
+        .size(120, 6)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo min 0 time 20; ",
+                r"printf '\033P+q6b63757531\033\\'; ",
+                r"dd bs=1 count=80 2>/dev/null | tr -d '\033' | tr -s '\\' '|'; ",
+                r"printf ' DONE'; read g"
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let text = t.screen().text();
+    assert!(text.contains("P1+r6b63757531=1b5b41"), "{text}");
+    // And that is exactly what Key::Up encodes to in default mode.
+    assert_eq!(termlens::Key::Up.encode(), b"\x1b[A");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -135,7 +135,16 @@ input involved. A full queue means the application is not reading at
 all — so it cannot be waiting on those bytes — and the replies are
 counted and named in the next wait's error instead.
 
-Whatever remains unanswered (XTGETTCAP, pixel-size reports, …) is
+`XTGETTCAP` is answered from a table of capabilities the crate actually
+implements, and every entry was checked against the code that implements it
+rather than copied from a terminfo file — the key capabilities are literally
+the bytes `Key::encode` produces, so an application that reads them and then
+matches incoming input against them matches what we send. Anything else gets
+the explicit "unsupported" reply, which is the half that matters: a
+capability we guessed at would be believed, while a refusal lets the
+application decide instead of wait.
+
+Whatever remains unanswered (DECRQSS, the non-pixel `CSI t` reports, …) is
 recorded, and the next wait timeout names it: "the application queried
 the terminal (`^[[14t`) and received no answer" — a hang becomes a
 diagnosis. `answer_queries(false)` mutes the responder for tests that


### PR DESCRIPTION
Closes #100.

## Verified

Against the published 0.4.2, `DCS + q 544e ST` gets **no reply** — only a mention in the next timeout note. Of the six probes a capability-hungry application fires at startup, five were answered and this was the exception.

## Both halves, and the second is the point

A capability the crate genuinely implements → `DCS 1 + r <name>=<value> ST`.
Anything else → an explicit `DCS 0 + r <name> ST`.

The refusal is what turns a hang into a *decision*: the application learns the answer is no instead of waiting for one. Silence and "unsupported" are very different things to a program blocked on a reply, which is exactly the gap the issue described — a diagnosis in a timeout note is better than nothing, but it still means the application cannot be driven.

## The table was checked, not copied

`TN`/`name`, `Co`/`colors`, and the cursor, home/end, delete, page and backspace keys. Every entry was verified against the code that implements it rather than lifted from a terminfo file — the key capabilities are literally the bytes `Key::encode` emits in default mode.

`xtgettcap_key_capabilities_match_what_send_emits` asserts the `kcuu1` reply **and** `Key::Up.encode()` in the same test, so the two cannot drift apart. That matters more than it looks: an application that reads a key capability and then matches incoming input against it would silently fail to match if we reported bytes we do not send.

**`TN` reports whatever `TERM` the child was actually given**, not a constant, so an application cannot get two different answers to "which terminal is this?" — pinned by `xtgettcap_tn_follows_the_configured_term` with `TERM=xterm`.

## One reply per capability

The status flag is per-reply, so a request mixing known and unknown names cannot be answered in a single frame without lying about half of it. The test asks for `TN;colors;zzzz` and asserts all three outcomes.

## An honest bound

Answering needs the requested *names*, which run ~6 hex bytes each and are longer than the 24-byte diagnostic buffer holds — so they come from the DCS header capture, raised to 128 bytes. Truncation behaviour is documented rather than hidden: names that survive are answered, the rest get no reply, which is the case an application already has to handle.

DECRQSS stays declined, and now carries the test that used to pin XTGETTCAP.

## Checklist

- [x] Linked an issue — closes #100
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none