### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-20
+
+What the harness could not observe, could not reach, and quietly got wrong.
+
+Seventeen issues, every one verified against the published 0.4.2 before a
+line was written — four by reproductions that contradicted the report, and
+one of those by a reproduction that contradicted *me*. Three themes:
+behaviour a test could not see at all (repaints, bells, images, focus),
+applications that could not be driven down a path they probe for first, and
+accessors that answered confidently where they had nothing to say.
+
+Two API changes are breaking, both in the direction of honesty:
+`send`/`send_str`/`paste` return `Result`, and `ExitStatus::code` returns
+`Option`.
+
 ### Changed
 
 - **`send`, `send_str` and `paste` return `Result<()>`** and no longer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "crossterm",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "crossterm",
 ]
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "crossterm",
 ]
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -588,7 +588,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.4.2"
+version = "0.5.0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.4.2" }
+termlens = { path = "crates/termlens", version = "0.5.0" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
Cuts **0.5.0** — milestone v0.5, all 17 issues closed.

- `workspace.package.version` → `0.5.0` (lockfile refreshed by `cargo check`)
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.0] - 2026-08-20`, fresh empty `[Unreleased]`
- `extract-changelog.sh v0.5.0` verified locally — 221 lines, the section only

Rebased onto #136 (the documentation audit), which had to land first: the README still described 0.4, and its headline example dropped the `Result` that `send` now returns.

## Why a minor bump

Two breaking changes, both in the direction of honesty:

- `send` / `send_str` / `paste` return `Result<()>` (#105)
- `ExitStatus::code` returns `Option<u32>` (#110)

Plus `Screen::rect_text` panics on a backwards range instead of returning `""` (#109), and `spawn`/`resize` refuse more than 1000 per axis (#106). Pre-1.0, minor versions may break; the CHANGELOG lists all of it under **Changed**.

## Gates

- Full suite: **256 tests**, green
- Stress ×100 on **both** OSes: green — [run 32313743333](https://github.com/vyncint/termlens/actions/runs/32313743333)
- 8 debug + 8 release full-suite loops locally, 0 failures
- Adversarial pass over every new surface from *outside* the crate, 6/6

The stress gate earned its keep four times during this milestone: two load-dependent test assertions, one measurement-latency assumption I had under-stated in the docs, and one real reply-queue ceiling that two earlier fixes had both missed. Each is recorded in its own commit.

## Checklist

- [x] Linked an issue (or explained above why none exists) — release chore for milestone v0.5
- [x] Tests added/updated for the change — none needed; the suite is green on the merged base
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated — this PR is the release section move
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none