### PR TITLE
test(frames): compare a frame span with a tolerance, and say why

### DIFF
--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -73,6 +73,14 @@ const FRAME_TIMING_HISTORY: usize = 512;
 /// the other end experiences. It is not a render benchmark, and treating it as
 /// one will mislead you. What it is good for is a *trend*: the same
 /// application, the same fixture, a p99 that grew.
+///
+/// It is also, precisely, the span between **our observations** of the two
+/// markers rather than the application's own clock, and the two can differ by
+/// the read latency at either end. A repaint that slept 150ms inside its
+/// update has measured 149.72ms here — the opening bytes reached the reader a
+/// fraction late while the End still arrived 150ms after the application's
+/// flush. So compare spans with a tolerance; an exact expectation is a
+/// statement about scheduling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrameTiming {
     index: u64,

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -541,8 +541,14 @@ fn the_timing_series_shows_a_deliberately_slow_repaint() -> termlens::Result<()>
         torn.repaints(),
         "the series and the frame count agree on which repaint this was"
     );
+    // A tolerance, not a floor at exactly 150ms — and the reason is a real
+    // property of the measurement rather than slack for its own sake. Both
+    // ends are stamped when *we* consume the marker byte, so if the opening
+    // bytes reach the reader a fraction late while the End still arrives
+    // 150ms after the application's flush, the span measures marginally
+    // *under* the sleep. Stress caught it at 149.72ms — 276µs short.
     assert!(
-        slow.duration() >= Duration::from_millis(150),
+        slow.duration() >= Duration::from_millis(140),
         "the deliberate 150ms sleep must be inside the span: {:?}",
         slow.duration()
     );


### PR DESCRIPTION
Stress failed on ubuntu at iteration 19:

```
the deliberate 150ms sleep must be inside the span: 149.724866ms
```

**276 microseconds short** of the sleep the fixture performs inside its synchronized update.

## Not slack — a property of the measurement I under-stated

Both ends of a span are stamped when the **reader consumes the marker byte**. If the opening bytes arrive a fraction late while the End still lands 150 ms after the application's flush, the span measures marginally *under* the application's own sleep. Our clock and the application's clock are not the same clock, and the difference is the read latency at either end.

`FrameTiming`'s docs now say this, with the measured figure, and add the conclusion a reader actually needs: **compare spans with a tolerance**, because an exact expectation is a statement about scheduling rather than about the frame.

#98 asked for the measurement to be "stated honestly" — this is part of what honest means, and I only had half of it (write pacing) written down.

## The test

Now allows 140 ms, which still fails if the sleep were skipped entirely — the thing the assertion is actually for.

## Checklist

- [x] Linked an issue (or explained above why none exists) — found by the stress gate on merged main
- [x] Tests added/updated for the change — this *is* the test fix
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]` — n/a, docs on an unreleased API
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none