### PR TITLE
docs: bring the documentation set up to 0.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     id: version
     attributes:
       label: termlens version
-      placeholder: "0.4.2 (or git SHA)"
+      placeholder: "0.5.0 (or git SHA)"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,19 @@ listed under a **Changed** or **Removed** heading.
 
 ### Documented
 
+- **The README, crate docs and design notes describe 0.5.** The README's
+  headline example now propagates the `Result` that `send` returns — it is the
+  first code anyone copies — its limitations section drops `XTGETTCAP` (0.5
+  answers it) and gains the two bounds this release introduced: graphics are
+  observed and offered but never rendered, and a reply the terminal's own
+  input queue cannot hold may not arrive, undetectably so on Linux. The
+  docs.rs landing page and `docs/DESIGN.md` §6 gained the observability
+  counters, focus events, per-cell drag motion and `send_after`.
+- **`SECURITY.md`'s resource bounds match the code again.** The reply queue is
+  a 1 MiB byte cap rather than "a fixed depth", and the note now says why a
+  depth bounds the wrong thing: two earlier versions counted slots and both
+  shorted a well-behaved application, while a byte bound leaves the queue
+  unbounded so the drain can never block on it.
 - **What a large grid costs**, on `TerminalBuilder::size`: a snapshot holds
   one entry per cell and is rebuilt on every state change, so the cost is
   O(cells) and shape-independent, while repeat reads of an unchanged screen

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fn quits_from_the_main_screen() -> termlens::Result<()> {
     insta::assert_snapshot!(t.screen());   // snapshot the rendered grid
     // …or t.screen().with_styles() to catch style-only regressions too
 
-    t.send(Key::Char('q'));
+    t.send(Key::Char('q'))?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }
@@ -61,10 +61,10 @@ flowchart TB
   test["your test<br/>drive · wait · assert"]
   subgraph proc["your test process · cargo test"]
     subgraph tt["termlens"]
-      api["Terminal<br/>send · click · drag · paste · signal · resize · wait_until / wait_frame / wait_idle / wait_exit"]
+      api["Terminal<br/>send · click · drag · paste · focus · signal · resize · wait_until / wait_frame / wait_idle / wait_exit"]
       reader["reader thread<br/>drains continuously — output is never lost between waits"]
       emu["VT emulator<br/>vt100 behind a small internal trait, swappable"]
-      screen["Screen<br/>immutable grid snapshots · cells · cursor · styles"]
+      screen["Screen<br/>immutable grid snapshots · cells · cursor · styles · modes · repaints · bells · images"]
     end
   end
   subgraph kernel["kernel"]
@@ -88,20 +88,34 @@ flowchart TB
 The reader thread drains the PTY into the emulator *continuously* — the
 kernel buffer can't fill up and stall your app, and no output is lost
 between assertions. It also **answers the queries real terminals
-answer** (cursor position, device attributes, window size, background
-color), so capability-probing apps run instead of hanging — and anything
-left unanswered is named inside the next timeout error.
+answer** — cursor position, device attributes, window size, background
+colour, `DECRQM` mode probes, and terminfo capabilities via `XTGETTCAP` —
+so capability-probing apps run instead of hanging, and anything left
+unanswered is named inside the next timeout error. Every answer is
+truthful or absent: nothing is claimed that the emulator cannot render.
 
 Input is **mode-aware**: mouse clicks and scrolls, pastes, modifier
 chords, and cursor keys are encoded exactly as the application
 configured its terminal (SGR mouse, bracketed paste, DECCKM) — because
-the emulator knows which modes the app enabled. The same knowledge is
+the emulator knows which modes the app enabled. A `drag` reports one
+motion **per cell crossed**, so an application that paints along the path
+sees the path. The same knowledge is
 readable from every `Screen`: the window title, the alternate-screen
 flag, the input modes and the last `OSC 52` clipboard write are plain
 accessors, so "did the app enter the alt screen?" and "did it copy the
 right text?" are assertions, not inferences. Focus events go the other way:
 `focus_out()` reaches an application that enabled mode 1004, so the
 unfocused branch of a UI can be driven at all.
