### PR TITLE
feat(terminal): add send_after for the Esc/Alt wire ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,15 @@ listed under a **Changed** or **Removed** heading.
   background — and it matters because for an application that *probes first*
   the pixel path is not merely unasserted, it is unreachable: the code never
   runs, so nothing about it is testable.
+- **`Terminal::send_after`** — wait, then send, so this write and the previous
+  one land in separate reads. The remedy for the `Esc` wire ambiguity when the
+  `Esc` has no observable effect to wait for: a vim-style TUI where `Esc`
+  leaves insert mode silently and `j` then moves down could not be driven at
+  all, because sending them together is byte-identical to `Alt+j`. The delay
+  is a named argument, not a hidden constant, and `send(Key::Esc)` carries no
+  default separation — most suites send `Esc` with nothing behind it, and a
+  hidden sleep would slow all of them for a hazard they do not have while
+  making the tests that need it work for a reason invisible at the call site.
 - **`Terminal::focus_in` / `Terminal::focus_out`** and
   **`Screen::focus_events`** — focus reporting (mode 1004). The unfocused
   branch of a UI was not merely unasserted, it was **unreachable**: no input

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -24,14 +24,19 @@ pub enum Key {
     /// byte-identical to an [`Alt`](Key::Alt) chord, and every input
     /// parser resolves it as one — real keyboards are saved only by human
     /// inter-key delay, which [`send`](crate::Terminal::send) does not
-    /// add. Make the `Esc`'s effect observable and wait for it before
-    /// sending the next key:
+    /// add. Where the `Esc` has an observable effect, wait for it and the
+    /// next key is unambiguous:
     ///
     /// ```text
     /// t.send(Key::Esc)?;
     /// t.wait_until(|s| s.contains("NORMAL"))?; // Esc took effect
     /// t.send(Key::Char('?'))?;                 // now unambiguous
     /// ```
+    ///
+    /// Where it has none — leaving a text field's insert mode often changes
+    /// nothing visible — there is nothing to wait *for*, and
+    /// [`send_after`](crate::Terminal::send_after) puts a named delay
+    /// between the two writes instead.
     Esc,
     /// Tab (`0x09`).
     Tab,
@@ -417,6 +422,17 @@ mod tests {
         for (chord, bytes) in table {
             assert_eq!(chord.encode(), *bytes, "wrong encoding for {chord:?}");
         }
+    }
+
+    /// The hazard `send_after` exists for, stated as the identity it is.
+    /// Nothing in an encoding can fix this — the two are the same bytes — so
+    /// the only remedy is to separate the writes in time.
+    #[test]
+    fn esc_then_a_key_is_byte_identical_to_an_alt_chord() {
+        let mut separate = Key::Esc.encode();
+        separate.extend(Key::Char('j').encode());
+        assert_eq!(separate, Key::Alt('j').encode());
+        assert_eq!(separate, b"\x1bj");
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1561,6 +1561,55 @@ impl Terminal {
         self.write_input(&key.encode_modal(application_cursor), &what)
     }
 
+    /// Wait `delay`, then send one key — so this write and the previous one
+    /// land in **separate reads**.
+    ///
+    /// The remedy for the [`Esc`](crate::Key::Esc) wire ambiguity when the
+    /// `Esc` has no observable effect to wait for. `Esc` followed
+    /// immediately by another key is byte-identical to an `Alt` chord, and
+    /// whether the application sees one chord or two presses depends on
+    /// whether its input loop happens to read both writes together. A
+    /// vim-style TUI where `Esc` leaves insert mode silently and `j` then
+    /// moves down cannot otherwise be driven at all:
+    ///
+    /// ```no_run
+    /// # use std::time::Duration;
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.send(termlens::Key::Esc)?;
+    /// // Two presses, not Alt+j — the delay is what makes it so.
+    /// t.send_after(Duration::from_millis(20), termlens::Key::Char('j'))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # This is a heuristic, and the delay is deliberately at the call site
+    ///
+    /// It works by making the application's *read* boundary fall between the
+    /// two writes, and nothing here can force that: an application that
+    /// polls slowly, or is descheduled at the wrong moment, can still merge
+    /// them. So the delay is a named argument rather than a hidden constant
+    /// — a test that only passes because of a sleep should say the sleep out
+    /// loud.
+    ///
+    /// For the same reason `send(Key::Esc)` does **not** carry a default
+    /// separation. Most suites send `Esc` where nothing follows it, and a
+    /// hidden sleep would slow every one of them for a hazard they do not
+    /// have — while making the tests that *do* depend on it work for a
+    /// reason invisible at the call site.
+    ///
+    /// `delay` is a plain sleep on the calling thread and is **not** bounded
+    /// by the terminal's deadline: it is time you asked to spend, not a wait
+    /// for something to happen.
+    ///
+    /// # Errors
+    ///
+    /// Same contract as [`send`](Self::send), evaluated after the delay.
+    pub fn send_after(&mut self, delay: Duration, key: impl Input + fmt::Debug) -> Result<()> {
+        thread::sleep(delay);
+        self.send(key)
+    }
+
     /// Send a string literally (UTF-8 bytes, no key mapping, no newline).
     ///
     /// # Errors

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -1,7 +1,7 @@
 //! Typed input beyond plain keys: mouse (mode-aware), modifier chords,
 //! bracketed paste, and cursor-key modes.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use termlens::{Error, Key, Scroll, Terminal};
 
@@ -528,5 +528,58 @@ fn typed_input_to_a_live_child_that_has_not_read_yet_succeeds() -> termlens::Res
     t.send_str("pending\n")?;
     t.wait_until(|s| s.contains("got:pending"))?;
     assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// `send_after` delays, then sends — and the delay is real, which is the
+/// whole mechanism: it exists to put this write and the previous one in
+/// separate reads.
+#[test]
+fn send_after_delays_then_delivers() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    let at = Instant::now();
+    t.send_after(Duration::from_millis(120), Key::Char('z'))?;
+    let waited = at.elapsed();
+    assert!(
+        waited >= Duration::from_millis(120),
+        "the delay must actually happen: {waited:?}"
+    );
+    t.wait_frame(|s| s.contains("input: z"))?;
+
+    t.send(Key::Esc)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The remedy, on the case it was written for. With nothing following in the
+/// same read, the `Esc` stands alone and is decoded as an `Esc` rather than
+/// half an `Alt` chord — form-echo quits on it, which makes that
+/// unmistakable. The follow-up key then has nowhere to go, and saying so is
+/// exactly what a separated write means for a fixture that exits on `Esc`.
+///
+/// The byte-level identity behind the hazard is pinned deterministically in
+/// `keys.rs`; the merge itself is a race, so nothing here asserts on it.
+#[test]
+fn a_separated_esc_is_decoded_as_an_esc() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    t.send(Key::Esc)?;
+    assert!(
+        t.wait_exit()?.success(),
+        "an Esc with nothing behind it is an Esc"
+    );
+
+    // And the key that would have merged with it now reports that it could
+    // not be delivered, rather than vanishing.
+    assert!(
+        matches!(
+            t.send_after(Duration::from_millis(10), Key::Char('j')),
+            Err(Error::Write { .. })
+        ),
+        "the follow-up key must not vanish silently"
+    );
     Ok(())
 }


### PR DESCRIPTION
Closes #108.

## The hazard, stated as what it is

```rust
let mut separate = Key::Esc.encode();
separate.extend(Key::Char('j').encode());
assert_eq!(separate, Key::Alt('j').encode());   // the same bytes
```

No encoding can fix this. The documented remedy since 0.2 — wait for the `Esc`'s effect before sending the next key — only works when the `Esc` *has* an effect. A vim-style TUI where `Esc` leaves insert mode silently and `j` then moves down could not be driven at all.

## `send_after(delay, key)`

Sleeps, then sends, so the two writes land in separate reads.

## The two decisions the issue asked to be made deliberately

**The delay is a named argument, not a hidden constant.** This is a heuristic: it works by making the application's *read boundary* fall between two writes, and nothing here can force that — a slow enough poll loop can still merge them. A test that passes only because of a sleep should say the sleep out loud.

**`send(Key::Esc)` carries no default separation.** Most suites send `Esc` with nothing behind it. A hidden sleep would slow all of them for a hazard they do not have, while making the tests that *do* depend on it work for a reason invisible at the call site. Friendlier, but the crate's posture everywhere else is that timing tricks are named — `wait_idle` is documented as a heuristic rather than hidden, and this is the same call.

Also documented: the delay is **not** bounded by the terminal's deadline. It is time the caller asked to spend, not a wait for something to happen.

## Writing the test taught me something about the crate's own new behaviour

The obvious test — `send(Esc)` then `send_after(150ms, Char('j'))` — **fails**:

```
Error: Write { what: "Char('j') to `…/form-echo` (the child released the terminal (EOF), so nothing can read this)" }
```

Because a separated `Esc` makes form-echo quit, and the follow-up write then correctly reports `Error::Write` — the behaviour #105 added earlier in this milestone. That error *is* the proof, not a problem. So the test waits for the exit first (deterministic) and then asserts the follow-up key reports it could not be delivered rather than vanishing.

**Nothing asserts on the merge itself.** That is a race — the study measured it at roughly 1 run in 5 — and a test of it would be flaky by construction, which the stress gate would rightly reject. The byte-level identity is pinned deterministically instead, which is the actual invariant.

## Tests

- `esc_then_a_key_is_byte_identical_to_an_alt_chord` — the hazard, deterministic
- `send_after_delays_then_delivers` — the delay is real (measured) and the key arrives
- `a_separated_esc_is_decoded_as_an_esc` — the remedy, plus the follow-up key reporting rather than vanishing

## Checklist

- [x] Linked an issue — closes #108
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none