### PR TITLE
test: make two v0.5 tests measure the harness, not the machine

### DIFF
--- a/crates/termlens/tests/backpressure.rs
+++ b/crates/termlens/tests/backpressure.rs
@@ -11,12 +11,23 @@ use termlens::{Key, Terminal};
 
 /// Ask `n` cursor-position queries back to back, then read everything, and
 /// count the answers. Each DSR reply carries exactly one `R`.
+///
+/// The read *loops* rather than making one long `dd`. A single read ends at
+/// the first gap longer than its `VTIME`, and under a loaded runner the
+/// answers arrive in bursts with real gaps between them — so a one-shot read
+/// stops early and measures the machine instead of the harness. Stress found
+/// exactly that: 310 of 400 on a busy macOS runner, with nothing wrong on
+/// this side of the PTY.
 fn answered(n: usize) -> termlens::Result<usize> {
     let script = format!(
-        "stty -icanon -echo min 0 time 30; i=0; \
+        "stty -icanon -echo min 0 time 5; i=0; \
          while [ $i -lt {n} ]; do printf '\\033[6n'; i=$((i+1)); done; \
          printf ASKED; \
-         got=$(dd bs=1 count=100000 2>/dev/null | tr -cd 'R' | wc -c | tr -d ' '); \
+         got=0; tries=0; \
+         while [ $got -lt {n} ] && [ $tries -lt 40 ]; do \
+           chunk=$(dd bs=1 count=8192 2>/dev/null | tr -cd 'R' | wc -c | tr -d ' '); \
+           got=$((got+chunk)); tries=$((tries+1)); \
+         done; \
          printf ' GOT[%s] DONE' \"$got\"; read guard"
     );
     let mut t = Terminal::builder()

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -546,9 +546,14 @@ fn the_timing_series_shows_a_deliberately_slow_repaint() -> termlens::Result<()>
         "the deliberate 150ms sleep must be inside the span: {:?}",
         slow.duration()
     );
+    // Deliberately *not* "the slow frame is 5x the quick ones". Under a
+    // loaded runner an ordinary repaint can take tens of milliseconds, so a
+    // ratio is a claim about the machine rather than about the measurement.
+    // The 150ms floor above is the property that holds regardless, and it is
+    // the one the fixture actually creates.
     assert!(
-        slow.duration() > slowest_quick * 5,
-        "and it must stand out: {:?} vs {slowest_quick:?}",
+        slow.duration() > slowest_quick,
+        "the slowed repaint must still be the slowest: {:?} vs {slowest_quick:?}",
         slow.duration()
     );
 


### PR DESCRIPTION
The stress gate failed on **both** OSes at iterations 5 and 7. Both failures were mine, in tests added during v0.5, and neither indicated a library problem.

## macOS, iteration 5 — `a_batch_of_probes_is_answered_in_full`

```
assertion `left == right` failed: asked 400 probes back to back
  left: 310
 right: 400
```

The test read the replies with **one long `dd`**. A read ends at the first gap longer than its `VTIME`, and on a loaded runner the answers arrive in bursts with real gaps between them — so the read stopped early and reported 310. Nothing was lost on this side of the PTY; the *instrument* was measuring scheduling.

It now loops until it has the expected count or exhausts a bounded number of tries, so it measures delivery.

## Ubuntu, iteration 7 — `the_timing_series_shows_a_deliberately_slow_repaint`

The assertion was `slow.duration() > slowest_quick * 5`. Under load an ordinary repaint can take tens of milliseconds, which makes a **ratio a claim about the machine** rather than about the measurement.

The 150 ms floor is the property the fixture actually creates — it sleeps 150 ms inside one synchronized update — and it holds regardless. The ratio is now only "still the slowest", with a comment recording why the stronger form was wrong.

## Verification

25 release runs of both files at `--test-threads=8` — more contention than the stress workflow applies — with 0 failures. Full suite, clippy and fmt clean.

## Note

This is the same class of finding the stress gate produced in 0.4: not a library regression, but a test asserting something timing-dependent that passes locally and fails once in fifty under load. Both fixes narrow the claim to what the subject actually guarantees.

## Checklist

- [x] Linked an issue (or explained above why none exists) — found by the stress gate on merged main
- [x] Tests added/updated for the change — this *is* the test fix; verification above
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]` — n/a, not user-facing
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none