+
+**Behaviour that leaves the screen identical is still assertable.** A
+repaint that drew nothing, a bell on a rejected key, an inline image — none
+of these change a single cell, so no content predicate can see them. Every
+`Screen` carries the counters instead: `repaints()` (completed DEC 2026
+updates, so *one input became four repaints* is catchable), `bells()`, and
+`graphics()` for kitty and sixel payloads — where the assertion is as often
+the negative one, "this must render as text in every terminal and never go
+out as an image". `frame_timings()` adds the cost of each repaint, so a
+suite can hold a performance line as well as a correctness one.
 
 **Scrollback is retained** (1000 rows by default), so an application that
 hands finished output *back* to the terminal — a pager, a log view, a TUI
@@ -137,6 +151,12 @@ design. termlens's position:
   `blink`, `conceal` and `strikethrough` alongside the usual attributes, so
   a test asserting that a password field is masked fails against an
   application that prints the secret in clear — the two are identical text.
+- **Needles are matched by what the terminal draws, not by how it is
+  spelled.** `contains` and `find` fold both sides to NFC, so a needle typed
+  in an editor still finds text an application normalized the other way —
+  `caf\u{e9}` and `cafe\u{301}` render identically, and so does the failure
+  output, which made the mismatch a trap rather than a limitation. The grid
+  itself keeps exactly the codepoints the application sent.
 - **`wait_frame` gives exact frame boundaries** for apps that bracket
   repaints in DEC 2026 synchronized updates (crossterm's
   `BeginSynchronizedUpdate`/`EndSynchronizedUpdate`): the predicate only
@@ -164,7 +184,7 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.4)
+## Known limitations (v0.5)
 
 - Scrollback is **bounded** (1000 rows by default), **text only** — a
   scrolled-off row has no styles and no cell addressing — and is **not
@@ -174,10 +194,22 @@ design. termlens's position:
   synchronized updates, and only the last 8 completed frames are retained;
   everything else waits with `wait_until`, under the three rules in
   [docs/DESIGN.md](docs/DESIGN.md) §2.
-- Some questions stay deliberately unanswered — kitty's `CSI ? u`,
-  `XTGETTCAP`, DECRQSS, `OSC 52` *reads* — because a guessed reply is worse
-  than none. An application blocked on one is **named in the next timeout**
-  rather than left to hang unexplained.
+- Some questions stay deliberately unanswered — kitty's `CSI ? u`, DECRQSS,
+  DA3, `OSC 12`, `OSC 52` *reads*, and the non-pixel `CSI … t` reports —
+  because a guessed reply is worse than none. An application blocked on one
+  is **named in the next timeout** rather than left to hang unexplained.
+- **Graphics are observed, not rendered.** termlens counts kitty and sixel
+  payloads and can tell an application that either is available
+  (`graphics()`, `cell_size()`), but it draws no pixels: what a payload
+  *depicted* is not assertable. Both are opt-in, so by default an
+  application that probes is truthfully told there is no graphics support.
+- **A reply the terminal's own input queue cannot hold may not arrive.**
+  termlens no longer drops answers of its own accord, but the tty input
+  queue is small (~1 KB on macOS, ~4 KB on Linux), so an application that
+  asks thousands of questions without reading has to read as it asks — as
+  it would against a real terminal. On Linux the kernel discards silently,
+  so that loss is undetectable and goes unreported; macOS blocks instead,
+  where it is counted and named.
 - Unix only for now (Linux + macOS in CI). The PTY layer (`portable-pty`)
   supports ConPTY, so Windows is planned, not designed out.
 - A child that writes and exits within its first milliseconds can lose

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,10 +32,19 @@ can reach is bounded, and a hostile child can at worst waste its own test's
 time budget. The reader uses a fixed 8 KiB buffer; every wait is
 deadline-bounded; retained scrollback is capped at the configured length
 (1000 rows by default, `scrollback(0)` to disable) and held as text rather
