### PR TITLE
fix(input): report a drag motion per cell crossed instead of teleporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ listed under a **Changed** or **Removed** heading.
   therefore an error on one CI runner and silently discarded on the other.
   Every sender now checks for a closed terminal before writing, so the
   answer is the same everywhere and no keystroke is lost quietly.
+- **`drag` reports one motion per cell crossed**, on a straight interpolated
+  path, instead of a single report at the destination. Seven cells crossed
+  used to produce one motion event. Invisible to an application that only
+  asks "where did it start, where is it now" — which is why it went unnoticed
+  — and wrong for every application that does something *along* the path: a
+  drawing surface painting each crossed cell, a selection highlighting
+  incrementally, a drag that must cross a pane edge to register. The
+  mode-aware refusals are unchanged: `?1000` still hears no motion at all,
+  and X10 is still a typed error.
 - **A mouse action at a departed child names the child.** `click`, `drag`
   and `scroll` check liveness *before* the mouse-tracking mode, because a
   child that has exited necessarily never enabled tracking either — so the

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1274,6 +1274,36 @@ fn encode_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
+/// The cells a straight drag crosses, from just after `from` through `to`.
+///
+/// Bresenham-free on purpose: stepping the long axis one cell at a time and
+/// scaling the short axis to it is exact for the endpoints, monotone, and
+/// visits every intervening column (or row, whichever spans further) exactly
+/// once — which is the property an application acting on the path depends on.
+/// `from` itself is excluded, because the press already reported it.
+fn cells_between(from: (u16, u16), to: (u16, u16)) -> Vec<(u16, u16)> {
+    let (from_col, from_row) = (i32::from(from.0), i32::from(from.1));
+    let (to_col, to_row) = (i32::from(to.0), i32::from(to.1));
+    let d_col = to_col - from_col;
+    let d_row = to_row - from_row;
+    let steps = d_col.abs().max(d_row.abs());
+    if steps == 0 {
+        // A drag that goes nowhere still reports the motion it was asked
+        // for, at the one cell involved.
+        return vec![to];
+    }
+    (1..=steps)
+        .map(|step| {
+            // Round to nearest so the short axis turns over mid-run rather
+            // than at the end, which is what a straight line looks like.
+            let col = from_col + (d_col * step + d_col.signum() * steps / 2) / steps;
+            let row = from_row + (d_row * step + d_row.signum() * steps / 2) / steps;
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            (col as u16, row as u16)
+        })
+        .collect()
+}
+
 /// `cells * per_cell` for `TIOCGWINSZ`, saturating, and 0 when no cell size
 /// was declared — the value a real terminal reports when it has no pixel
 /// geometry.
@@ -1696,11 +1726,19 @@ impl Terminal {
         self.write_input(&bytes, "a mouse click")
     }
 
-    /// Drag from one cell to another: press, motion, release.
+    /// Drag from one cell to another: press, a motion report **per cell
+    /// crossed**, release.
+    ///
+    /// The path is a straight line, interpolated on both axes for a diagonal
+    /// drag. A real pointer's exact path is not reproducible and does not
+    /// need to be; what matters is that every intervening cell is reported,
+    /// because an application may act on the path and not just its ends — a
+    /// drawing surface painting each crossed cell, a selection highlighting
+    /// incrementally, a drag that has to cross a pane edge to register.
     ///
     /// What actually reaches the application depends on what it asked
     /// for, as always. Under button-event or any-event tracking
-    /// (`?1002`/`?1003`) the motion report is included; under plain
+    /// (`?1002`/`?1003`) the motion reports are included; under plain
     /// `?1000` the application asked not to hear about motion, so it
     /// receives the press and release alone — the endpoints, which is
     /// what selection handling usually needs. Under X10 (`?9`) there is
@@ -1735,15 +1773,21 @@ impl Terminal {
             MouseMode::PressRelease => false,
             MouseMode::ButtonMotion | MouseMode::AnyMotion => true,
         };
