### PR TITLE
feat(terminal): record per-frame cost so a suite can hold a performance line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,11 +100,23 @@ listed under a **Changed** or **Removed** heading.
 ### Added
 
 - **`Screen::repaints`** — how many synchronized updates the application has
-  completed, as of this observation. It counts *repaints, not changes*, so a
+  completed, as of this observation, on every snapshot **including the frames
+  `wait_frame` returns**. It counts *repaints, not changes*, so a
   Begin/End pair that drew nothing still counts, which is exactly the
   property an amplification test needs: "one wheel notch produced four
   repaints" is invisible to every content predicate, because each
   intermediate frame shows correct content.
+- **`Terminal::frame_timings` and `FrameTiming`** — per-repaint wall-clock cost
+  and printable-character count, so a suite can hold a performance line as well
+  as a correctness one. A TUI's most common regression is not wrong output; it
+  is a repaint that got slower or larger, and no content predicate sees either.
+  Both ends of the span are stamped at the byte carrying the marker, not when
+  the read arrived, so a burst delivered in one read is still timed per frame.
+  The docs state what the span includes rather than leaving it to be assumed:
+  it is measured through a PTY and covers the application's write pacing, so it
+  is a trend to watch and not a render benchmark. Bounded at 512 repaints,
+  independently of the eight frames `wait_frame` retains, since a timing is
+  three words where a frame is a whole grid.
 - **`Screen::bells`** — how many times the application rang `BEL`. The bell
   is often the only feedback a rejected input produces, so "an invalid key
   does nothing" and "an invalid key is refused with a bell" used to be the

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -17,12 +17,20 @@ pub(crate) use self::vt100::Vt100Emulator;
 use crate::screen::MouseMode;
 use crate::Screen;
 
+/// What one completed repaint cost, measured between the application's own
+/// markers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FrameSpan {
+    pub(crate) duration: std::time::Duration,
+    pub(crate) printable: u32,
+}
+
 /// Why the emulator stopped consuming mid-segment.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Stop {
     /// A synchronized update ended (DEC 2026 ESU): the screen at this