-than cells; at most 8 completed frames are retained for `wait_frame`; a
-captured `OSC 52` payload is dropped past 64 KiB; queued query replies stop
-at a fixed depth; and the set of distinct unanswered queries kept for
-diagnostics is capped, with the remainder counted.
+than cells; at most 8 completed frames and 512 frame timings are retained; a
+captured `OSC 52` payload is dropped past 64 KiB; **undelivered query replies
+are capped at 1 MiB** and discarded past it, counted and named in the next
+wait's error; the capture of a DCS-class header is fixed at 128 bytes; and the
+set of distinct unanswered queries kept for diagnostics is capped, with the
+remainder counted.
+
+The reply cap is a byte bound rather than a queue depth on purpose: a depth
+bounds the wrong thing. Two earlier versions counted queue slots and both
+shorted a well-behaved application asking a legitimate batch of startup
+probes, while a byte bound leaves the queue itself unbounded — so the drain
+can never block on it, which is what keeps a hostile child from deadlocking
+the harness rather than merely slowing its own test.
 
 ## Supported versions
 

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -53,11 +53,30 @@
 //!
 //! Input is mode-aware: [mouse clicks](Terminal::click),
 //! [pastes](Terminal::paste), modifier [chords](Chord), and cursor keys
-//! are encoded exactly as the application configured its terminal. And
-//! the terminal's out-of-band state — the window title, the
+//! are encoded exactly as the application configured its terminal — and a
+//! [drag](Terminal::drag) reports one motion per cell crossed, so an
+//! application that acts along the path sees the path. [Focus
+//! events](Terminal::focus_out) go the other way, reaching an application
+//! that enabled mode 1004 so the unfocused branch of a UI can be driven at
+//! all. The terminal's out-of-band state — the window title, the
 //! alternate-screen flag, the input modes, the last `OSC 52`
 //! [clipboard](Screen::clipboard) write — is readable from every
 //! [`Screen`] as plain accessors.
+//!
+//! Behaviour that leaves the screen **identical** is assertable too, which
+//! no content predicate can manage: [`repaints`](Screen::repaints) counts
+//! completed frames (so "one input became four repaints" is catchable),
+//! [`bells`](Screen::bells) counts `BEL`, and
+//! [`graphics`](Screen::graphics) counts the inline images an application
+//! transmitted — often to assert that it transmitted *none*.
+//! [`frame_timings`](Terminal::frame_timings) adds what each repaint cost,
+//! so a suite can hold a performance line as well as a correctness one.
+//!
+//! Needles are matched by what the terminal draws rather than by how it is
+//! spelled: [`contains`](Screen::contains) and [`find`](Screen::find) fold
+//! both sides to NFC, so a needle typed in an editor finds text an
+//! application normalized the other way. The grid keeps exactly the
+//! codepoints the application sent.
 //!
 //! With the default `insta` feature, snapshot-test whole screens:
 //!

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -465,7 +465,8 @@ Rules:
    input modes (bracketed paste, application cursor, mouse tracking) are
    captured with every snapshot and read through plain accessors —
    `Screen::title`, `Screen::alternate_screen`, `Screen::bracketed_paste`,
-   `Screen::application_cursor`, `Screen::mouse_mode`. Keeping them out of
+   `Screen::application_cursor`, `Screen::mouse_mode`,
+   `Screen::focus_events`, `Screen::clipboard`. Keeping them out of
    the rendering means existing snapshot files stay valid, and state
    assertions read as ordinary predicates:
    `wait_until(|s| s.alternate_screen())`.
@@ -589,6 +590,21 @@ encoding the application enabled (`?9/?1000/?1002/?1003`, SGR `?1006`),
 `click`/`scroll` encode to match, and no tracking enabled is a typed
 error — never bytes the application would misparse as keys.
 