-        let (from_col, from_row) = from;
-        let (to_col, to_row) = to;
-
-        let mut bytes = self.mouse_report(&modes, chord.code(), from_col, from_row, true)?;
+        let mut bytes = self.mouse_report(&modes, chord.code(), from.0, from.1, true)?;
         if report_motion {
-            // A motion report is the button code plus 32.
-            bytes.extend(self.mouse_report(&modes, chord.code() + 32, to_col, to_row, true)?);
+            // One motion report per cell crossed, which is what a terminal
+            // sends. A single report at the destination is invisible to an
+            // application that only asks "where did it start, where is it
+            // now" — and wrong for every application that does something
+            // *along* the path: a drawing surface painting each crossed
+            // cell, a selection highlighting incrementally, a drag that has
+            // to cross a pane edge to register. A motion report is the
+            // button code plus 32.
+            for (col, row) in cells_between(from, to) {
+                bytes.extend(self.mouse_report(&modes, chord.code() + 32, col, row, true)?);
+            }
         }
-        bytes.extend(self.mouse_report(&modes, chord.code(), to_col, to_row, false)?);
+        bytes.extend(self.mouse_report(&modes, chord.code(), to.0, to.1, false)?);
         self.write_input(&bytes, "a mouse drag")
     }
 
@@ -2533,5 +2577,61 @@ impl Drop for Terminal {
                 .take(),
         );
         drop(self.master.take());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cells_between;
+
+    #[test]
+    fn a_horizontal_drag_visits_every_column() {
+        assert_eq!(
+            cells_between((5, 4), (9, 4)),
+            vec![(6, 4), (7, 4), (8, 4), (9, 4)]
+        );
+    }
+
+    #[test]
+    fn a_backwards_drag_steps_backwards() {
+        assert_eq!(cells_between((9, 4), (6, 4)), vec![(8, 4), (7, 4), (6, 4)]);
+    }
+
+    #[test]
+    fn a_vertical_drag_visits_every_row() {
+        assert_eq!(cells_between((3, 1), (3, 4)), vec![(3, 2), (3, 3), (3, 4)]);
+    }
+
+    /// A diagonal interpolates both axes, and the short axis turns over
+    /// mid-run rather than all at the end — a straight line, not an L.
+    #[test]
+    fn a_diagonal_drag_interpolates_both_axes() {
+        assert_eq!(
+            cells_between((0, 0), (4, 2)),
+            vec![(1, 1), (2, 1), (3, 2), (4, 2)]
+        );
+        // Steps are driven by the longer axis, so no cell is visited twice.
+        let path = cells_between((0, 0), (8, 3));
+        assert_eq!(path.len(), 8);
+        assert_eq!(path.last(), Some(&(8, 3)));
+    }
+
+    #[test]
+    fn a_drag_that_goes_nowhere_still_reports_one_motion() {
+        assert_eq!(cells_between((7, 7), (7, 7)), vec![(7, 7)]);
+    }
+
+    /// The endpoints are exact — an off-by-one here would put a drop target
+    /// one cell away from where the test asked for it.
+    #[test]
+    fn interpolation_always_lands_on_the_destination() {
+        for to in [(1u16, 0u16), (0, 1), (37, 5), (5, 37), (200, 199)] {
+            let path = cells_between((0, 0), to);
+            assert_eq!(path.last(), Some(&to), "from (0,0) to {to:?}");
+            assert!(
+                !path.contains(&(0, 0)),
+                "the press already reported the origin"
+            );
+        }
     }
 }

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -206,10 +206,11 @@ fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Res
         .args([
             "-c",
             concat!(
-                r"stty -icanon -echo; printf '\033[?1003h\033[?1006h'; printf READY; ",
-                // 78 bytes: 20 (right press+release) + 20 (ctrl+left)
-                // + 10 (wheel left) + 28 (drag press+motion+release).
-                r#"wire=$(head -c 78 | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
+                // `min 0 time 20` rather than an exact byte count: the drag
+                // reports one motion per cell crossed, so the length depends
+                // on the path.
+                r"stty -icanon -echo min 0 time 20; printf '\033[?1003h\033[?1006h'; printf READY; ",
+                r#"wire=$(dd bs=1 count=200 2>/dev/null | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
             ),
         ])
         .spawn("/bin/sh")?;
@@ -230,12 +231,85 @@ fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Res
         "[<16;4;2M",
         "[<16;4;2m", // ctrl + left
         "[<66;6;6M", // horizontal wheel
+        // Drag (2,2) -> (6,3): press, one motion per crossed cell, release.
         "[<0;3;3M",
+        "[<32;4;3M",
+        "[<32;5;4M",
+        "[<32;6;4M",
         "[<32;7;4M",
