### PR TITLE
fix(queries): bound the reply queue by memory, not by queue slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,18 +23,22 @@ listed under a **Changed** or **Removed** heading.
   therefore an error on one CI runner and silently discarded on the other.
   Every sender now checks for a closed terminal before writing, so the
   answer is the same everywhere and no keystroke is lost quietly.
-- **A batch of startup probes is answered in full.** 200 queries asked back to
-  back returned 173 answers; 400 returned 235; 1000 returned 285. The stated
-  cause — the application had stopped reading — was wrong: the same 200
-  queries a millisecond apart were all answered, so nothing was blocked
-  anywhere. The reader was enqueueing one channel entry per *reply* while the
-  writer issued one `write(2)` per entry, and the queue filled because the
-  reader outran it. Replies from one read are now one entry, the writer
-  coalesces whatever is queued behind it into a single write, and 50, 200 and
-  400 are all answered completely. The remaining ceiling is the terminal's own
-  input queue rather than ours — around 4 KB on Linux, so a batch past roughly
-  680 replies still needs the application to read as it asks, which is true of
-  a real terminal too.
+- **A batch of startup probes is answered in full**, and the reply queue is
+  now bounded by **memory rather than by queue slots** — which took three
+  attempts to get right, each one teaching what the invariant actually is.
+  200 queries asked back to back returned 173 answers; 400 returned 235; 1000
+  returned 285. The stated cause — the application had stopped reading — was
+  wrong: the same 200 queries a millisecond apart were all answered, so
+  nothing was blocked anywhere. The reader was enqueueing one entry per
+  *reply* while the writer issued one `write(2)` per entry, so it outran the
+  writer and the 64-slot queue overflowed. Batching per *read* fixed that on a
+  fast machine — but on a slow one an application's writes dribble out, the
+  same 400 queries arrive in hundreds of small reads, and 64 slots ran out
+  again at 235 of 400. Slots were never the thing worth bounding: the queue is
+  now unbounded with a 1 MiB ceiling on undelivered reply *bytes*, so the
+  reader can never block, a real application is never shorted, and a hostile
+  one still cannot grow memory without limit. The writer coalesces whatever is
+  queued into a single write.
 - **Undelivered replies are counted whether dropped or blocked mid-write**, so
   a non-reading application is named in the wait error rather than producing a
   plain timeout.

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -129,19 +129,28 @@ impl FrameTiming {
 /// string rather than a grid of cells.
 const DEFAULT_SCROLLBACK: usize = 1000;
 
-/// Writes that may be queued for the writer thread before the drain starts
-/// discarding query replies.
+/// Reply bytes that may be waiting for the writer thread before the drain
+/// starts discarding query replies.
 ///
-/// The depth counts *reads*, not answers: the reader batches every reply from
-/// one read into a single entry, and the writer coalesces whatever is queued
-/// behind it into one `write(2)`. That matters because the original premise
-/// here — a full queue means the application stopped reading — was false. It
-/// filled because the reader could build answers faster than the writer could
-/// issue one syscall each, so a startup batch of 200 probes lost 27 answers
-/// with nothing blocked anywhere. With one entry per read, filling this really
-/// does take 64 reads' worth of undelivered answers, which no reading
-/// application produces.
-const REPLY_QUEUE_DEPTH: usize = 64;
+/// **Bytes, not entries**, and that distinction is the whole point. Two
+/// earlier versions of this bound counted queue slots, and both were the wrong
+/// invariant:
+///
+/// - One slot per *reply* filled at 64 answers, so a startup batch of 200
+///   probes lost 27 of them with nothing blocked anywhere — the reader simply
+///   built answers faster than the writer issued one `write(2)` each.
+/// - One slot per *read* fixed that on a fast machine, where a batch of
+///   queries arrives in a single read. On a slow one the application's writes
+///   dribble out, the same 400 queries arrive across hundreds of small reads,
+///   and 64 slots ran out again: 235 of 400 on a loaded macOS runner, twice,
+///   at the same number both times.
+///
+/// What actually needs bounding is memory, so that is what is bounded. A DSR
+/// reply is six bytes, so a mebibyte is on the order of a hundred thousand
+/// undelivered answers — past any real application, and still a hard ceiling
+/// against a hostile one. The queue itself is unbounded, so the reader can
+/// never block on it and the drain can never stall.
+const REPLY_QUEUE_BYTES: usize = 1 << 20;
 
 /// One write handed to the writer thread.
 ///
@@ -1207,6 +1216,9 @@ impl TerminalBuilder {
             .map_err(|e| Error::Pty(format!("taking PTY writer failed: {e}")))?;
 
         let replies_pending = Arc::new(AtomicUsize::new(0));
+        // Reply bytes waiting for the writer, so the drain can refuse on a
+        // memory bound instead of on a queue-slot count.
+        let queued_bytes = Arc::new(AtomicUsize::new(0));
         let shared = Arc::new(Monitor::new(EmuState::new(
             Box::new(Vt100Emulator::new(self.rows, self.cols, self.scrollback)),
             Responder {
@@ -1230,8 +1242,9 @@ impl TerminalBuilder {
         // deadline and no diagnosis.
         let write_tx = match dup_writer(pair.master.as_ref()) {
             Some(mut pty_writer) => {
-                let (tx, rx) = mpsc::sync_channel::<WriteRequest>(REPLY_QUEUE_DEPTH);
+                let (tx, rx) = mpsc::channel::<WriteRequest>();
                 let written = Arc::clone(&replies_pending);
+                let drained = Arc::clone(&queued_bytes);
                 thread::Builder::new()
                     .name("termlens-pty-writer".into())
                     .spawn(move || {
@@ -1249,6 +1262,7 @@ impl TerminalBuilder {
                                 acks.extend(next.ack);
                                 replies += next.replies;
                             }
+                            let queued = bytes.len();
                             let result = pty_writer
                                 .write_all(&bytes)
                                 .and_then(|()| pty_writer.flush());
@@ -1257,6 +1271,10 @@ impl TerminalBuilder {
                             // undelivered, and that is precisely what the
                             // next wait's error needs to be able to say.
                             written.fetch_sub(replies, Ordering::Relaxed);
+                            drained.fetch_sub(
+                                queued.min(drained.load(Ordering::Relaxed)),
+                                Ordering::Relaxed,
+                            );
                             let failed = result.is_err();
                             for ack in acks {
                                 // Every waiter in the batch learns the same
@@ -1285,6 +1303,7 @@ impl TerminalBuilder {
         let reader_writer = Arc::clone(&writer);
         let reader_tx = write_tx.clone();
         let reader_pending = Arc::clone(&replies_pending);
+        let reader_queued = Arc::clone(&queued_bytes);
         thread::Builder::new()
             .name("termlens-pty-reader".into())
             .spawn(move || {
@@ -1294,6 +1313,7 @@ impl TerminalBuilder {
                     &reader_writer,
                     reader_tx.as_ref(),
                     &reader_pending,
+                    &reader_queued,
                 )
             })
             .map_err(Error::Io)?;
@@ -1535,8 +1555,9 @@ fn reader_loop(
     mut reader: Box<dyn Read + Send>,
     shared: &Monitor<EmuState>,
     writer: &SharedWriter,
-    replies_to: Option<&mpsc::SyncSender<WriteRequest>>,
+    replies_to: Option<&mpsc::Sender<WriteRequest>>,
     pending: &AtomicUsize,
+    queued_bytes: &AtomicUsize,
 ) {
     let mut buf = [0u8; 8192];
     loop {
@@ -1618,18 +1639,28 @@ fn reader_loop(
                         // regardless, or the child blocks writing into a full
                         // output buffer and the harness deadlocks itself.
                         Some(tx) => {
-                            let request = WriteRequest {
-                                bytes: batch,
-                                ack: None, // fire and forget: never wait here
-                                replies: count,
-                            };
-                            // Counted as pending *before* the hand-off, so a
-                            // wait that fails while the write is blocked can
-                            // say how many answers are stuck.
-                            pending.fetch_add(count, Ordering::Relaxed);
-                            if let Err(mpsc::TrySendError::Full(_)) = tx.try_send(request) {
-                                pending.fetch_sub(count, Ordering::Relaxed);
+                            // Refuse only on the memory bound. The queue is
+                            // unbounded, so this hand-off cannot block and the
+                            // drain cannot stall — which is the constraint
+                            // that rules out backpressuring the reader.
+                            let size = batch.len();
+                            if queued_bytes.load(Ordering::Relaxed) + size > REPLY_QUEUE_BYTES {
                                 shared.mutate(|state| state.replies_dropped += count);
+                            } else {
+                                // Counted as pending *before* the hand-off, so
+                                // a wait that fails while the write is blocked
+                                // can say how many answers are stuck.
+                                pending.fetch_add(count, Ordering::Relaxed);
+                                queued_bytes.fetch_add(size, Ordering::Relaxed);
+                                let request = WriteRequest {
+                                    bytes: batch,
+                                    ack: None, // fire and forget: never wait
+                                    replies: count,
+                                };
+                                if tx.send(request).is_err() {
+                                    pending.fetch_sub(count, Ordering::Relaxed);
+                                    queued_bytes.fetch_sub(size, Ordering::Relaxed);
+                                }
                             }
                         }
                         // No responder thread (no descriptor to duplicate):
@@ -1668,7 +1699,7 @@ pub struct Terminal {
     writer: SharedWriter,
     /// Queue to the writer thread. `None` only when no descriptor could
     /// be duplicated, in which case writes go through `writer` directly.
-    write_tx: Option<mpsc::SyncSender<WriteRequest>>,
+    write_tx: Option<mpsc::Sender<WriteRequest>>,
     shared: Arc<Monitor<EmuState>>,
     default_timeout: Duration,
     exit_status: Option<ExitStatus>,
@@ -2204,25 +2235,12 @@ impl Terminal {
             // Typed input, not a reply: it reports through `ack`.
             replies: 0,
         };
-        // A full queue means the writer thread is already stuck on an
-        // earlier write, which is the same diagnosis. (`send_timeout` is
-        // still unstable, so this is a bounded retry on `try_send`.)
-        let deadline = Instant::now() + self.default_timeout;
-        let mut pending = request;
-        loop {
-            match tx.try_send(pending) {
-                Ok(()) => break,
-                Err(mpsc::TrySendError::Full(returned)) => {
-                    if Instant::now() >= deadline {
-                        return Err(not_reading());
-                    }
-                    pending = returned;
-                    thread::sleep(Duration::from_millis(1));
-                }
-                Err(mpsc::TrySendError::Disconnected(_)) => {
-                    return Err("the terminal is closed".to_owned())
-                }
-            }
+        // The queue is unbounded, so handing off cannot block and there is
+        // no full-queue case to retry. The deadline that matters is the
+        // acknowledgement below: it is the write itself that can stall, when
+        // the application has stopped reading and the PTY buffer is full.
+        if tx.send(request).is_err() {
+            return Err("the terminal is closed".to_owned());
         }
         match ack_rx.recv_timeout(self.default_timeout) {
             Ok(Ok(())) => Ok(()),

--- a/crates/termlens/tests/backpressure.rs
+++ b/crates/termlens/tests/backpressure.rs
@@ -64,6 +64,10 @@ fn a_batch_of_probes_is_answered_in_full() -> termlens::Result<()> {
     // 200 and 400 are the sizes the issue measured losses at (94 and 161
     // answered).
     //
+    // 400 is also the size that failed on a loaded macOS runner at 235
+    // answered, twice, while the queue was bounded by slots rather than
+    // bytes — see `fine_grained_arrival_is_answered_in_full` for why.
+    //
     // The ceiling here is the terminal's own input queue, not ours: 400 DSR
     // replies are ~2.4 KB, inside Linux's 4 KB `N_TTY_BUF_SIZE`, while 1000
     // would be ~6 KB and could not be delivered before the application read
@@ -71,6 +75,46 @@ fn a_batch_of_probes_is_answered_in_full() -> termlens::Result<()> {
     // lost while the answers still fit, which is the bug.
     for n in [50usize, 200, 400] {
         assert_eq!(answered(n)?, n, "asked {n} probes back to back");
+    }
+    Ok(())
+}
+
+/// The shape that defeated a slot-counted queue: queries arriving across
+/// *many small reads* instead of one.
+///
+/// Batching per read fixed the original loss on a fast machine, where a
+/// startup batch lands in a single read. On a slow one the application's
+/// writes dribble out, the same 400 queries arrive in hundreds of reads, and
+/// 64 slots ran out again — 235 of 400 on a loaded macOS runner, at the same
+/// number twice. A fork per query reproduces that arrival shape on purpose.
+#[test]
+fn fine_grained_arrival_is_answered_in_full() -> termlens::Result<()> {
+    for n in [100usize, 400] {
+        // `$(true)` forks per iteration, so each query is written separately
+        // and the reader sees it in its own read.
+        let script = format!(
+            "stty -icanon -echo min 0 time 100; i=0; \
+             while [ $i -lt {n} ]; do x=$(true); printf '\\033[6n'; i=$((i+1)); done; \
+             printf ASKED; \
+             got=$(dd bs=1 count=$(({n} * 6)) 2>/dev/null | tr -cd 'R' | wc -c | tr -d ' '); \
+             printf ' GOT[%s] DONE' \"$got\"; read guard"
+        );
+        let mut t = Terminal::builder()
+            .size(80, 6)
+            .timeout(Duration::from_secs(40))
+            .args(["-c", &script])
+            .spawn("/bin/sh")?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let text = t.screen().text();
+        let got: usize = text
+            .split("GOT[")
+            .nth(1)
+            .and_then(|s| s.split(']').next())
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(usize::MAX);
+        assert_eq!(got, n, "one read per query must not lose answers");
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
     }
     Ok(())
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -133,22 +133,35 @@ input; the drain would stop, the child would then block writing into a
 full output buffer, and the harness would deadlock itself with no test
 input involved.
 
-**One queue entry per read, not per reply**, and the writer coalesces
-whatever is queued behind the entry it took into a single `write(2)`. This
-is not an optimization; it is the fix for a correctness bug. The queue was
-filling for a reason that had nothing to do with the application: the reader
-could build answers faster than the writer could issue one syscall each, so
-a startup batch of 200 probes lost 27 answers with nothing blocked anywhere
-— confirmed by spacing the same queries a millisecond apart, which answered
-all 200. The comment in the source claiming a full queue meant the
-application had stopped reading was simply false.
+**The queue is unbounded, capped on undelivered reply *bytes*, and the writer
+coalesces everything queued into one `write(2)`.** That shape is the third
+attempt, and the two it replaced are worth recording, because each was a
+plausible invariant that turned out to be the wrong one.
 
-With one entry per read, filling the queue really does take 64 reads' worth
-of undelivered answers, which no reading application produces. That makes a
-discard rare and moves the diagnosis: an application that genuinely never
-reads leaves its answers *stuck in a blocked write* rather than dropped, so
-both are counted — a lock-free pending count the writer clears only once
-bytes are actually out — and the next wait's error names the total.
+One slot per *reply* filled at 64 answers. A startup batch of 200 probes lost
+27 with nothing blocked anywhere — confirmed by spacing the same queries a
+millisecond apart, which answered all 200. So the source comment claiming a
+full queue meant the application had stopped reading was simply false; the
+reader was outrunning our own writer.
+
+One slot per *read* fixed that on a fast machine, where a batch arrives in a
+single read. On a slow one the application's writes dribble out, the same 400
+queries arrive in hundreds of reads, and 64 slots ran out again — 235 of 400
+on a loaded macOS runner, at the same number twice, which is what a fixed
+ceiling looks like rather than a race.
+
+Slots were never the thing worth bounding. What must be bounded is memory, so
+that is what is: an unbounded channel with a 1 MiB ceiling on queued reply
+bytes. The reader therefore can never block on the hand-off — which is the
+constraint that rules out backpressuring it at all, since a blocked reader
+stops the drain and deadlocks the harness — a real application is never
+shorted, and a hostile one still cannot grow memory without limit.
+
+A discard is now rare, which moves the diagnosis: an application that
+genuinely never reads leaves its answers *stuck in a blocked write* rather
+than dropped, so both are counted — a lock-free pending count the writer
+clears only once bytes are actually out — and the next wait's error names the
+total.
 
 **How much of that is knowable differs by platform, and the honest answer is
 that Linux hides it.** A write into a full terminal input queue blocks on


### PR DESCRIPTION
Stress failed on macOS **twice at 235 of 400** — the same number both times, which is what a fixed ceiling looks like rather than a race. Neither of my earlier bounds was the right invariant.

## Three attempts, and what each one taught

| bound | held until | failure |
|---|---|---|
| one slot per **reply** | 64 answers | 173 of 200 asked back to back, nothing blocked anywhere |
| one slot per **read** | 64 reads | fine on a fast machine; **235 of 400** on a loaded macOS runner, twice |
| **1 MiB of undelivered reply bytes** | — | none found |

The second bound is the interesting failure. Batching per read is right when a startup batch arrives in one read, which is what a fast machine does. On a slow one the application's writes dribble out, the same 400 queries arrive in *hundreds* of small reads, one queue entry each — and 64 slots ran out again.

**Slots were never the thing worth bounding.** Memory is, so that is what is bounded now: an unbounded channel with a 1 MiB ceiling on queued reply bytes. A DSR reply is six bytes, so that is on the order of a hundred thousand pending answers — past any real application, and still a hard limit against a hostile one.

The reader therefore **can never block on the hand-off**, which is the constraint that rules out backpressuring it at all: a blocked reader stops the drain, the child then blocks writing into a full output buffer, and the harness deadlocks itself.

## A simplification that falls out

With an unbounded queue there is no full-queue case for typed input to retry, so the bounded `try_send` loop is gone. The deadline that mattered was always the **acknowledgement** — it is the write itself that stalls when the application stops reading, not the hand-off.

## Tests

`fine_grained_arrival_is_answered_in_full` pins the arrival shape that defeated the slot count: `$(true)` forks per query so each one lands in its own read. 100 and 400 both answered in full.

Verified with 30 runs of the reply tests under four concurrent copies of the release suite: 0 failures. Full suite, fmt, clippy clean.

## Where this leaves the diagnosis

Unchanged and still correct: a discard is now rare, so an application that genuinely never reads leaves its answers *stuck in a blocked write* rather than dropped — both are counted, and the next wait's error names the total. `docs/DESIGN.md` §1 records all three bounds, because a plausible-but-wrong invariant is worth writing down.

## Checklist

- [x] Linked an issue (or explained above why none exists) — found by the stress gate on merged main; refines #107
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none