+A **drag reports one motion per cell crossed**, interpolated on a straight
+line and on both axes for a diagonal. A single report at the destination is
+invisible to an application that only asks where a gesture started and where
+it is now — which is why it went unnoticed — and wrong for every application
+that acts *along* the path: a drawing surface painting each crossed cell, a
+selection highlighting incrementally, a drag that must cross a pane edge to
+register. A real pointer's exact path is not reproducible and does not need
+to be; every intervening cell being reported is the property that matters.
+
+**Focus events** (`ESC [ I` / `ESC [ O`) follow the same mode-aware contract
+as the mouse: sent only when the application enabled mode 1004, refused with
+a typed error when it did not. Without a way to deliver one, the unfocused
+branch of a UI is not merely unasserted — it is unreachable, since no input
+exists that can enter it.
+
 `Key::encode` documents the xterm *default-mode* sequences (CSI arrows,
 SS3 F1–F4, CSI-tilde function keys, DEL for Backspace). `send` is
 mode-aware: cursor keys switch to their `ESC O _` application forms while
@@ -597,5 +613,14 @@ reports match the tracking mode/encoding the application enabled — the
 emulator knows every one of these modes, and the input path consults it,
 so the bytes always match what the application configured its "terminal"
 to send. The one thing no encoding can fix is the wire itself: `Esc`
-immediately followed by another key is byte-identical to an Alt chord;
-the documented idiom is to wait for the Esc's visible effect first.
+immediately followed by another key is byte-identical to an Alt chord.
+Where the `Esc` has a visible effect, waiting for it resolves the
+ambiguity. Where it has none — leaving a text field's insert mode often
+changes nothing — `send_after(delay, key)` puts the two writes in separate
+reads instead. The delay is a named argument rather than a hidden constant,
+and `send(Key::Esc)` carries no default separation: most suites send `Esc`
+with nothing behind it, and a hidden sleep would slow all of them for a
+hazard they do not have while making the tests that need it work for a
+reason invisible at the call site. It is a heuristic either way — it works
+by making the application's read boundary fall between two writes, and a
+slow enough poll loop can still merge them.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -4,7 +4,7 @@
 > the project as it stood on 2026-08-09 and is kept as the record of that
 > work, not as a description of termlens today. Since then the repository has
 > been made public, the crate has been published, and the API has grown
-> through 0.2, 0.3 and 0.4 — `CHANGELOG.md` says what each release changed,
+> through 0.2 to 0.5 — `CHANGELOG.md` says what each release changed,
 > and `README.md` plus `docs/DESIGN.md` describe the current design. The
 > go-public checklist in §3 has its outcome recorded beneath it.
 

--- a/docs/announce-r-rust.md
+++ b/docs/announce-r-rust.md
@@ -31,7 +31,7 @@ let mut t = Terminal::builder()
 t.wait_until(|screen| screen.contains("Ready"))?;
 insta::assert_snapshot!(t.screen()); // snapshot the rendered grid
 