-    /// instant is a complete frame.
-    FrameComplete,
+    /// instant is a complete frame, and the span is what it cost.
+    FrameComplete(FrameSpan),
     /// The application asked the terminal a question; the screen state
     /// (cursor, size) is exactly as of the query.
     Query(Query),

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -245,6 +245,10 @@ pub(crate) struct SeqTracker {
     bells: u64,
     /// Inline graphics payloads transmitted.
     graphics: GraphicsSeen,
+    /// Printable characters written since the current frame began. Reset by
+    /// the Begin, read by the End — so it measures what one repaint drew,
+    /// which is the other half of "did this repaint get more expensive?".
+    frame_printable: u32,
     /// True while the application has focus reporting (mode 1004) enabled.
     /// Tracked here because vt100 does not model 1004 at all — the same
     /// reason the window title is tracked here.
@@ -297,6 +301,7 @@ impl SeqTracker {
             clipboard: None,
             bells: 0,
             graphics: GraphicsSeen::default(),
+            frame_printable: 0,
             focus_events: false,
             dcs_introducer: 0,
             dcs_final: 0,
@@ -348,6 +353,12 @@ impl SeqTracker {
     /// True while the application has focus reporting (mode 1004) enabled.
     pub(crate) fn focus_events(&self) -> bool {
         self.focus_events
+    }
+
+    /// Printable characters written since the current frame began, cleared
+    /// for the next one.
+    pub(crate) fn take_frame_printable(&mut self) -> u32 {
+        std::mem::replace(&mut self.frame_printable, 0)
     }
 
     fn reset_dcs_scanner(&mut self, introducer: u8) {
@@ -471,6 +482,7 @@ impl SeqTracker {
             match b {
                 b'h' => {
                     self.sync_update = true;
+                    self.frame_printable = 0;
                     return SeqEvent::SyncBegin;
                 }
                 // Only an End that closes a Begin we saw ends a frame.
@@ -715,6 +727,13 @@ impl SeqTracker {
                     // and both of those are other states.
                     if b == BEL && self.utf8_remaining == 0 {
                         self.bells = self.bells.saturating_add(1);
+                    }
+                    // One per *character*: continuation bytes arrive while
+                    // `utf8_remaining` is non-zero, so nothing is counted
+                    // twice. Controls, the BEL just handled included, are not
+                    // printable.
+                    if self.utf8_remaining == 0 && b >= 0x20 && b != 0x7f {
+                        self.frame_printable = self.frame_printable.saturating_add(1);
                     }
                     self.track_utf8(b);
                     State::Ground

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -3,10 +3,11 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use super::seq::{SeqEvent, SeqTracker};
 use super::shadow::AttrShadow;
-use super::{Emulator, InputModes, ModeState, MouseEncoding, Processed, Stop};
+use super::{Emulator, FrameSpan, InputModes, ModeState, MouseEncoding, Processed, Stop};
 use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
 
 pub(crate) struct Vt100Emulator {
@@ -18,6 +19,9 @@ pub(crate) struct Vt100Emulator {
     shadow: AttrShadow,
     /// How many rows of history to retain (0 disables it entirely).
     scrollback_len: usize,
+    /// When the current synchronized update began, stamped at the byte that
+    /// opened it. `None` outside a frame.
+    frame_started: Option<Instant>,
     /// Rows that have scrolled off the top, oldest first, as text.
     ///
     /// Materialized here — once per read that scrolled — rather than in
@@ -31,12 +35,27 @@ pub(crate) struct Vt100Emulator {
 }
 
 impl Vt100Emulator {
+    /// Close out the frame that just ended: how long it ran between the
+    /// application's own markers, and how much it drew.
+    fn close_frame(&mut self) -> FrameSpan {
+        let started = self.frame_started.take();
+        debug_assert!(
+            started.is_some(),
+            "a frame only ends where a Begin was seen, so the start must exist"
+        );
+        FrameSpan {
+            duration: started.map_or(Duration::ZERO, |at| at.elapsed()),
+            printable: self.tracker.take_frame_printable(),
+        }
+    }
+
     pub(crate) fn new(rows: u16, cols: u16, scrollback_len: usize) -> Self {
         Self {
             parser: ::vt100::Parser::new(rows, cols, scrollback_len),
             tracker: SeqTracker::new(),
             shadow: AttrShadow::new(rows, cols),
             scrollback_len,
+            frame_started: None,
             history: VecDeque::new(),
             captured: 0,
         }
@@ -116,9 +135,17 @@ impl Emulator for Vt100Emulator {
     fn process(&mut self, bytes: &[u8]) -> Processed {
         for (i, &byte) in bytes.iter().enumerate() {
             let stop = match self.tracker.step(byte) {
-                SeqEvent::SyncEnd => Some(Stop::FrameComplete),
+                SeqEvent::SyncEnd => Some(Stop::FrameComplete(self.close_frame())),
                 SeqEvent::Query(query) => Some(Stop::Query(query)),
-                SeqEvent::None | SeqEvent::SyncBegin => None,
+                SeqEvent::None => None,
+                SeqEvent::SyncBegin => {
+                    // Stamped here, at the byte that opened the update,
+                    // rather than when the read arrived: a read can carry a
+                    // whole burst, and stamping per chunk would fold PTY
+                    // scheduling into the measurement.
+                    self.frame_started = Some(Instant::now());
+                    None
+                }
             };
             if let Some(stop) = stop {
                 self.parser.process(&bytes[..=i]);
@@ -466,7 +493,11 @@ mod tests {
         let stream = b"\x1b[?2026hframe1\x1b[?2026lnext";
 
         let first = emu.process(stream);
-        assert_eq!(first.stop, Some(Stop::FrameComplete));
+        assert!(
+            matches!(first.stop, Some(Stop::FrameComplete(_))),
+            "stop: {:?}",
+            first.stop
+        );
         // Everything through the ESU is consumed; "next" is not.
         assert_eq!(
             &stream[..first.consumed],

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -85,7 +85,7 @@ pub use screen::{Cell, Clipboard, Color, GraphicsSeen, MouseMode, Screen, Style}
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{
-    ExitStatus, Graphics, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder,
+    ExitStatus, FrameTiming, Graphics, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder,
 };
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -47,6 +47,66 @@ const MAX_UNANSWERED: usize = 8;
 /// 0.6 MB and 3.8 MB respectively.
 const FRAME_HISTORY: usize = 8;
 
+/// How many per-frame timings a terminal keeps.
+///
+/// Deliberately larger than [`FRAME_HISTORY`], and bounded on its own terms:
+/// a frame is a whole grid snapshot, while a timing is three words, so there
+/// is no reason to forget a repaint's cost as soon as its content ages out. A
+/// suite holding a p99 line wants a run's worth, not the last eight.
+const FRAME_TIMING_HISTORY: usize = 512;
+
+/// What one completed repaint cost.
+///
+/// Read the series with [`Terminal::frame_timings`].
+///
+/// # What the span does and does not include
+///
+/// The duration is the wall-clock time between the application's **own
+/// markers** — its `BeginSynchronizedUpdate` and `EndSynchronizedUpdate` —
+/// observed through a PTY. Both ends are stamped at the byte that carried the
+/// marker, not when the read arrived, so a burst delivered in one read is
+/// still measured per frame.
+///
+/// That means it includes the application's write pacing, not just its render
+/// cost: a program that computes a frame quickly and then dribbles it out in
+/// small writes measures slow, correctly, because that is what a terminal on
+/// the other end experiences. It is not a render benchmark, and treating it as
+/// one will mislead you. What it is good for is a *trend*: the same
+/// application, the same fixture, a p99 that grew.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameTiming {
+    index: u64,
+    duration: Duration,
+    printable: u32,
+}
+
+impl FrameTiming {
+    /// Which repaint this was, counting from 1 — the same numbering
+    /// [`Screen::repaints`](crate::Screen::repaints) reports.
+    #[must_use]
+    pub fn index(&self) -> u64 {
+        self.index
+    }
+
+    /// Wall-clock time between the application's Begin and End markers. See
+    /// the type docs for what that includes.
+    #[must_use]
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Printable characters the application wrote inside this repaint.
+    ///
+    /// The other half of a performance regression: a repaint can get slower,
+    /// or it can get *bigger*, and no content predicate sees either. Counted
+    /// per character rather than per byte, so a screen of CJK does not read as
+    /// three times the work.
+    #[must_use]
+    pub fn printable_chars(&self) -> u32 {
+        self.printable
+    }
+}
+
 /// Rows of scrolled-off history a terminal retains by default.
 ///
 /// On by default because the alternative is a whole class of application
@@ -444,6 +504,8 @@ struct EmuState {
     /// what lets a waiter ask for frames *newer than the last one it was
     /// given* rather than rescanning the whole ring forever.
     frames: VecDeque<(u64, Screen)>,
+    /// Per-frame cost, kept separately and for longer than `frames`.
+    timings: VecDeque<FrameTiming>,
     /// Whether to answer recognized terminal queries (builder-configured).
     respond: bool,
     /// Background color reported to OSC 11 queries.
@@ -508,6 +570,7 @@ impl EmuState {
             snapshot_cache: None,
             frames_seen: 0,
             frames: VecDeque::with_capacity(FRAME_HISTORY),
+            timings: VecDeque::new(),
             respond,
             background,
             foreground,
@@ -1490,13 +1553,30 @@ fn reader_loop(
                         let processed = state.emu.process(&buf[offset..n]);
                         offset += processed.consumed;
                         match processed.stop {
-                            Some(Stop::FrameComplete) => {
+                            Some(Stop::FrameComplete(span)) => {
                                 state.frames_seen += 1;
-                                let frame = state.emu.snapshot();
+                                // Through `build_snapshot`, so a retained
+                                // frame carries the repaint count like every
+                                // other snapshot. Taking it straight from the
+                                // emulator left `Screen::repaints()` at zero
+                                // on exactly the screens `wait_frame` hands
+                                // back — the ones most likely to be asked.
+                                let frame = state.build_snapshot();
                                 if state.frames.len() == FRAME_HISTORY {
                                     state.frames.pop_front();
                                 }
                                 state.frames.push_back((state.frames_seen, frame));
+                                // Timings outlive the frame ring: a
+                                // performance line is held over a run, not
+                                // over the last eight repaints.
+                                if state.timings.len() == FRAME_TIMING_HISTORY {
+                                    state.timings.pop_front();
+                                }
+                                state.timings.push_back(FrameTiming {
+                                    index: state.frames_seen,
+                                    duration: span.duration,
+                                    printable: span.printable,
+                                });
                             }
                             Some(Stop::Query(query)) => {
                                 if let Some(reply) = state.answer(&query) {
@@ -1635,6 +1715,39 @@ impl Terminal {
     #[must_use]
     pub fn screen(&self) -> Screen {
         self.shared.lock().snapshot()
+    }
+
+    /// Per-frame cost for every repaint this terminal has seen, oldest
+    /// first — the wall-clock span between the application's own
+    /// synchronized-update markers, and how much it drew inside them.
+    ///
+    /// This is what lets a suite hold a performance line as well as a
+    /// correctness one. A TUI's most common regression is not wrong output; it
+    /// is a repaint that got slower or larger, and no content predicate can
+    /// see either.
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.wait_frame(|s| s.contains("ready"))?;
+    /// let mut spans: Vec<_> = t.frame_timings().iter().map(|f| f.duration()).collect();
+    /// spans.sort_unstable();
+    /// let p99 = spans[spans.len() * 99 / 100];
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Read [`FrameTiming`] for what the span includes — it is measured
+    /// through a PTY and covers the application's write pacing, so it is a
+    /// trend to watch rather than a render benchmark.
+    ///
+    /// The series is bounded at the last **512** repaints, independently of
+    /// the eight frames [`wait_frame`](Self::wait_frame) retains: a timing is
+    /// three words where a frame is a whole grid, so there is no reason for a
+    /// cost to be forgotten as soon as its content ages out.
+    #[must_use]
+    pub fn frame_timings(&self) -> Vec<FrameTiming> {
+        self.shared.lock().timings.iter().copied().collect()
     }
 
     /// Send one key press or modifier [`Chord`](crate::Chord). See

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -4,7 +4,7 @@
 
 use std::time::{Duration, Instant};
 
-use termlens::{Error, Key, Terminal};
+use termlens::{Error, FrameTiming, Key, Terminal};
 
 mod common;
 use common as util;
@@ -509,4 +509,107 @@ fn a_wait_idle_timeout_names_an_unfinished_frame() {
         msg.contains("half-painted frame"),
         "and what the embedded screen is: {msg}"
     );
+}
+
+/// A repaint that got slower, or bigger, is the most common TUI regression
+/// and no content predicate sees either. form-echo's F2 draw sleeps 150ms
+/// *inside* one synchronized update, so it is the outlier the series has to
+/// show.
+#[test]
+fn the_timing_series_shows_a_deliberately_slow_repaint() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    // A few ordinary repaints first, to have something to be an outlier
+    // against.
+    for c in ['a', 'b', 'c'] {
+        t.send(Key::Char(c))?;
+        t.wait_frame(|s| s.contains(&format!("input: {}", "abc".split(c).next().unwrap_or(""))))?;
+    }
+    let quick = t.frame_timings();
+    assert!(quick.len() >= 4, "one per repaint so far: {}", quick.len());
+    let slowest_quick = quick.iter().map(|f| f.duration()).max().unwrap();
+
+    t.send(Key::F(2))?;
+    let torn = t.wait_frame(|s| s.contains("torn: left") && s.contains("right"))?;
+    assert!(torn.contains("torn: left right"), "{torn}");
+
+    let all = t.frame_timings();
+    let slow = all.last().expect("the torn frame");
+    assert_eq!(
+        slow.index(),
+        torn.repaints(),
+        "the series and the frame count agree on which repaint this was"
+    );
+    assert!(
+        slow.duration() >= Duration::from_millis(150),
+        "the deliberate 150ms sleep must be inside the span: {:?}",
+        slow.duration()
+    );
+    assert!(
+        slow.duration() > slowest_quick * 5,
+        "and it must stand out: {:?} vs {slowest_quick:?}",
+        slow.duration()
+    );
+
+    // The size half of the same question: every repaint drew something, and
+    // the count is per character.
+    assert!(
+        all.iter().all(|f| f.printable_chars() > 0),
+        "each repaint drew something: {:?}",
+        all.iter()
+            .map(FrameTiming::printable_chars)
+            .collect::<Vec<_>>()
+    );
+    // "torn: left" + " right" = 16 printable characters, and nothing else in
+    // that update is printable.
+    assert_eq!(slow.printable_chars(), 16, "{slow:?}");
+
+    t.send(Key::Esc)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Timings are per frame even when a burst arrives in one read — the markers
+/// are stamped at the byte that carried them, not when the read landed.
+#[test]
+fn a_burst_in_one_read_is_timed_per_frame() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(40, 6)
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"printf READY; read a; ",
+                // Three frames in a single write, so they arrive as one read.
+                r"printf '\033[?2026hone\033[?2026l\033[?2026htwotwo\033[?2026l\033[?2026hthree!\033[?2026l'; ",
+                r"printf ' DONE'; read b"
+            ),
+        ])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("READY"))?;
+    assert!(t.frame_timings().is_empty(), "nothing has repainted yet");
+
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("DONE"))?;
+
+    let timings = t.frame_timings();
+    assert_eq!(timings.len(), 3, "three frames, three timings: {timings:?}");
+    assert_eq!(
+        timings.iter().map(FrameTiming::index).collect::<Vec<_>>(),
+        vec![1, 2, 3],
+        "numbered in emission order"
+    );
+    // Each frame is credited with what *it* drew, not the whole read.
+    assert_eq!(
+        timings
+            .iter()
+            .map(FrameTiming::printable_chars)
+            .collect::<Vec<_>>(),
+        vec![3, 6, 6],
+        "one/twotwo/three! — per frame, not per read"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
 }

--- a/crates/termlens/tests/observe.rs
+++ b/crates/termlens/tests/observe.rs
@@ -172,3 +172,31 @@ fn a_kitty_transmission_does_not_pollute_the_timeout() -> termlens::Result<()> {
     t.send(Key::Enter)?;
     Ok(())
 }
+
+/// The frame `wait_frame` returns must carry the repaint count too — it is
+/// the screen a test is most likely to ask, since asserting on the returned
+/// frame rather than a later `screen()` is the documented idiom. Retained
+/// frames used to be built straight from the emulator, which skipped the
+/// count and left it at zero.
+#[test]
+fn a_frame_from_wait_frame_carries_the_repaint_count() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf READY; read a; ",
+        r"printf '\033[?2026hone\033[?2026l'; ",
+        r"printf '\033[?2026htwo\033[?2026l'; ",
+        r"read b"
+    ))?;
+    t.wait_until(|s| s.contains("READY"))?;
+    t.send(Key::Enter)?;
+
+    let first = t.wait_frame(|s| s.contains("one"))?;
+    assert_eq!(first.repaints(), 1, "the first frame is repaint 1: {first}");
+    let second = t.wait_frame(|s| s.contains("two"))?;
+    assert_eq!(second.repaints(), 2, "and the second is 2: {second}");
+    // And the live grid agrees with the frame it last handed out.
+    assert_eq!(t.screen().repaints(), 2);
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -469,6 +469,19 @@ Rules:
    declining both protocols, which is why an application that transmits one
    anyway is worth catching.
 
+   Per-frame **cost** is the one observation that does not fit a snapshot: a
+   `Screen` is an instant, and a performance line is a series. So
+   `Terminal::frame_timings` keeps one `FrameTiming` per repaint — the span
+   between the application's own DEC 2026 markers, and the printable
+   characters written inside them — bounded at 512 and independently of the
+   eight frames `wait_frame` retains, because a timing is three words where a
+   frame is a whole grid. Both ends are stamped at the byte carrying the
+   marker rather than when the read arrived, so a burst delivered in one read
+   is still timed per frame. The span is measured through a PTY and therefore
+   includes the application's write pacing: it is a trend to watch, not a
+   render benchmark, and the rustdoc says so where someone would otherwise
+   assume otherwise.
+
    All of it lives behind one `Arc` on `Screen`. `Screen` is embedded in
    every `Error`, so its size is load-bearing: the counters alone pushed
    `Result<T>` past clippy's `result_large_err` threshold, and the `Arc`


### PR DESCRIPTION
Closes #98. **Last of the 17 in milestone v0.5.**

A TUI's most common regression is not wrong output; it is a repaint that got **slower** or **larger**, and no content predicate sees either.

`Terminal::frame_timings()` returns one `FrameTiming` per repaint: the wall-clock span between the application's own DEC 2026 markers, and the printable characters written inside them. Characters rather than bytes, so a screen of CJK does not read as three times the work.

## The issue named three things that decide whether the numbers mean anything

**Stamped at the byte, not the read.** `process` already walks bytes one at a time and the tracker reports the Begin at the exact byte, so the clock starts there rather than when a chunk arrived. `a_burst_in_one_read_is_timed_per_frame` puts three frames in a single write and asserts three timings with per-frame character counts of `3, 6, 6` — `one`/`twotwo`/`three!`, not one lump of 15.

**Stated honestly.** The rustdoc says the span is measured *through a PTY* between the application's own markers, so it includes the application's write pacing: a program that computes a frame fast and dribbles it out measures slow, correctly, because that is what a terminal on the other end experiences. It is a trend to watch, not a render benchmark — and someone would otherwise treat it as one.

**Retained separately.** 512 timings against the 8-frame ring: a timing is three words where a frame is a whole grid, so there is no reason for a cost to be forgotten as soon as its content ages out.

## No fixture change needed

form-echo's F2 draw already sleeps 150 ms *inside* one synchronized update — it exists to prove `wait_frame` never sees a tear. That makes it exactly the outlier the series has to show, and the test asserts it is both ≥150 ms and more than 5× the ordinary repaints around it.

## Writing that test found a bug from earlier in this milestone

`Screen::repaints()` read **0** on every frame `wait_frame` returns. Retained frames were built straight from the emulator (`state.emu.snapshot()`), bypassing the stamp that `build_snapshot` applies — so the counter was correct on `t.screen()` and wrong on precisely the screens a test is most likely to ask, since asserting on the *returned* frame rather than a later `screen()` is the documented idiom.

The doctest demonstrating that idiom was `no_run`, so it never executed and never caught it. Fixed, and pinned by `a_frame_from_wait_frame_carries_the_repaint_count`, which checks the returned frames report 1 and 2 and that the live grid agrees.

## Tests

- `the_timing_series_shows_a_deliberately_slow_repaint` — the 150 ms outlier, its index agreeing with `Screen::repaints()`, and the exact 16-character count
- `a_burst_in_one_read_is_timed_per_frame` — three frames in one write, timed and counted separately
- `a_frame_from_wait_frame_carries_the_repaint_count` — the regression above

## Checklist

- [x] Linked an issue — closes #98
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none