-        "[<0;7;4m", // drag: press, motion, release
+        "[<0;7;4m",
     ] {
         assert!(text.contains(expected), "missing {expected} in:\n{text}");
     }
+    Ok(())
+}
+
+/// A drag used to teleport: one motion report at the destination, however
+/// many cells it crossed. Invisible to an application that only asks "where
+/// did it start, where is it now", and wrong for every application that does
+/// something *along* the path.
+#[test]
+fn a_drag_reports_one_motion_per_cell_crossed() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(200, 24)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo min 0 time 20; printf '\033[?1002h\033[?1006h'; printf READY; ",
+                r#"wire=$(dd bs=1 count=300 2>/dev/null | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+
+    // Seven cells crossed, from column 5 to column 12 on row 4.
+    t.drag(termlens::MouseButton::Left, (5, 4), (12, 4))?;
+    t.wait_until(|s| s.row_text(0).contains("|"))?;
+    let text = t.screen().row_text(0);
+
+    // One motion at each intervening column, 1-based on the wire.
+    for col in 7..=13 {
+        assert!(
+            text.contains(&format!("[<32;{col};5M")),
+            "missing motion at column {col} in:\n{text}"
+        );
+    }
+    assert_eq!(
+        text.matches("[<32;").count(),
+        7,
+        "seven cells crossed, seven motion reports:\n{text}"
+    );
+    // The press and release still bracket it, at the endpoints.
+    assert!(text.contains("[<0;6;5M"), "{text}");
+    assert!(text.contains("[<0;13;5m"), "{text}");
+    Ok(())
+}
+
+/// The mode-aware refusals are untouched: under plain `?1000` the
+/// application asked not to hear about motion, so it hears none.
+#[test]
+fn press_release_tracking_still_gets_no_motion_at_all() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(200, 24)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"stty -icanon -echo min 0 time 20; printf '\033[?1000h\033[?1006h'; printf READY; ",
+                r#"wire=$(dd bs=1 count=100 2>/dev/null | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+    t.drag(termlens::MouseButton::Left, (5, 4), (12, 4))?;
+    t.wait_until(|s| s.row_text(0).contains("|"))?;
+    let text = t.screen().row_text(0);
+    assert!(!text.contains("[<32;"), "no motion under ?1000:\n{text}");
+    assert!(
+        text.contains("[<0;6;5M") && text.contains("[<0;13;5m"),
+        "{text}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Closes #104.

## Verified

Dragging column 5 → 12 under `1002`+`1006`, against the published 0.4.2:

```
E[<0;6;4M      press at column 6
E[<32;13;4M    one motion, already at the destination
E[<0;13;4m     release at column 13
```

Seven cells crossed, **one** motion event — exactly as the issue measured.

## Why it went unnoticed, and why it matters anyway

For an application that only asks "where did it start, where is it now", the shortcut is invisible. It breaks the moment an application does something *along* the path: a drawing surface painting each crossed cell, a selection highlighting incrementally, anything counting motion events, a drag that must cross a boundary to register. Those are precisely the cases someone reaches for `drag` to test.

It also sat oddly against the crate's own standard, as the issue notes: `drag` refuses under X10 rather than send a misleading half-gesture, while sending a teleport under `1002` was the same category of half-truth, just quieter.

## The path

A straight line, interpolated on both axes for a diagonal, and documented as such — a real pointer's exact path is not reproducible and does not need to be.

Stepping the long axis one cell at a time and scaling the short axis to it is exact at both endpoints, monotone, and visits every intervening cell exactly once. Rounding to nearest makes the short axis turn over **mid-run** rather than all at the end, so a diagonal reads as a line and not an L:

```
(0,0) -> (4,2)   =>   (1,1) (2,1) (3,2) (4,2)
```

`interpolation_always_lands_on_the_destination` checks the endpoint across five shapes including both axis-dominant directions — an off-by-one here would put a drop target one cell from where the test asked for it.

## Unchanged, and now pinned

- `?1000` (press/release only): **no motion at all** — `press_release_tracking_still_gets_no_motion_at_all`
- X10 `?9`: still a typed error

## One existing test changed

`buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire` asserted the single motion report, so it now asserts the interpolated path. Its hard-coded `head -c 78` is gone too: the wire length depends on the path, so it reads with a timeout rather than a byte count computed by hand.

## Checklist

- [x] Linked an issue — closes #104
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none