-t.send(Key::Char('q'));
+t.send(Key::Char('q'))?;
 assert!(t.wait_exit()?.success());
 ```
 
@@ -40,7 +40,7 @@ it continuously through a vt100 emulator into an immutable screen grid;
 waits are all deadline-bounded, and a timeout error embeds the full
 screen dump — so a CI log alone shows what the app was displaying.
 
-Two things worth pointing at beyond the basics. If your app brackets its
+Three things worth pointing at beyond the basics. If your app brackets its
 repaints in DEC 2026 synchronized updates (crossterm's
 `BeginSynchronizedUpdate`), `wait_frame` evaluates predicates only on
 complete frames and hands back the one it matched — never a torn screen,
@@ -52,6 +52,12 @@ which is what stops a test asserting "the password field is masked" from
 passing against an app that printed the secret in clear — the two are
 identical text.
 
+And behaviour that leaves the screen *identical* is assertable, which no
+content predicate can manage: a repaint that drew nothing, a bell on a
+rejected key, an inline image. Every `Screen` carries the counters, so
+"one wheel notch became four repaints" is a test, and so is "this diagram
+must render as box art and never go out as a Kitty image".
+
 The part I'm proudest of is the flake story. CI runs the whole suite 100
 times on Linux **and** macOS before anything merges to the wait paths.
 That gate caught, among other things, a genuine macOS kernel race where
@@ -60,12 +66,14 @@ pty* because device numbers recycle instantly — termlens serializes pty
 lifecycle edges behind a process-wide lock so your parallel tests don't
 hit it.
 
-Honest limitations (v0.4): Unix only for now (portable-pty supports
+Honest limitations (v0.5): Unix only for now (portable-pty supports
 ConPTY, so Windows is planned); scrollback is retained but bounded, text
 only, and not reflowed on resize; `wait_frame` needs the app to opt into
-DEC 2026; and a few questions (kitty `CSI ? u`, `XTGETTCAP`, `OSC 52`
-*reads*) are deliberately left unanswered rather than guessed — an app
-blocked on one is named in the next timeout instead of hanging silently.
+DEC 2026; graphics are observed and offered but never rendered, so what an
+image *depicted* is not assertable; and a few questions (kitty `CSI ? u`,
+DECRQSS, `OSC 52` *reads*) are deliberately left unanswered rather than
+guessed — an app blocked on one is named in the next timeout instead of
+hanging silently.
 
 - crates.io: https://crates.io/crates/termlens (`cargo add termlens --dev`)
 - GitHub: https://github.com/vyncint/termlens


### PR DESCRIPTION
Caught before tagging: the README still described 0.4, and the release would have shipped a front page contradicting the crate.

## The sharpest one is the headline example

`send` returns `Result` now, so the first code anyone copies dropped the value:

```diff
-    t.send(Key::Char('q'));
+    t.send(Key::Char('q'))?;
```

Fixed there and in the announcement draft.

## Wrong, not merely stale

The limitations section listed **`XTGETTCAP`** among the questions deliberately left unanswered — 0.5 answers it. It now names what really is declined (kitty `CSI ? u`, DECRQSS, DA3, `OSC 12`, `OSC 52` reads, the non-pixel `CSI … t` reports) and adds the two bounds this release introduced:

- **Graphics are observed, not rendered.** termlens counts payloads and can offer support, but draws no pixels — what an image *depicted* is not assertable.
- **A reply the terminal's own input queue cannot hold may not arrive.** ~1 KB on macOS, ~4 KB on Linux; and on Linux the kernel discards silently, so that loss is undetectable and goes unreported.

`SECURITY.md` said queued replies "stop at a fixed depth". They stop at **1 MiB**, and the note now says why a depth was the wrong invariant.

## Missing, where 0.5's headline should have been

Neither the README nor the docs.rs landing page mentioned the thing this release is mostly about: **behaviour that leaves the screen identical**. `repaints()`, `bells()`, `graphics()` and `frame_timings()` are now on both, together with NFC needle folding (a matching behaviour change users should know about), focus events, per-cell drag motion, and `send_after` in `docs/DESIGN.md` §6.

The mermaid diagram's node labels grew to match the API.

## Swept, not assumed

Every markdown file and every shipped source file checked for stale claims: no reference to `write_or_panic`, a `u32` exit code, or an unanswered `XTGETTCAP` survives outside the changelog and one test comment that describes history in the past tense.

`RUSTDOCFLAGS="-D warnings" cargo doc` clean, so every new intra-doc link resolves.

## Checklist

- [x] Linked an issue (or explained above why none exists) — pre-release doc audit for milestone v0.5
- [x] Tests added/updated for the change — docs only; full suite green
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Snapshot changes (if any) were reviewed with `cargo insta review` — none