### PR TITLE
feat(graphics): capture the payloads, and count images rather than escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+What an application *drew*, as against how many bytes it spent drawing it.
+
+Inline graphics were observable only as a count and a size: an image had
+gone out, and it had been about so big. Three things were wrong with that,
+and the first two were wrong rather than merely thin — the count was of
+escapes, not of images, so the kitty protocol's own 4096-byte chunking
+inflated it and a delete posed as a transmission.
+
+### Added
+
+- **`GraphicsSeen::payloads` — the transmissions themselves.** Each
+  `GraphicsPayload` carries its protocol, action, format, compression,
+  image id, the pixel size and cell extent the application declared, the
+  bytes it cost, the chunks it took, and the data itself. Placement is the
+  one fact that lives in the grid rather than in the payload, so `at()`
+  reports the cursor position at the terminator — the image's top-left
+  corner for both protocols. An application that lays out in characters and
+  draws in pixels can now be held to keeping the two in step, which is a
+  failure nothing on screen shows: a picture that slides out from under its
+  own labels leaves every cell exactly as it was.
+- **`GraphicsSeen::deletes`**, counting kitty `a=d` — images taken *off*
+  the screen — apart from images transmitted.
+- **The `decode` feature: `GraphicsPayload::decode` and `Bitmap`.** Kitty
+  `f=24`/`f=32`, zlib'd or not, and the sixel data stream decode into
+  pixels, so an assertion can be about the picture rather than about its
+  size. Off by default: it is the one thing here needing a dependency of
+  its own (zlib), and every other fact about a payload stays free. Refusals
+  name their reason — `f=100` (PNG) is unsupported rather than guessed, a
+  delete carries no image, and a payload past the capture bound says so
+  instead of decoding a prefix of itself into a plausible wrong picture.
+- **`TerminalBuilder::capture_graphics`**, the retention budget: 4 MiB by
+  default, `0` to keep counts and drop every byte. Bounded like scrollback,
+  and the counters stay exact whatever the bound.
+- **The `image-echo` fixture**, which transmits a known image over kitty
+  (compressed, plain, and chunked), over sixel, and with a delete after it.
+
+### Fixed
+
+- **A chunked kitty transmission is one image, not one per escape.** The
+  protocol caps a payload at 4096 bytes and continues with `m=1`, so a
+  4.9 KB chart counted as two images and the continuations — which carry no
+  control block — counted as pictures nothing could be said about. The
+  chunks are joined before anything is counted.
+- **A kitty delete is no longer counted as an image transmitted.** `a=d`
+  carries no picture. Every byte of it is still counted in `bytes()`: a
+  delete is traffic.
+
+### Changed
+
+- **`GraphicsSeen` is `Clone` rather than `Copy`**, since it now carries the
+  payload list. Existing code that reads a counter is unaffected; code that
+  copied the value into two bindings needs a `clone`.
+
 ## [0.5.0] - 2026-08-20
 
 What the harness could not observe, could not reach, and quietly got wrong.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +187,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-echo"
+version = "0.5.0"
+dependencies = [
+ "miniz_oxide",
+]
+
+[[package]]
 name = "insta"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +255,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -503,6 +525,7 @@ dependencies = [
  "anyhow",
  "insta",
  "libc",
+ "miniz_oxide",
  "portable-pty",
  "thiserror 2.0.20",
  "unicode-normalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ unicode-normalization = "0.1"
 # Already in the tree transitively (portable-pty); used directly for one
 # kill(2) call behind Terminal::signal.
 libc = "0.2"
+# zlib, for the `decode` feature: kitty transmits `o=z` compressed, so an
+# image cannot be read back off the wire without inflating it first.
+miniz_oxide = "0.9"
 
 # Dev / fixture dependencies.
 insta = "1.48"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ cargo add termlens --dev
 cargo add insta --dev    # used by the snapshot assertions below
 ```
 
+Add `--features decode` if you test an application that draws inline images
+and want to assert on the pixels it transmitted.
+
 ## Example
 
 ```rust
@@ -117,6 +120,24 @@ the negative one, "this must render as text in every terminal and never go
 out as an image". `frame_timings()` adds the cost of each repaint, so a
 suite can hold a performance line as well as a correctness one.
 
+**And an image is more than a byte count.** `graphics().payloads()` hands
+back the transmissions themselves — where each was placed, the size and
+cell extent it declared, its format and id — so an application that lays
+out in characters and draws in pixels can be held to keeping the two in
+step. Images are counted as *images*: a transmission split across the kitty
+protocol's 4096-byte chunks is one, and a delete is counted apart, under
+`deletes()`, because it carries no picture. With the `decode` feature a
+payload decodes into a `Bitmap`, so the assertion can finally be about the
+picture:
+
+```rust
+let seen = screen.graphics();
+let image = seen.last().expect("the chart went out as an image");
+assert_eq!(image.cells(), Some((106, 7)));       // on the cells reserved
+assert_eq!(image.at(), (4, 5));                  // at the grid's origin
+assert_eq!(image.decode()?.pixel(9, 9), Some([0x39, 0xd3, 0x53, 0xff]));
+```
+
 **Scrollback is retained** (1000 rows by default), so an application that
 hands finished output *back* to the terminal — a pager, a log view, a TUI
 that commits completed blocks into native scrollback and keeps a small
@@ -198,11 +219,17 @@ design. termlens's position:
   DA3, `OSC 12`, `OSC 52` *reads*, and the non-pixel `CSI … t` reports —
   because a guessed reply is worse than none. An application blocked on one
   is **named in the next timeout** rather than left to hang unexplained.
-- **Graphics are observed, not rendered.** termlens counts kitty and sixel
-  payloads and can tell an application that either is available
-  (`graphics()`, `cell_size()`), but it draws no pixels: what a payload
-  *depicted* is not assertable. Both are opt-in, so by default an
-  application that probes is truthfully told there is no graphics support.
+- **Graphics are captured, not rendered.** termlens can tell an application
+  that kitty or sixel is available (`graphics()`, `cell_size()`), collect
+  what it then transmits, and — with the `decode` feature — decode a payload
+  into pixels. It still draws none: an image never reaches the screen grid,
+  so what a picture looks like *composited over the text under it* is not
+  assertable, and `f=100` (PNG) payloads are reported unsupported rather
+  than decoded, since termlens carries no image codec. Retention is bounded
+  (4 MiB by default, `capture_graphics`); past it a payload is counted and
+  described but its bytes are dropped, and it says so rather than decoding a
+  prefix of itself. Support stays opt-in, so by default an application that
+  probes is truthfully told there is none.
 - **A reply the terminal's own input queue cannot hold may not arrive.**
   termlens no longer drops answers of its own accord, but the tty input
   queue is small (~1 KB on macOS, ~4 KB on Linux), so an application that

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -19,6 +19,12 @@ default = ["insta"]
 # Snapshot-testing glue: re-exports `insta` and provides
 # `assert_screen_snapshot!`. Disable if you bring your own snapshot tool.
 insta = ["dep:insta"]
+# Decoding inline graphics payloads into pixels: `GraphicsPayload::decode`
+# and `Bitmap`. Off by default because it is the one thing here that needs a
+# dependency of its own (zlib, for kitty's `o=z`), and a suite that only asks
+# whether an image went out should not pay for it. Every other fact about a
+# payload — placement, declared size, format, id — is free and always on.
+decode = ["dep:miniz_oxide"]
 
 [dependencies]
 portable-pty.workspace = true
@@ -26,6 +32,7 @@ vt100.workspace = true
 thiserror.workspace = true
 unicode-normalization.workspace = true
 insta = { workspace = true, optional = true }
+miniz_oxide = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -11,6 +11,8 @@ mod seq;
 mod shadow;
 mod vt100;
 
+#[cfg(feature = "decode")]
+pub(crate) use self::seq::decode_base64;
 pub(crate) use self::seq::Query;
 pub(crate) use self::vt100::Vt100Emulator;
 

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -20,7 +20,8 @@
 
 use std::sync::Arc;
 
-use crate::screen::{Clipboard, GraphicsSeen};
+use crate::graphics::{GraphicsBuilder, GraphicsCounts, GraphicsPayload};
+use crate::screen::Clipboard;
 
 /// OSC strings are captured whole (titles must not truncate), but bounded:
 /// a buggy or hostile stream must not grow memory without limit. No real
@@ -33,7 +34,7 @@ const OSC_CAPTURE_MAX: usize = 64 * 1024;
 /// a partially decoded clipboard would be indistinguishable from a
 /// correct one, and a test asserting on it would pass while proving
 /// nothing.
-fn decode_base64(input: &[u8]) -> Option<Vec<u8>> {
+pub(crate) fn decode_base64(input: &[u8]) -> Option<Vec<u8>> {
     fn value(b: u8) -> Option<u32> {
         match b {
             b'A'..=b'Z' => Some(u32::from(b - b'A')),
@@ -112,6 +113,10 @@ pub(crate) enum SeqEvent {
     SyncEnd,
     /// The application asked the terminal a question.
     Query(Query),
+    /// An inline graphics payload completed. Carried out of the tracker
+    /// rather than stored in it because the placement — where the cursor
+    /// stood — is a fact about the grid, which only the emulator holds.
+    Graphics(Box<GraphicsPayload>),
 }
 
 /// A terminal query the application issued. The tracker classifies;
@@ -184,6 +189,15 @@ fn kitty_key(control: &[u8], key: &[u8]) -> Option<u32> {
         .and_then(|digits| digits.parse().ok())
 }
 
+/// Whether a kitty control block sets `key` to exactly `value`.
+fn key_is(control: &[u8], key: &[u8], value: &[u8]) -> bool {
+    control.split(|&b| b == b',').any(|pair| {
+        pair.strip_prefix(key)
+            .and_then(|rest| rest.strip_prefix(b"="))
+            == Some(value)
+    })
+}
+
 /// Render a captured escape sequence printably (`ESC` becomes `^[`).
 fn printable(bytes: &[u8]) -> String {
     let mut out = String::new();
@@ -243,8 +257,15 @@ pub(crate) struct SeqTracker {
     /// terminator and one inside a DCS-class string is payload; neither is
     /// a bell, and both are handled by the state machine rather than here.
     bells: u64,
-    /// Inline graphics payloads transmitted.
-    graphics: GraphicsSeen,
+    /// Inline graphics transmitted, counted as images rather than as
+    /// escapes: [`GraphicsBuilder`] joins a chunked kitty transmission
+    /// before either is incremented.
+    counts: GraphicsCounts,
+    /// The payload being assembled, if a kitty transmission is mid-chunk.
+    building: GraphicsBuilder,
+    /// How many payload bytes may be kept for inspection. Counting is
+    /// unaffected by it; only the data is dropped.
+    capture: usize,
     /// Printable characters written since the current frame began. Reset by
     /// the Begin, read by the End — so it measures what one repaint drew,
     /// which is the other half of "did this repaint get more expensive?".
@@ -275,10 +296,16 @@ pub(crate) struct SeqTracker {
     /// which is what an application already has to handle.
     dcs_head: [u8; 128],
     dcs_head_len: u8,
+    /// Every byte of the current DCS-class string, up to the capture bound —
+    /// the image data itself, which the 128-byte head deliberately is not.
+    /// Kept only while the bound allows; `dcs_body_full` says whether it is
+    /// the whole payload or the start of one.
+    dcs_body: Vec<u8>,
+    dcs_body_full: bool,
 }
 
 impl SeqTracker {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(capture: usize) -> Self {
         Self {
             state: State::Ground,
             utf8_remaining: 0,
@@ -300,7 +327,9 @@ impl SeqTracker {
             title: Arc::from(""),
             clipboard: None,
             bells: 0,
-            graphics: GraphicsSeen::default(),
+            counts: GraphicsCounts::default(),
+            building: GraphicsBuilder::default(),
+            capture,
             frame_printable: 0,
             focus_events: false,
             dcs_introducer: 0,
@@ -309,6 +338,8 @@ impl SeqTracker {
             dcs_data_len: 0,
             dcs_head: [0; 128],
             dcs_head_len: 0,
+            dcs_body: Vec::new(),
+            dcs_body_full: true,
         }
     }
 
@@ -345,9 +376,9 @@ impl SeqTracker {
         self.bells
     }
 
-    /// Inline graphics payloads transmitted so far.
-    pub(crate) fn graphics(&self) -> GraphicsSeen {
-        self.graphics
+    /// Inline graphics counted so far.
+    pub(crate) fn graphics(&self) -> GraphicsCounts {
+        self.counts
     }
 
     /// True while the application has focus reporting (mode 1004) enabled.
@@ -367,6 +398,8 @@ impl SeqTracker {
         self.dcs_intermediate = 0;
         self.dcs_data_len = 0;
         self.dcs_head_len = 0;
+        self.dcs_body.clear();
+        self.dcs_body_full = true;
     }
 
     fn reset_csi_scanner(&mut self) {
@@ -603,25 +636,41 @@ impl SeqTracker {
                 }
             }
         }
-        // An APC opening with `G` is the kitty graphics protocol.
-        if self.dcs_introducer == b'_' && self.dcs_head.first() == Some(&b'G') {
-            let control = self.dcs_control_block();
-            // Count the payload either way: "did this go out as an image?"
-            // and, more often, "did it *not*?" are the assertions, and a
-            // query carries no picture but is still traffic worth seeing.
-            let is_query = control.windows(3).any(|w| w == b"a=q");
+        // An APC opening with `G` is the kitty graphics protocol — or a
+        // continuation of one, which carries `m=` and nothing else.
+        if self.dcs_introducer == b'_'
+            && (self.dcs_head.first() == Some(&b'G') || self.building.in_progress())
+        {
+            let control = self.dcs_control_block().to_vec();
+            // The control block is `G` followed by the comma-separated keys.
+            let keys = control.strip_prefix(b"G").unwrap_or(&control);
+            let is_query = keys.split(|&b| b == b',').any(|pair| pair == b"a=q");
             if !is_query {
-                self.graphics.record(true, self.dcs_data_len);
-                return SeqEvent::None;
+                // One image, however many escapes it took. `m=1` says
+                // another follows; the transmission is not an image until
+                // one arrives without it, and counting each escape instead
+                // reported a 4.9 KB chart as two pictures.
+                self.building.kitty(keys);
+                let at = self.dcs_payload_start();
+                self.building
+                    .chunk(self.dcs_data_len, &self.dcs_body[at..], self.dcs_body_full);
+                if key_is(keys, b"m", b"1") {
+                    return SeqEvent::None;
+                }
+                return match self.building.finish() {
+                    Some(payload) => {
+                        self.counts.record(&payload);
+                        SeqEvent::Graphics(Box::new(payload))
+                    }
+                    None => SeqEvent::None,
+                };
             }
             // Only an explicit `a=q` is a question. A transmission is an
             // instruction, and classifying one as a query would put "the
             // application queried the terminal" into the next timeout of
             // every application that draws — a false diagnosis, and a loud
             // one.
-            // The control block is `G` followed by the comma-separated
-            // keys, so the keys start one byte in.
-            let id = kitty_key(&control[1..], b"i=");
+            let id = kitty_key(keys, b"i=");
             return SeqEvent::Query(Query::KittyGraphics {
                 id,
                 shape: self.seq_printable(),
@@ -631,8 +680,17 @@ impl SeqTracker {
         // intermediate is the whole distinction from the two DCS questions
         // below, which reach the same `q` final through `+` and `$`.
         if self.dcs_introducer == b'P' && self.dcs_final == b'q' && self.dcs_intermediate == 0 {
-            self.graphics.record(false, self.dcs_data_len);
-            return SeqEvent::None;
+            self.building.sixel();
+            let at = self.dcs_payload_start();
+            self.building
+                .chunk(self.dcs_data_len, &self.dcs_body[at..], self.dcs_body_full);
+            return match self.building.finish() {
+                Some(payload) => {
+                    self.counts.record(&payload);
+                    SeqEvent::Graphics(Box::new(payload))
+                }
+                None => SeqEvent::None,
+            };
         }
         // XTGETTCAP (`ESC P + q <hex names> ST`). The names are needed to
         // answer, so they come out of the header capture rather than the
@@ -656,6 +714,24 @@ impl SeqTracker {
             return SeqEvent::Query(Query::Unanswerable(self.seq_printable()));
         }
         SeqEvent::None
+    }
+
+    /// The image data inside the captured body: for kitty everything after
+    /// the `;` that closes the control block, and for sixel everything after
+    /// the final byte that closes the DCS header. The protocol's own framing
+    /// is metadata, already parsed; what is left is what a decoder wants.
+    fn dcs_payload_start(&self) -> usize {
+        let separator = if self.dcs_introducer == b'_' {
+            b';'
+        } else {
+            self.dcs_final
+        };
+        self.dcs_body.iter().position(|&b| b == separator).map_or(
+            // No separator: a control-only escape — a delete, or a
+            // placement of something transmitted earlier — with no data.
+            self.dcs_body.len(),
+            |at| at + 1,
+        )
     }
 
     /// The captured head of a DCS-class payload, cut at the first `;`.
@@ -692,6 +768,15 @@ impl SeqTracker {
         if usize::from(self.dcs_head_len) < self.dcs_head.len() {
             self.dcs_head[usize::from(self.dcs_head_len)] = b;
             self.dcs_head_len += 1;
+        }
+        // The body is what a decoder needs and the head is not: 128 bytes
+        // holds a control block, never an image. Bounded, and the flag says
+        // which of the two this is, so a truncated payload is reported as
+        // uncaptured rather than decoded into a plausible wrong picture.
+        if self.dcs_body.len() < self.capture {
+            self.dcs_body.push(b);
+        } else {
+            self.dcs_body_full = false;
         }
     }
 
@@ -845,9 +930,10 @@ impl SeqTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graphics::GraphicsFormat;
 
     fn fed(bytes: &[u8]) -> SeqTracker {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(bytes);
         t
     }
@@ -872,33 +958,111 @@ mod tests {
         assert_eq!(fed(b"\x1b]0;t\x07\x07").bells(), 1);
     }
 
+    /// Every payload a feed produced, in order.
+    fn payloads(bytes: &[u8]) -> Vec<GraphicsPayload> {
+        let mut tracker = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
+        let mut out = Vec::new();
+        for &byte in bytes {
+            if let SeqEvent::Graphics(payload) = tracker.step(byte) {
+                out.push(*payload);
+            }
+        }
+        out
+    }
+
     /// Kitty and sixel payloads, and the two DCS *questions* that share
     /// sixel's `q` final byte and must not be counted as pictures.
     #[test]
     fn graphics_payloads_are_counted_by_protocol() {
         let kitty = fed(b"\x1b_Gf=24,s=1,v=1,a=T;AAAABBBB\x1b\\");
-        assert_eq!(kitty.graphics().kitty(), 1);
-        assert_eq!(kitty.graphics().sixel(), 0);
+        assert_eq!(kitty.graphics().kitty, 1);
+        assert_eq!(kitty.graphics().sixel, 0);
         // Everything between the introducer and the terminator.
-        assert_eq!(kitty.graphics().bytes(), 26);
-        assert_eq!(fed(b"\x1bPq~~\x1b\\").graphics().bytes(), 3, "q~~");
+        assert_eq!(kitty.graphics().bytes, 26);
+        assert_eq!(fed(b"\x1bPq~~\x1b\\").graphics().bytes, 3, "q~~");
 
         let sixel = fed(b"\x1bPq#0;2;0;0;0#0~~-~~\x1b\\");
-        assert_eq!(sixel.graphics().sixel(), 1);
-        assert_eq!(sixel.graphics().kitty(), 0);
+        assert_eq!(sixel.graphics().sixel, 1);
+        assert_eq!(sixel.graphics().kitty, 0);
 
         // Sixel with parameters before the `q`.
-        assert_eq!(fed(b"\x1bP0;1;0q~~\x1b\\").graphics().sixel(), 1);
+        assert_eq!(fed(b"\x1bP0;1;0q~~\x1b\\").graphics().sixel, 1);
 
         // Neither of these is a picture: both reach `q` through an
         // intermediate byte, which is the whole distinction.
-        assert!(fed(b"\x1bP+q544e\x1b\\").graphics().is_empty(), "XTGETTCAP");
-        assert!(fed(b"\x1bP$qm\x1b\\").graphics().is_empty(), "DECRQSS");
+        let termcap = fed(b"\x1bP+q544e\x1b\\").graphics();
+        assert_eq!((termcap.kitty, termcap.sixel), (0, 0), "XTGETTCAP");
+        let decrqss = fed(b"\x1bP$qm\x1b\\").graphics();
+        assert_eq!((decrqss.kitty, decrqss.sixel), (0, 0), "DECRQSS");
 
         // Two of each accumulate.
         let both = fed(b"\x1b_Ga=T;AA\x1b\\\x1bPq~\x1b\\\x1b_Ga=T;BB\x1b\\");
-        assert_eq!((both.graphics().kitty(), both.graphics().sixel()), (2, 1));
-        assert_eq!(both.graphics().total(), 3);
+        assert_eq!((both.graphics().kitty, both.graphics().sixel), (2, 1));
+    }
+
+    /// The protocol caps a payload at 4096 bytes and continues with `m=1`,
+    /// so every image of consequence arrives in several escapes. Counting
+    /// each of them reported one 4.9 KB chart as two pictures — and the
+    /// second "picture" had no control block, so nothing could be said
+    /// about it either.
+    #[test]
+    fn a_chunked_kitty_transmission_is_one_image() {
+        let wire = b"\x1b_Ga=T,f=32,s=2,v=2,i=1,m=1;AAAA\x1b\\                     \x1b_Gm=1;BBBB\x1b\\\x1b_Gm=0;CCCC\x1b\\";
+        let counts = fed(wire).graphics();
+        assert_eq!(counts.kitty, 1, "one image, three escapes");
+
+        let payloads = payloads(wire);
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0].chunks(), 3);
+        assert_eq!(payloads[0].data(), Some(&b"AAAABBBBCCCC"[..]));
+        // The facts come off the first escape; the continuations carry none.
+        assert_eq!(payloads[0].size(), Some((2, 2)));
+        assert_eq!(payloads[0].id(), Some(1));
+        // And the cost is the whole transmission, not the last escape.
+        assert_eq!(counts.bytes, payloads[0].bytes());
+    }
+
+    /// A delete takes an image *off* the screen. Counting it as one
+    /// transmitted made an application that tears down what it drew
+    /// indistinguishable from one that drew twice as much.
+    #[test]
+    fn a_delete_is_counted_apart_from_the_images() {
+        let counts = fed(b"\x1b_Ga=T,f=32,s=1,v=1;AA\x1b\\\x1b_Ga=d,d=I,i=1,q=2\x1b\\").graphics();
+        assert_eq!(counts.kitty, 1, "one image");
+        assert_eq!(counts.deletes, 1, "and one teardown");
+        // The wire cost of both is still counted: a delete is traffic.
+        assert!(counts.bytes > 22);
+    }
+
+    /// A payload past the capture bound keeps every count and drops the
+    /// data, rather than handing back a prefix that would decode into a
+    /// plausible-looking wrong picture.
+    #[test]
+    fn a_payload_past_the_capture_bound_is_counted_and_not_kept() {
+        let mut tracker = SeqTracker::new(8);
+        let mut seen = None;
+        for &byte in b"\x1b_Ga=T,f=32,s=4,v=4;AAAABBBBCCCCDDDD\x1b\\" {
+            if let SeqEvent::Graphics(payload) = tracker.step(byte) {
+                seen = Some(*payload);
+            }
+        }
+        let payload = seen.expect("a payload");
+        assert_eq!(payload.data(), None, "not kept");
+        assert_eq!(payload.size(), Some((4, 4)), "but still described");
+        assert_eq!(tracker.graphics().kitty, 1, "and still counted");
+    }
+
+    /// The control block is metadata; the data is what a decoder wants.
+    #[test]
+    fn a_payload_carries_the_data_and_not_the_framing() {
+        let kitty = payloads(b"\x1b_Ga=T,f=24,s=1,v=1;QUJD\x1b\\");
+        assert_eq!(kitty[0].data(), Some(&b"QUJD"[..]));
+        assert_eq!(kitty[0].format(), GraphicsFormat::Rgb);
+
+        // Sixel's header ends at the `q`; everything after it is the image.
+        let sixel = payloads(b"\x1bP0;1;0q\"1;1;2;6#0;2;100;0;0~~\x1b\\");
+        assert_eq!(sixel[0].data(), Some(&b"\"1;1;2;6#0;2;100;0;0~~"[..]));
+        assert_eq!(sixel[0].size(), Some((2, 6)));
     }
 
     /// The kitty graphics *query* was the one probe of the startup set that
@@ -907,7 +1071,7 @@ mod tests {
     /// it and the timeout said nothing.
     #[test]
     fn the_kitty_graphics_query_is_classified() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let mut events = Vec::new();
         for &b in b"\x1b_Gi=1,a=q;\x1b\\" {
             events.push(t.step(b));
@@ -922,7 +1086,7 @@ mod tests {
              timeout note: {events:?}"
         );
         // A query carries no picture, so it is not counted as one.
-        assert!(t.graphics().is_empty());
+        assert_eq!(t.graphics().kitty, 0);
     }
 
     /// A transmission is an instruction, not a question. Classifying one as
@@ -930,7 +1094,7 @@ mod tests {
     /// next timeout of every application that draws.
     #[test]
     fn a_kitty_transmission_is_not_treated_as_a_query() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let mut events = Vec::new();
         for &b in b"\x1b_Gf=24,a=T;QUJD\x1b\\" {
             events.push(t.step(b));
@@ -939,7 +1103,7 @@ mod tests {
             !events.iter().any(|e| matches!(e, SeqEvent::Query(_))),
             "a transmit is not a question: {events:?}"
         );
-        assert_eq!(t.graphics().kitty(), 1);
+        assert_eq!(t.graphics().kitty, 1);
     }
 
     #[test]
@@ -949,7 +1113,7 @@ mod tests {
 
     #[test]
     fn split_csi_is_mid_sequence_until_final_byte() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b[3");
         assert!(t.mid_sequence());
         t.feed(b"1");
@@ -999,7 +1163,7 @@ mod tests {
 
     #[test]
     fn sync_update_events_fire_on_2026_set_and_reset() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let events: Vec<SeqEvent> = b"\x1b[?2026h".iter().map(|&b| t.step(b)).collect();
         assert_eq!(*events.last().unwrap(), SeqEvent::SyncBegin);
         assert!(t.in_sync_update());
@@ -1010,17 +1174,17 @@ mod tests {
 
     #[test]
     fn sync_2026_is_recognized_anywhere_in_a_multi_mode_list() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b[?2026;25h");
         assert!(t.in_sync_update());
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b[?25;2026h");
         assert!(t.in_sync_update());
     }
 
     #[test]
     fn lookalike_sequences_do_not_toggle_sync() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b[2026h"); // not private (no '?')
         assert!(!t.in_sync_update());
         t.feed(b"\x1b[?2026m"); // wrong final byte
@@ -1107,7 +1271,7 @@ mod tests {
 
     #[test]
     fn a_clipboard_read_is_a_query_not_a_write() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let events: Vec<SeqEvent> = b"\x1b]52;c;?\x07".iter().map(|&b| t.step(b)).collect();
         assert!(matches!(
             events.last(),
@@ -1121,19 +1285,19 @@ mod tests {
         // Applications reset terminal modes defensively at startup and on
         // crash, and such a reset string contains `?2026l`. It must not end
         // a frame that never began.
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let events: Vec<SeqEvent> = b"\x1b[?2026l".iter().map(|&b| t.step(b)).collect();
         assert!(!events.contains(&SeqEvent::SyncEnd));
         assert!(!t.in_sync_update());
 
         // Taken verbatim from a real crash handler.
         let reset = b"\x1b[?2026l\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?2004l\x1b[?1049l";
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let events: Vec<SeqEvent> = reset.iter().map(|&b| t.step(b)).collect();
         assert!(!events.contains(&SeqEvent::SyncEnd));
 
         // And the End of a real frame still ends it, once only.
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let events: Vec<SeqEvent> = b"\x1b[?2026h\x1b[?2026l\x1b[?2026l"
             .iter()
             .map(|&b| t.step(b))
@@ -1146,7 +1310,7 @@ mod tests {
 
     #[test]
     fn sync_survives_an_aborted_csi_inside_the_update() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b[?2026h\x1b[31\x18"); // CAN aborts the SGR, not the frame
         assert!(t.in_sync_update());
         t.feed(b"\x1b[?2026l");
@@ -1154,7 +1318,7 @@ mod tests {
     }
 
     fn queries_of(bytes: &[u8]) -> Vec<Query> {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         bytes
             .iter()
             .filter_map(|&b| match t.step(b) {
@@ -1307,7 +1471,7 @@ mod tests {
 
     #[test]
     fn osc_0_and_2_set_the_title_via_bel_or_st() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         assert_eq!(&*t.title(), "");
         t.feed(b"\x1b]2;hello world\x07");
         assert_eq!(&*t.title(), "hello world");
@@ -1317,7 +1481,7 @@ mod tests {
 
     #[test]
     fn titles_longer_than_the_diagnostic_capture_are_kept_whole() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         let title = "t".repeat(80); // seq_buf truncates at 24; titles must not
         t.feed(format!("\x1b]2;{title}\x07").as_bytes());
         assert_eq!(&*t.title(), title.as_str());
@@ -1325,7 +1489,7 @@ mod tests {
 
     #[test]
     fn title_survives_chunked_delivery() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b]2;split");
         t.feed(b" title\x07");
         assert_eq!(&*t.title(), "split title");
@@ -1333,14 +1497,14 @@ mod tests {
 
     #[test]
     fn title_keeps_embedded_semicolons() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b]0;a;b;c\x07");
         assert_eq!(&*t.title(), "a;b;c");
     }
 
     #[test]
     fn icon_only_and_aborted_titles_do_not_change_the_title() {
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(b"\x1b]2;kept\x07");
         t.feed(b"\x1b]1;icon only\x07"); // OSC 1: icon name, not the title
         assert_eq!(&*t.title(), "kept");
@@ -1355,7 +1519,7 @@ mod tests {
     #[test]
     fn split_utf8_is_mid_sequence() {
         let bytes = "汉".as_bytes(); // 3 bytes
-        let mut t = SeqTracker::new();
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
         t.feed(&bytes[..1]);
         assert!(t.mid_sequence());
         t.feed(&bytes[1..2]);

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -652,8 +652,12 @@ impl SeqTracker {
                 // reported a 4.9 KB chart as two pictures.
                 self.building.kitty(keys);
                 let at = self.dcs_payload_start();
-                self.building
-                    .chunk(self.dcs_data_len, &self.dcs_body[at..], self.dcs_body_full);
+                self.building.chunk(
+                    self.dcs_data_len,
+                    &self.dcs_body[at..],
+                    self.dcs_body_full,
+                    self.capture,
+                );
                 if key_is(keys, b"m", b"1") {
                     return SeqEvent::None;
                 }
@@ -682,8 +686,12 @@ impl SeqTracker {
         if self.dcs_introducer == b'P' && self.dcs_final == b'q' && self.dcs_intermediate == 0 {
             self.building.sixel();
             let at = self.dcs_payload_start();
-            self.building
-                .chunk(self.dcs_data_len, &self.dcs_body[at..], self.dcs_body_full);
+            self.building.chunk(
+                self.dcs_data_len,
+                &self.dcs_body[at..],
+                self.dcs_body_full,
+                self.capture,
+            );
             return match self.building.finish() {
                 Some(payload) => {
                     self.counts.record(&payload);
@@ -956,6 +964,38 @@ mod tests {
         assert_eq!(fed(b"\x1bPq\x07\x07\x1b\\").bells(), 0);
         // A bell after a sequence closes still counts.
         assert_eq!(fed(b"\x1b]0;t\x07\x07").bells(), 1);
+    }
+
+    /// The capture bound is a bound on the *payload*, not on each escape.
+    ///
+    /// kitty sends one escape per 4096 bytes, so a bound applied per escape
+    /// would let a thousand-chunk image retain a thousand times the budget —
+    /// which is the whole of what the knob is for.
+    #[test]
+    fn the_capture_bound_holds_across_a_chunked_transmission() {
+        let mut tracker = SeqTracker::new(40);
+        // Ten chunks of eight data bytes: every escape fits the bound
+        // comfortably, and the ten together do not.
+        let mut wire: Vec<u8> = b"\x1b_Ga=T,f=32,s=4,v=4,m=1;AAAAAAAA\x1b\\".to_vec();
+        for _ in 0..8 {
+            wire.extend_from_slice(b"\x1b_Gm=1;BBBBBBBB\x1b\\");
+        }
+        wire.extend_from_slice(b"\x1b_Gm=0;CCCCCCCC\x1b\\");
+
+        let mut seen = None;
+        for &byte in &wire {
+            if let SeqEvent::Graphics(payload) = tracker.step(byte) {
+                seen = Some(*payload);
+            }
+        }
+        let payload = seen.expect("a payload");
+        assert_eq!(payload.chunks(), 10);
+        assert_eq!(
+            payload.data(),
+            None,
+            "80 bytes must not be kept under a 40-byte bound"
+        );
+        assert_eq!(tracker.graphics().kitty, 1, "and it is still one image");
     }
 
     /// Every payload a feed produced, in order.

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use super::seq::{SeqEvent, SeqTracker};
 use super::shadow::AttrShadow;
 use super::{Emulator, FrameSpan, InputModes, ModeState, MouseEncoding, Processed, Stop};
+use crate::graphics::{GraphicsPayload, GraphicsSeen, HISTORY};
 use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
 
 pub(crate) struct Vt100Emulator {
@@ -32,6 +33,14 @@ pub(crate) struct Vt100Emulator {
     /// Rows of vt100's own scrollback already copied into `history`, so a
     /// read that scrolled nothing costs one length check.
     captured: usize,
+    /// Inline graphics payloads, oldest first, behind an `Arc` so a
+    /// snapshot costs one refcount rather than a copy of every image.
+    graphics: Arc<Vec<GraphicsPayload>>,
+    /// Payload bytes currently retained, so eviction is a subtraction
+    /// rather than a walk.
+    graphics_bytes: usize,
+    /// The retention budget, from `TerminalBuilder::capture_graphics`.
+    capture: usize,
 }
 
 impl Vt100Emulator {
@@ -49,15 +58,54 @@ impl Vt100Emulator {
         }
     }
 
-    pub(crate) fn new(rows: u16, cols: u16, scrollback_len: usize) -> Self {
+    pub(crate) fn new(rows: u16, cols: u16, scrollback_len: usize, capture: usize) -> Self {
         Self {
             parser: ::vt100::Parser::new(rows, cols, scrollback_len),
-            tracker: SeqTracker::new(),
+            tracker: SeqTracker::new(capture),
             shadow: AttrShadow::new(rows, cols),
             scrollback_len,
             frame_started: None,
             history: VecDeque::new(),
             captured: 0,
+            graphics: Arc::new(Vec::new()),
+            graphics_bytes: 0,
+            capture,
+        }
+    }
+
+    /// Hand the grid the bytes the tracker has already scanned.
+    ///
+    /// The tracker runs a byte ahead of the parser so it can stop the read
+    /// at a frame end or a query; everything else is fed in bulk. Splitting
+    /// the feed is what lets a graphics payload be stamped with the cursor
+    /// position as of its terminator rather than as of the whole read.
+    fn feed(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        self.parser.process(bytes);
+        self.shadow.feed(bytes);
+        self.capture_scrolled_rows();
+    }
+
+    /// File a completed payload, stamped with where it landed.
+    ///
+    /// Neither protocol's escape moves the cursor, so the position once the
+    /// terminator has been consumed *is* the image's top-left corner — the
+    /// one fact about an image that lives in the grid rather than in the
+    /// payload, and the one an application gets wrong when a picture drifts
+    /// out from under its own labels.
+    fn record_graphics(&mut self, mut payload: GraphicsPayload) {
+        payload.place(self.parser.screen().cursor_position());
+        let kept = payload.data().map_or(0, <[u8]>::len);
+        let log = Arc::make_mut(&mut self.graphics);
+        log.push(payload);
+        self.graphics_bytes += kept;
+        // Evict oldest-first, on both bounds. A snapshot already taken keeps
+        // its own view: it holds an `Arc` to the vector as it stood.
+        while log.len() > HISTORY || (self.graphics_bytes > self.capture && log.len() > 1) {
+            let dropped = log.remove(0);
+            self.graphics_bytes -= dropped.data().map_or(0, <[u8]>::len);
         }
     }
 
@@ -133,10 +181,20 @@ impl Vt100Emulator {
 
 impl Emulator for Vt100Emulator {
     fn process(&mut self, bytes: &[u8]) -> Processed {
+        // How much of this segment the grid has already been given. Only a
+        // graphics payload moves it mid-segment; everything else is fed in
+        // one go, exactly as before.
+        let mut fed = 0;
         for (i, &byte) in bytes.iter().enumerate() {
             let stop = match self.tracker.step(byte) {
                 SeqEvent::SyncEnd => Some(Stop::FrameComplete(self.close_frame())),
                 SeqEvent::Query(query) => Some(Stop::Query(query)),
+                SeqEvent::Graphics(payload) => {
+                    self.feed(&bytes[fed..=i]);
+                    fed = i + 1;
+                    self.record_graphics(*payload);
+                    None
+                }
                 SeqEvent::None => None,
                 SeqEvent::SyncBegin => {
                     // Stamped here, at the byte that opened the update,
@@ -148,18 +206,14 @@ impl Emulator for Vt100Emulator {
                 }
             };
             if let Some(stop) = stop {
-                self.parser.process(&bytes[..=i]);
-                self.shadow.feed(&bytes[..=i]);
-                self.capture_scrolled_rows();
+                self.feed(&bytes[fed..=i]);
                 return Processed {
                     consumed: i + 1,
                     stop: Some(stop),
                 };
             }
         }
-        self.parser.process(bytes);
-        self.shadow.feed(bytes);
-        self.capture_scrolled_rows();
+        self.feed(&bytes[fed..]);
         Processed {
             consumed: bytes.len(),
             stop: None,
@@ -198,7 +252,7 @@ impl Emulator for Vt100Emulator {
             clipboard: self.tracker.clipboard(),
             bells: self.tracker.bells(),
             focus_events: self.tracker.focus_events(),
-            graphics: self.tracker.graphics(),
+            graphics: GraphicsSeen::new(self.tracker.graphics(), Arc::clone(&self.graphics)),
             // Filled in by the terminal, which owns the frame count.
             repaints: 0,
             scrollback: self.history.iter().cloned().collect(),
@@ -357,7 +411,7 @@ mod tests {
     }
 
     fn emu_with(bytes: &[u8]) -> Vt100Emulator {
-        let mut emu = Vt100Emulator::new(4, 10, 0);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
         feed_all(&mut emu, bytes);
         emu
     }
@@ -480,7 +534,7 @@ mod tests {
 
     #[test]
     fn mid_sequence_tracks_partial_escape() {
-        let mut emu = Vt100Emulator::new(4, 10, 0);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
         feed_all(&mut emu, b"text\x1b[3");
         assert!(emu.mid_sequence());
         feed_all(&mut emu, b"1m");
@@ -489,7 +543,7 @@ mod tests {
 
     #[test]
     fn process_stops_at_the_end_of_a_synchronized_update() {
-        let mut emu = Vt100Emulator::new(4, 10, 0);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
         let stream = b"\x1b[?2026hframe1\x1b[?2026lnext";
 
         let first = emu.process(stream);
@@ -514,7 +568,7 @@ mod tests {
 
     #[test]
     fn in_sync_update_is_true_between_bsu_and_esu() {
-        let mut emu = Vt100Emulator::new(4, 10, 0);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
         feed_all(&mut emu, b"\x1b[?2026hpartial");
         assert!(emu.in_sync_update());
         assert!(!emu.mid_sequence()); // the escape itself is finished
@@ -546,7 +600,7 @@ mod tests {
 
     /// Feed a stream into an emulator with `scrollback` rows of history.
     fn emu_with_history(scrollback: usize, bytes: &[u8]) -> Vt100Emulator {
-        let mut emu = Vt100Emulator::new(4, 10, scrollback);
+        let mut emu = Vt100Emulator::new(4, 10, scrollback, crate::graphics::DEFAULT_CAPTURE);
         feed_all(&mut emu, bytes);
         emu
     }
@@ -571,7 +625,7 @@ mod tests {
     fn history_is_bounded_and_drops_its_oldest_rows() {
         // Ten rows, each ending in a newline, on a 4-row screen: seven
         // scroll off (row1..row7) and the cap of 3 keeps the newest three.
-        let mut emu = Vt100Emulator::new(4, 10, 3);
+        let mut emu = Vt100Emulator::new(4, 10, 3, crate::graphics::DEFAULT_CAPTURE);
         for n in 1..=10 {
             feed_all(&mut emu, format!("row{n}\r\n").as_bytes());
         }
@@ -589,7 +643,7 @@ mod tests {
         // The rebuild path: once at the cap vt100's length stops changing,
         // so a naive "did the length grow?" check would freeze the history
         // at its first full window.
-        let mut emu = Vt100Emulator::new(4, 10, 2);
+        let mut emu = Vt100Emulator::new(4, 10, 2, crate::graphics::DEFAULT_CAPTURE);
         feed_all(&mut emu, b"a\r\nb\r\nc\r\nd\r\ne\r\nf\r\n");
         assert_eq!(emu.snapshot().scrollback_text(), "b\nc");
         feed_all(&mut emu, b"g\r\nh\r\n");
@@ -622,7 +676,7 @@ mod tests {
     #[test]
     fn history_rows_keep_the_width_they_were_captured_at() {
         // Documented limit: resize does not reflow.
-        let mut emu = Vt100Emulator::new(2, 10, 100);
+        let mut emu = Vt100Emulator::new(2, 10, 100, crate::graphics::DEFAULT_CAPTURE);
         feed_all(&mut emu, b"0123456789\r\nabcdefghij\r\nnext");
         assert_eq!(emu.snapshot().scrollback_text(), "0123456789");
         emu.set_size(2, 4);

--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -870,14 +870,21 @@ impl GraphicsBuilder {
         self.format = GraphicsFormat::Sixel;
     }
 
-    /// Add one escape's worth of wire cost and image data. `complete` is
-    /// false when the capture bound cut this chunk short — the counts stay
-    /// exact either way, and the data is dropped entirely rather than kept
-    /// as a prefix that would decode into a plausible-looking wrong picture.
-    pub(crate) fn chunk(&mut self, bytes: u64, data: &[u8], complete: bool) {
+    /// Add one escape's worth of wire cost and image data.
+    ///
+    /// `complete` is false when the capture bound cut this chunk short, and
+    /// `cap` bounds the payload as a whole — a kitty transmission arrives as
+    /// one escape per 4096 bytes, so a bound applied per escape would let a
+    /// thousand-chunk image retain a thousand times the budget.
+    ///
+    /// The counts stay exact either way; past the bound the data is dropped
+    /// entirely rather than kept as a prefix that would decode into a
+    /// plausible-looking wrong picture.
+    pub(crate) fn chunk(&mut self, bytes: u64, data: &[u8], complete: bool, cap: usize) {
         self.chunks += 1;
         self.bytes += bytes;
-        if complete && !self.dropped {
+        let fits = self.data.len().saturating_add(data.len()) <= cap;
+        if complete && fits && !self.dropped {
             self.data.extend_from_slice(data);
         } else {
             self.dropped = true;
@@ -963,7 +970,7 @@ mod tests {
     fn kitty_payload(control: &[u8], data: &[u8]) -> GraphicsPayload {
         let mut builder = GraphicsBuilder::default();
         builder.kitty(control);
-        builder.chunk(data.len() as u64, data, true);
+        builder.chunk(data.len() as u64, data, true, usize::MAX);
         builder.finish().expect("a payload")
     }
 
@@ -1007,8 +1014,8 @@ mod tests {
     fn chunks_join_into_one_payload() {
         let mut builder = GraphicsBuilder::default();
         builder.kitty(b"a=T,f=32,s=2,v=1,m=1");
-        builder.chunk(20, b"AAAA", true);
-        builder.chunk(10, b"BBBB", true);
+        builder.chunk(20, b"AAAA", true, usize::MAX);
+        builder.chunk(10, b"BBBB", true, usize::MAX);
         let payload = builder.finish().expect("a payload");
         assert_eq!(payload.chunks(), 2);
         assert_eq!(payload.bytes(), 30);
@@ -1019,7 +1026,7 @@ mod tests {
     fn a_payload_past_the_bound_is_counted_and_not_kept() {
         let mut builder = GraphicsBuilder::default();
         builder.kitty(b"a=T,f=32,s=2,v=1");
-        builder.chunk(64, b"AAAABBBB", false);
+        builder.chunk(64, b"AAAABBBB", false, usize::MAX);
         let payload = builder.finish().expect("a payload");
         assert_eq!(payload.bytes(), 64, "the cost is still known");
         assert_eq!(payload.data(), None, "and the bytes are not kept");
@@ -1029,7 +1036,7 @@ mod tests {
     fn a_sixel_reads_its_size_off_its_raster_attributes() {
         let mut builder = GraphicsBuilder::default();
         builder.sixel();
-        builder.chunk(30, b"\"1;1;18;12#0;2;100;100;100~", true);
+        builder.chunk(30, b"\"1;1;18;12#0;2;100;100;100~", true, usize::MAX);
         let payload = builder.finish().expect("a payload");
         assert_eq!(payload.protocol(), GraphicsProtocol::Sixel);
         assert_eq!(payload.size(), Some((18, 12)));
@@ -1040,7 +1047,7 @@ mod tests {
     fn a_sixel_that_declares_no_size_says_so_rather_than_guessing() {
         let mut builder = GraphicsBuilder::default();
         builder.sixel();
-        builder.chunk(10, b"#0;2;100;100;100~~~", true);
+        builder.chunk(10, b"#0;2;100;100;100~~~", true, usize::MAX);
         assert_eq!(builder.finish().expect("a payload").size(), None);
     }
 
@@ -1098,7 +1105,7 @@ mod tests {
 
         let mut builder = GraphicsBuilder::default();
         builder.kitty(b"a=T,f=32,s=2,v=1");
-        builder.chunk(64, b"AAAABBBB", false);
+        builder.chunk(64, b"AAAABBBB", false, usize::MAX);
         let dropped = builder.finish().expect("a payload");
         assert_eq!(dropped.decode(), Err(DecodeError::NotCaptured));
     }
@@ -1110,7 +1117,7 @@ mod tests {
         // band, so a run of four fills the whole thing.
         let mut builder = GraphicsBuilder::default();
         builder.sixel();
-        builder.chunk(40, b"\"1;1;4;6#0;2;100;100;100!4~-", true);
+        builder.chunk(40, b"\"1;1;4;6#0;2;100;100;100!4~-", true, usize::MAX);
         let bitmap = builder
             .finish()
             .expect("a payload")
@@ -1131,7 +1138,7 @@ mod tests {
         // never written, and sixel has no alpha to say so with.
         let mut builder = GraphicsBuilder::default();
         builder.sixel();
-        builder.chunk(30, b"\"1;1;1;6#0;2;0;100;0@-", true);
+        builder.chunk(30, b"\"1;1;1;6#0;2;0;100;0@-", true, usize::MAX);
         let bitmap = builder
             .finish()
             .expect("a payload")
@@ -1148,7 +1155,12 @@ mod tests {
         // over the first band's second column.
         let mut builder = GraphicsBuilder::default();
         builder.sixel();
-        builder.chunk(60, b"\"1;1;2;12#0;2;100;0;0~~$#1;2;0;0;100?~-#0??-", true);
+        builder.chunk(
+            60,
+            b"\"1;1;2;12#0;2;100;0;0~~$#1;2;0;0;100?~-#0??-",
+            true,
+            usize::MAX,
+        );
         let bitmap = builder
             .finish()
             .expect("a payload")
@@ -1165,7 +1177,7 @@ mod tests {
     fn a_sixel_without_raster_attributes_takes_its_size_from_its_data() {
         let mut builder = GraphicsBuilder::default();
         builder.sixel();
-        builder.chunk(20, b"#0;2;100;100;100!3~-", true);
+        builder.chunk(20, b"#0;2;100;100;100!3~-", true, usize::MAX);
         let bitmap = builder
             .finish()
             .expect("a payload")
@@ -1194,7 +1206,7 @@ mod tests {
     fn hls_colours_are_refused_rather_than_converted() {
         let mut builder = GraphicsBuilder::default();
         builder.sixel();
-        builder.chunk(30, b"\"1;1;1;6#0;1;120;50;100~-", true);
+        builder.chunk(30, b"\"1;1;1;6#0;1;120;50;100~-", true, usize::MAX);
         assert!(matches!(
             builder.finish().expect("a payload").decode(),
             Err(DecodeError::Unsupported(_))

--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -1,0 +1,1234 @@
+//! Inline graphics: the payloads an application transmitted, and — with the
+//! `decode` feature — what they depicted.
+//!
+//! Two protocols reach a terminal as escape strings rather than as cells:
+//! kitty's (`APC G <control> ; <base64> ST`) and sixel's
+//! (`DCS <params> q <data> ST`). Neither touches the grid, so no content
+//! predicate can see one, and until a payload is *captured* the only
+//! questions a test can ask are "did anything go out?" and "how big was it?".
+//!
+//! Capturing is not rendering. termlens draws no pixels and goes on declining
+//! both protocols in DA1 unless a test declares otherwise with
+//! [`TerminalBuilder::graphics`](crate::TerminalBuilder::graphics) — which is
+//! precisely why an application that transmits one anyway is worth catching.
+//! What capture adds is the other half of the assertion: *which* image, of
+//! what size, placed where, and — decoded — of what colour.
+//!
+//! This is the same position [`Clipboard`](crate::Clipboard) takes on
+//! `OSC 52`. A write is not a question, the application's own toast proves
+//! only that the code path ran, and the payload is usually the behaviour
+//! actually under test.
+//!
+//! ```no_run
+//! # fn main() -> termlens::Result<()> {
+//! # let mut t = termlens::Terminal::builder().spawn("true")?;
+//! let screen = t.wait_frame(|s| s.contains("ready"))?;
+//! let seen = screen.graphics();
+//! let image = seen.payloads().last().expect("the chart went out as an image");
+//! // Placed on exactly the character cells the layout reserved.
+//! assert_eq!(image.cells(), Some((106, 7)));
+//! # Ok(())
+//! # }
+//! ```
+
+use std::fmt;
+use std::sync::Arc;
+
+/// How many payload bytes are kept for inspection by default: enough for a
+/// screenful of chart at any plausible cell size, and small enough that a
+/// suite which never looks at an image pays nothing it would notice.
+///
+/// [`TerminalBuilder::capture_graphics`](crate::TerminalBuilder::capture_graphics)
+/// moves it, in either direction.
+pub(crate) const DEFAULT_CAPTURE: usize = 4 << 20;
+
+/// The most payloads retained at once, however small they are. A sliding
+/// window like scrollback's: an application that redraws for an hour must
+/// not grow this without limit, and it is the recent ones an assertion is
+/// about.
+pub(crate) const HISTORY: usize = 512;
+
+/// Which protocol carried a payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GraphicsProtocol {
+    /// The kitty graphics protocol: `APC G <control> ; <base64> ST`.
+    Kitty,
+    /// Sixel: `DCS <params> q <data> ST`.
+    Sixel,
+}
+
+impl fmt::Display for GraphicsProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            GraphicsProtocol::Kitty => "kitty",
+            GraphicsProtocol::Sixel => "sixel",
+        })
+    }
+}
+
+/// What the application asked the terminal to *do* with an image.
+///
+/// Only kitty distinguishes these; a sixel is always drawn where the cursor
+/// stands, so it reports [`TransmitAndPlace`](Self::TransmitAndPlace).
+///
+/// The distinction is not cosmetic: a delete carries no picture, and counting
+/// one as an image transmitted makes "how many images did this frame send?"
+/// answer with the number of *escapes* instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GraphicsAction {
+    /// `a=t`: transmit the data, place it later.
+    Transmit,
+    /// `a=p`: place an image transmitted earlier.
+    Place,
+    /// `a=T`, and every sixel: transmit and place in one go.
+    TransmitAndPlace,
+    /// `a=d`: delete an image, or the placements made from one.
+    Delete,
+    /// `a=f` (transmit a frame), `a=a` (animate), `a=c` (compose) and
+    /// anything else the protocol grows. Named rather than folded into
+    /// [`Transmit`](Self::Transmit): guessing that an unknown action carries
+    /// a picture is how a count starts lying.
+    Other,
+}
+
+impl GraphicsAction {
+    /// Whether this action carries image data — the question
+    /// [`GraphicsSeen::total`] is counting.
+    #[must_use]
+    pub fn carries_image(self) -> bool {
+        matches!(
+            self,
+            GraphicsAction::Transmit | GraphicsAction::TransmitAndPlace
+        )
+    }
+}
+
+/// How the pixels in a payload are encoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GraphicsFormat {
+    /// kitty `f=24`: three bytes a pixel.
+    Rgb,
+    /// kitty `f=32`: four bytes a pixel.
+    Rgba,
+    /// kitty `f=100`: a PNG file. Decoding one is out of scope — termlens
+    /// carries no image codec — so [`GraphicsPayload::decode`] reports it
+    /// as unsupported rather than guessing.
+    Png,
+    /// The sixel data stream itself.
+    Sixel,
+    /// A kitty `f=` value this crate does not know.
+    Other(u32),
+}
+
+impl fmt::Display for GraphicsFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GraphicsFormat::Rgb => f.write_str("rgb"),
+            GraphicsFormat::Rgba => f.write_str("rgba"),
+            GraphicsFormat::Png => f.write_str("png"),
+            GraphicsFormat::Sixel => f.write_str("sixel"),
+            GraphicsFormat::Other(value) => write!(f, "f={value}"),
+        }
+    }
+}
+
+/// One inline image an application transmitted, as observed on the wire.
+///
+/// Read the list from [`GraphicsSeen::payloads`]. Every field is a fact the
+/// application stated or the wire carried — nothing here is inferred from a
+/// rendering, because there is no rendering.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GraphicsPayload {
+    protocol: GraphicsProtocol,
+    action: GraphicsAction,
+    format: GraphicsFormat,
+    compressed: bool,
+    id: Option<u32>,
+    size: Option<(u32, u32)>,
+    cells: Option<(u16, u16)>,
+    chunks: u32,
+    bytes: u64,
+    at: (u16, u16),
+    data: Option<Arc<[u8]>>,
+}
+
+impl fmt::Debug for GraphicsPayload {
+    /// Compact on purpose: a `Screen` is embedded in every error, and a
+    /// derived `Debug` would put a megabyte of base64 into a CI log —
+    /// which is how a failure ends up with no diagnosable output at all.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {:?} {}",
+            self.protocol,
+            self.action,
+            match self.size {
+                Some((w, h)) => format!("{w}x{h}px"),
+                None => "?px".into(),
+            }
+        )?;
+        if let Some((cols, rows)) = self.cells {
+            write!(f, " {cols}x{rows}cells")?;
+        }
+        write!(f, " at {:?}", self.at)?;
+        if let Some(id) = self.id {
+            write!(f, " i={id}")?;
+        }
+        write!(f, " {} {} bytes", self.format, self.bytes)?;
+        if self.compressed {
+            f.write_str(" zlib")?;
+        }
+        if self.chunks > 1 {
+            write!(f, " in {} chunks", self.chunks)?;
+        }
+        if self.data.is_none() {
+            f.write_str(" (not captured)")?;
+        }
+        Ok(())
+    }
+}
+
+impl GraphicsPayload {
+    /// Which protocol carried it.
+    #[must_use]
+    pub fn protocol(&self) -> GraphicsProtocol {
+        self.protocol
+    }
+
+    /// What the application asked the terminal to do with it.
+    #[must_use]
+    pub fn action(&self) -> GraphicsAction {
+        self.action
+    }
+
+    /// How the pixels are encoded.
+    #[must_use]
+    pub fn format(&self) -> GraphicsFormat {
+        self.format
+    }
+
+    /// Whether the data is zlib-compressed (kitty `o=z`).
+    #[must_use]
+    pub fn compressed(&self) -> bool {
+        self.compressed
+    }
+
+    /// The image id the application gave it (kitty `i=`), if any.
+    #[must_use]
+    pub fn id(&self) -> Option<u32> {
+        self.id
+    }
+
+    /// The image's size in pixels, as the application *declared* it — kitty
+    /// `s=`/`v=`, or a sixel's raster attributes.
+    ///
+    /// `None` when nothing declared one, which for sixel means the size is
+    /// implicit in the data; [`decode`](Self::decode) computes it there.
+    #[must_use]
+    pub fn size(&self) -> Option<(u32, u32)> {
+        self.size
+    }
+
+    /// The placement the application pinned, in character cells (kitty
+    /// `c=`/`r=`).
+    ///
+    /// This is the field that keeps an image in step with the text around it:
+    /// an application that lays out a grid in cells and then transmits an
+    /// image of the wrong cell extent draws a picture that slides out from
+    /// under its own labels, and nothing on screen says so.
+    #[must_use]
+    pub fn cells(&self) -> Option<(u16, u16)> {
+        self.cells
+    }
+
+    /// Where the cursor stood when the payload completed, as `(row, col)` —
+    /// which for both protocols is the image's top-left corner.
+    #[must_use]
+    pub fn at(&self) -> (u16, u16) {
+        self.at
+    }
+
+    /// Escapes the transmission was split across. Kitty caps a payload at
+    /// 4096 bytes and continues with `m=1`, so any image of consequence
+    /// arrives in several; they are one payload here.
+    #[must_use]
+    pub fn chunks(&self) -> u32 {
+        self.chunks
+    }
+
+    /// Bytes this payload occupied on the wire, summed over its chunks:
+    /// everything between introducer and terminator, control blocks
+    /// included, since that is what the application actually spent.
+    #[must_use]
+    pub fn bytes(&self) -> u64 {
+        self.bytes
+    }
+
+    /// The image data as it arrived: the base64 body for kitty with the
+    /// control blocks stripped and the chunks joined, and everything after
+    /// the `q` that closes the header for sixel.
+    ///
+    /// `None` when the payload fell past the capture bound — see
+    /// [`TerminalBuilder::capture_graphics`](crate::TerminalBuilder::capture_graphics).
+    /// Deliberately distinct from `Some(&[])`, which is a real transmission
+    /// of nothing.
+    #[must_use]
+    pub fn data(&self) -> Option<&[u8]> {
+        self.data.as_deref()
+    }
+
+    /// Decode the payload into pixels.
+    ///
+    /// Supports kitty `f=24`/`f=32`, zlib-compressed or not, and the sixel
+    /// data stream. Everything else — `f=100` (PNG), an action that carries
+    /// no image, a payload past the capture bound — is an [error naming the
+    /// reason](DecodeError) rather than a `None` a test could mistake for
+    /// "the image was empty".
+    ///
+    /// Decoding is done here, on demand, and never as the bytes arrive: a
+    /// test that only counts payloads should not pay for inflating them.
+    #[cfg(feature = "decode")]
+    pub fn decode(&self) -> Result<Bitmap, DecodeError> {
+        let data = self.data.as_deref().ok_or(DecodeError::NotCaptured)?;
+        match self.protocol {
+            GraphicsProtocol::Kitty => self.decode_kitty(data),
+            GraphicsProtocol::Sixel => decode_sixel(data),
+        }
+    }
+
+    #[cfg(feature = "decode")]
+    fn decode_kitty(&self, data: &[u8]) -> Result<Bitmap, DecodeError> {
+        let (channels, has_alpha) = match self.format {
+            GraphicsFormat::Rgb => (3usize, false),
+            GraphicsFormat::Rgba => (4usize, true),
+            GraphicsFormat::Png => return Err(DecodeError::Unsupported("kitty f=100 (PNG)")),
+            other => {
+                return Err(DecodeError::Unsupported(match other {
+                    GraphicsFormat::Sixel => "a sixel stream sent as kitty data",
+                    _ => "an unknown kitty f= format",
+                }))
+            }
+        };
+        if !self.action.carries_image() {
+            return Err(DecodeError::NoImage(self.action));
+        }
+        let (width, height) = self.size.ok_or(DecodeError::Malformed(
+            "a kitty transmission without s= and v=",
+        ))?;
+        let raw = crate::emu::decode_base64(data).ok_or(DecodeError::Malformed("bad base64"))?;
+        let raw = if self.compressed {
+            miniz_oxide::inflate::decompress_to_vec_zlib(&raw)
+                .map_err(|_| DecodeError::Malformed("zlib data that would not inflate"))?
+        } else {
+            raw
+        };
+        let wanted = (width as usize)
+            .checked_mul(height as usize)
+            .and_then(|pixels| pixels.checked_mul(channels))
+            .ok_or(DecodeError::Malformed("a declared size that overflows"))?;
+        if raw.len() < wanted {
+            return Err(DecodeError::Malformed(
+                "fewer bytes than the declared size needs",
+            ));
+        }
+        let mut pixels = Vec::with_capacity(wanted / channels);
+        for chunk in raw[..wanted].chunks_exact(channels) {
+            pixels.push([
+                chunk[0],
+                chunk[1],
+                chunk[2],
+                if has_alpha { chunk[3] } else { 0xff },
+            ]);
+        }
+        Ok(Bitmap {
+            width,
+            height,
+            pixels,
+        })
+    }
+
+    pub(crate) fn place(&mut self, at: (u16, u16)) {
+        self.at = at;
+    }
+}
+
+/// The pixels one payload depicted.
+///
+/// A decoded image, not a rendering: termlens never composites this onto the
+/// screen grid, and the grid never mentions it. It exists so an assertion can
+/// be about the picture — "the day at week 30 is Primer's brightest green" —
+/// rather than about its size in bytes.
+#[cfg(feature = "decode")]
+#[derive(Clone, PartialEq, Eq)]
+pub struct Bitmap {
+    width: u32,
+    height: u32,
+    pixels: Vec<[u8; 4]>,
+}
+
+#[cfg(feature = "decode")]
+impl fmt::Debug for Bitmap {
+    /// The dimensions, never the pixels: a screen's worth of them in a
+    /// timeout error is a log nobody can read.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Bitmap {}x{}", self.width, self.height)
+    }
+}
+
+#[cfg(feature = "decode")]
+impl Bitmap {
+    /// Width in pixels.
+    #[must_use]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Height in pixels.
+    #[must_use]
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// The pixel at `(x, y)` as RGBA, or `None` when out of bounds.
+    ///
+    /// Alpha is `0` for a sixel pixel no colour was ever written to — sixel
+    /// has no alpha channel, so "transparent" there means "left as the
+    /// terminal found it", which is exactly the distinction an assertion
+    /// about a rounded corner needs.
+    #[must_use]
+    pub fn pixel(&self, x: u32, y: u32) -> Option<[u8; 4]> {
+        if x >= self.width || y >= self.height {
+            return None;
+        }
+        let index = (y as usize) * (self.width as usize) + (x as usize);
+        self.pixels.get(index).copied()
+    }
+
+    /// Every distinct colour in the image, with how many pixels carry it,
+    /// most common first.
+    ///
+    /// The shape of most assertions about a chart: how many greens, and is
+    /// the brightest one the one the palette names.
+    #[must_use]
+    pub fn colours(&self) -> Vec<([u8; 4], u32)> {
+        let mut seen: Vec<([u8; 4], u32)> = Vec::new();
+        for pixel in &self.pixels {
+            match seen.iter_mut().find(|(colour, _)| colour == pixel) {
+                Some((_, count)) => *count += 1,
+                None => seen.push((*pixel, 1)),
+            }
+        }
+        seen.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+        seen
+    }
+}
+
+/// Why a payload could not be decoded.
+#[cfg(feature = "decode")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DecodeError {
+    /// The payload fell past the capture bound, so its bytes were counted
+    /// but not kept. Raise the bound with
+    /// [`TerminalBuilder::capture_graphics`](crate::TerminalBuilder::capture_graphics).
+    NotCaptured,
+    /// The action carries no image at all — a delete, or a bare placement of
+    /// something transmitted earlier.
+    NoImage(GraphicsAction),
+    /// A well-formed payload in an encoding termlens does not decode.
+    Unsupported(&'static str),
+    /// The payload contradicts itself or the protocol.
+    Malformed(&'static str),
+}
+
+#[cfg(feature = "decode")]
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::NotCaptured => f.write_str(
+                "the payload was counted but not kept — raise TerminalBuilder::capture_graphics",
+            ),
+            DecodeError::NoImage(action) => {
+                write!(f, "a {action:?} action carries no image data")
+            }
+            DecodeError::Unsupported(what) => write!(f, "termlens does not decode {what}"),
+            DecodeError::Malformed(what) => write!(f, "the payload carries {what}"),
+        }
+    }
+}
+
+#[cfg(feature = "decode")]
+impl std::error::Error for DecodeError {}
+
+/// Decode a sixel data stream — everything after the `q` that closes the
+/// DCS header — into pixels.
+///
+/// The format in one paragraph: optional raster attributes
+/// (`"Pan;Pad;Ph;Pv`) declare the size; `#n;2;r;g;b` defines colour register
+/// `n` in percent; `#n` selects it; a byte `?`..`~` paints the six pixels of
+/// the current band whose bits it sets; `!<count>` repeats the next such
+/// byte; `$` returns to the left margin within the band; `-` ends the band.
+#[cfg(feature = "decode")]
+fn decode_sixel(data: &[u8]) -> Result<Bitmap, DecodeError> {
+    /// A colour register, or `None` where the application never defined one.
+    type Registers = Vec<Option<[u8; 4]>>;
+
+    fn percent(value: u32) -> u8 {
+        // Sixel colour components are percentages, and the rounding has to
+        // match what a terminal does or every assertion lands one off.
+        ((value.min(100) * 255 + 50) / 100) as u8
+    }
+
+    let mut at = 0usize;
+    let mut declared: Option<(u32, u32)> = None;
+    let mut registers: Registers = vec![None; 256];
+    let mut current = 0usize;
+    // Rows of runs, grown as the data addresses them: a sixel need not
+    // declare its size, and one that does can still overrun it.
+    let mut rows: Vec<Vec<Option<[u8; 4]>>> = Vec::new();
+    let mut band_top = 0usize;
+    let mut x = 0usize;
+    let mut width_seen = 0usize;
+
+    /// Read a `;`-separated run of decimal parameters.
+    fn params(data: &[u8], at: &mut usize) -> Vec<u32> {
+        let mut out = vec![0u32];
+        while *at < data.len() {
+            match data[*at] {
+                b'0'..=b'9' => {
+                    let last = out.last_mut().expect("seeded with one parameter");
+                    *last = last
+                        .saturating_mul(10)
+                        .saturating_add(u32::from(data[*at] - b'0'));
+                }
+                b';' => out.push(0),
+                _ => break,
+            }
+            *at += 1;
+        }
+        out
+    }
+
+    while at < data.len() {
+        match data[at] {
+            b'"' => {
+                at += 1;
+                let raster = params(data, &mut at);
+                if let (Some(&width), Some(&height)) = (raster.get(2), raster.get(3)) {
+                    declared = Some((width, height));
+                }
+            }
+            b'#' => {
+                at += 1;
+                let values = params(data, &mut at);
+                let index = values.first().copied().unwrap_or(0) as usize;
+                if index >= registers.len() {
+                    registers.resize(index + 1, None);
+                }
+                if values.len() >= 5 {
+                    // `#n;1;…` is HLS; only RGB (`2`) is defined here, and a
+                    // guessed conversion would put wrong colours into an
+                    // assertion that reads as exact.
+                    if values[1] != 2 {
+                        return Err(DecodeError::Unsupported("sixel HLS colours"));
+                    }
+                    registers[index] = Some([
+                        percent(values[2]),
+                        percent(values[3]),
+                        percent(values[4]),
+                        0xff,
+                    ]);
+                }
+                current = index;
+            }
+            b'!' => {
+                at += 1;
+                let counts = params(data, &mut at);
+                let count = counts.first().copied().unwrap_or(0) as usize;
+                if at < data.len() && (0x3f..=0x7e).contains(&data[at]) {
+                    let bits = data[at] - 0x3f;
+                    at += 1;
+                    paint(
+                        &mut rows,
+                        &mut width_seen,
+                        band_top,
+                        &mut x,
+                        bits,
+                        count,
+                        registers.get(current).copied().flatten(),
+                    );
+                }
+            }
+            0x3f..=0x7e => {
+                let bits = data[at] - 0x3f;
+                at += 1;
+                paint(
+                    &mut rows,
+                    &mut width_seen,
+                    band_top,
+                    &mut x,
+                    bits,
+                    1,
+                    registers.get(current).copied().flatten(),
+                );
+            }
+            b'$' => {
+                at += 1;
+                x = 0;
+            }
+            b'-' => {
+                at += 1;
+                band_top += 6;
+                x = 0;
+            }
+            // Whitespace between records, and anything else the stream
+            // carries that paints nothing.
+            _ => at += 1,
+        }
+    }
+
+    fn paint(
+        rows: &mut Vec<Vec<Option<[u8; 4]>>>,
+        width_seen: &mut usize,
+        band_top: usize,
+        x: &mut usize,
+        bits: u8,
+        count: usize,
+        colour: Option<[u8; 4]>,
+    ) {
+        for _ in 0..count {
+            if let Some(colour) = colour {
+                for bit in 0..6 {
+                    if bits & (1 << bit) != 0 {
+                        let y = band_top + bit;
+                        if rows.len() <= y {
+                            rows.resize(y + 1, Vec::new());
+                        }
+                        let row = &mut rows[y];
+                        if row.len() <= *x {
+                            row.resize(*x + 1, None);
+                        }
+                        row[*x] = Some(colour);
+                    }
+                }
+            }
+            *x += 1;
+            *width_seen = (*width_seen).max(*x);
+        }
+    }
+
+    let (width, height) = match declared {
+        Some((width, height)) if width > 0 && height > 0 => (width, height),
+        _ => (width_seen as u32, rows.len() as u32),
+    };
+    let mut pixels = Vec::with_capacity((width as usize).saturating_mul(height as usize));
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            pixels.push(
+                rows.get(y)
+                    .and_then(|row| row.get(x))
+                    .copied()
+                    .flatten()
+                    // Untouched: sixel has no alpha, so a pixel never
+                    // painted is the terminal's own background showing
+                    // through, which is not a colour we may invent.
+                    .unwrap_or([0, 0, 0, 0]),
+            );
+        }
+    }
+    Ok(Bitmap {
+        width,
+        height,
+        pixels,
+    })
+}
+
+/// Inline graphics payloads the application transmitted, as observed at one
+/// snapshot.
+///
+/// Read it from a [`Screen`](crate::Screen) via
+/// [`Screen::graphics`](crate::Screen::graphics). The counters are
+/// cumulative and monotonic, so a test takes a delta around an action rather
+/// than resetting a gauge; [`payloads`](Self::payloads) is the bounded tail
+/// of what was captured.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GraphicsSeen {
+    pub(crate) counts: GraphicsCounts,
+    pub(crate) payloads: Arc<Vec<GraphicsPayload>>,
+}
+
+impl GraphicsSeen {
+    pub(crate) fn new(counts: GraphicsCounts, payloads: Arc<Vec<GraphicsPayload>>) -> Self {
+        Self { counts, payloads }
+    }
+}
+
+/// The cumulative counters, kept by the sequence tracker as bytes arrive.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct GraphicsCounts {
+    pub(crate) kitty: u32,
+    pub(crate) sixel: u32,
+    pub(crate) deletes: u32,
+    pub(crate) bytes: u64,
+}
+
+impl GraphicsCounts {
+    /// Count one completed payload. Bytes are counted for every action —
+    /// a delete costs the wire something too — but only an action that
+    /// carries a picture counts as an image.
+    pub(crate) fn record(&mut self, payload: &GraphicsPayload) {
+        self.bytes += payload.bytes();
+        if payload.action() == GraphicsAction::Delete {
+            self.deletes += 1;
+        }
+        if !payload.action().carries_image() {
+            return;
+        }
+        match payload.protocol() {
+            GraphicsProtocol::Kitty => self.kitty += 1,
+            GraphicsProtocol::Sixel => self.sixel += 1,
+        }
+    }
+}
+
+impl GraphicsSeen {
+    /// Kitty images transmitted (`APC G … ST`).
+    ///
+    /// **Images, not escapes.** A transmission split across the protocol's
+    /// 4096-byte chunks is one image, and an action carrying no picture — a
+    /// delete above all — is not one at all.
+    #[must_use]
+    pub fn kitty(&self) -> u32 {
+        self.counts.kitty
+    }
+
+    /// Sixel images transmitted (`DCS q … ST`).
+    #[must_use]
+    pub fn sixel(&self) -> u32 {
+        self.counts.sixel
+    }
+
+    /// Images of either protocol.
+    #[must_use]
+    pub fn total(&self) -> u32 {
+        self.counts.kitty + self.counts.sixel
+    }
+
+    /// Kitty delete commands (`a=d`) — images taken *off* the screen.
+    ///
+    /// Counted apart from [`total`](Self::total) because a delete carries no
+    /// picture: an application that tears down what it drew and one that
+    /// draws twice as much are opposite behaviours, and folding them
+    /// together made the difference invisible.
+    #[must_use]
+    pub fn deletes(&self) -> u32 {
+        self.counts.deletes
+    }
+
+    /// True when the application has transmitted no inline graphics at all.
+    ///
+    /// Deletes do not count: an application whose only graphics traffic is a
+    /// teardown has drawn nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.total() == 0
+    }
+
+    /// Total payload bytes across both protocols and every action, counted
+    /// the same way for each: everything between the introducer and the
+    /// terminator.
+    #[must_use]
+    pub fn bytes(&self) -> u64 {
+        self.counts.bytes
+    }
+
+    /// The payloads themselves, oldest first — what went out, where it was
+    /// placed, and, with the `decode` feature, what it depicted.
+    ///
+    /// Bounded, like scrollback: the most recent payloads within the capture
+    /// bound, which
+    /// [`TerminalBuilder::capture_graphics`](crate::TerminalBuilder::capture_graphics)
+    /// sets. The counters above stay truthful whatever the bound, so a test
+    /// that only counts is never affected by one.
+    #[must_use]
+    pub fn payloads(&self) -> &[GraphicsPayload] {
+        &self.payloads
+    }
+
+    /// The most recent payload, if any.
+    #[must_use]
+    pub fn last(&self) -> Option<&GraphicsPayload> {
+        self.payloads.last()
+    }
+
+    /// Counters without payloads, for tests that assemble a `TermState` by
+    /// hand rather than driving an emulator.
+    #[cfg(test)]
+    pub(crate) fn for_test(kitty: u32, sixel: u32, deletes: u32, bytes: u64) -> Self {
+        Self {
+            counts: GraphicsCounts {
+                kitty,
+                sixel,
+                deletes,
+                bytes,
+            },
+            payloads: Arc::new(Vec::new()),
+        }
+    }
+}
+
+/// A payload under construction, owned by the sequence tracker: kitty splits
+/// one image across escapes, so a payload is not complete until an escape
+/// arrives without `m=1`.
+#[derive(Debug)]
+pub(crate) struct GraphicsBuilder {
+    protocol: Option<GraphicsProtocol>,
+    action: GraphicsAction,
+    format: GraphicsFormat,
+    compressed: bool,
+    id: Option<u32>,
+    size: Option<(u32, u32)>,
+    cells: Option<(u16, u16)>,
+    chunks: u32,
+    bytes: u64,
+    data: Vec<u8>,
+    /// Set once any chunk arrived past the capture bound. The payload then
+    /// reports no data at all rather than a prefix of one.
+    dropped: bool,
+}
+
+impl Default for GraphicsBuilder {
+    fn default() -> Self {
+        Self {
+            protocol: None,
+            action: GraphicsAction::Other,
+            format: GraphicsFormat::Rgba,
+            compressed: false,
+            id: None,
+            size: None,
+            cells: None,
+            chunks: 0,
+            bytes: 0,
+            data: Vec::new(),
+            dropped: false,
+        }
+    }
+}
+
+impl GraphicsBuilder {
+    /// True once a kitty escape has opened a transmission that later
+    /// escapes continue.
+    pub(crate) fn in_progress(&self) -> bool {
+        self.protocol.is_some()
+    }
+
+    /// Take on the facts of a kitty control block. Only the first escape of
+    /// a chunked transmission carries one; the continuations carry `m=` and
+    /// nothing else, so nothing here overwrites what is already known.
+    pub(crate) fn kitty(&mut self, control: &[u8]) {
+        if self.protocol.is_none() {
+            self.protocol = Some(GraphicsProtocol::Kitty);
+            self.action = match key(control, b"a") {
+                Some(b"t") => GraphicsAction::Transmit,
+                Some(b"p") => GraphicsAction::Place,
+                // `a=T` is the default when a transmission names no action.
+                Some(b"T") | None => GraphicsAction::TransmitAndPlace,
+                Some(b"d") => GraphicsAction::Delete,
+                Some(_) => GraphicsAction::Other,
+            };
+            self.format = match number(control, b"f") {
+                Some(24) => GraphicsFormat::Rgb,
+                // 32 is the protocol's default.
+                Some(32) | None => GraphicsFormat::Rgba,
+                Some(100) => GraphicsFormat::Png,
+                Some(other) => GraphicsFormat::Other(other),
+            };
+            self.compressed = key(control, b"o") == Some(b"z");
+            self.id = number(control, b"i");
+            self.size = match (number(control, b"s"), number(control, b"v")) {
+                (Some(width), Some(height)) => Some((width, height)),
+                _ => None,
+            };
+            self.cells = match (number(control, b"c"), number(control, b"r")) {
+                (Some(cols), Some(rows)) => Some((
+                    cols.min(u32::from(u16::MAX)) as u16,
+                    rows.min(u32::from(u16::MAX)) as u16,
+                )),
+                _ => None,
+            };
+        }
+    }
+
+    /// Take on the facts of a sixel header: the raster attributes are inside
+    /// the data, so only the protocol is settled here.
+    pub(crate) fn sixel(&mut self) {
+        self.protocol = Some(GraphicsProtocol::Sixel);
+        self.action = GraphicsAction::TransmitAndPlace;
+        self.format = GraphicsFormat::Sixel;
+    }
+
+    /// Add one escape's worth of wire cost and image data. `complete` is
+    /// false when the capture bound cut this chunk short — the counts stay
+    /// exact either way, and the data is dropped entirely rather than kept
+    /// as a prefix that would decode into a plausible-looking wrong picture.
+    pub(crate) fn chunk(&mut self, bytes: u64, data: &[u8], complete: bool) {
+        self.chunks += 1;
+        self.bytes += bytes;
+        if complete && !self.dropped {
+            self.data.extend_from_slice(data);
+        } else {
+            self.dropped = true;
+            self.data = Vec::new();
+        }
+    }
+
+    /// Finish the payload. `at` is stamped later, by the emulator, once the
+    /// grid has caught up with the terminator.
+    pub(crate) fn finish(&mut self) -> Option<GraphicsPayload> {
+        let protocol = self.protocol.take()?;
+        let mut size = self.size;
+        if protocol == GraphicsProtocol::Sixel {
+            size = raster_size(&self.data).or(size);
+        }
+        let payload = GraphicsPayload {
+            protocol,
+            action: self.action,
+            format: self.format,
+            compressed: self.compressed,
+            id: self.id,
+            size,
+            cells: self.cells,
+            chunks: self.chunks,
+            bytes: self.bytes,
+            at: (0, 0),
+            data: (!self.dropped)
+                .then(|| Arc::from(std::mem::take(&mut self.data).into_boxed_slice())),
+        };
+        *self = Self::default();
+        Some(payload)
+    }
+}
+
+/// The `"Pan;Pad;Ph;Pv` raster attributes at the head of a sixel stream, if
+/// it declares any.
+fn raster_size(data: &[u8]) -> Option<(u32, u32)> {
+    let at = data.iter().position(|&b| b == b'"')?;
+    // Only a leading raster record describes the whole image; one appearing
+    // after pixels have been painted is a different statement.
+    if data[..at].iter().any(|b| (0x3f..=0x7e).contains(b)) {
+        return None;
+    }
+    let mut values = vec![0u32];
+    for &b in &data[at + 1..] {
+        match b {
+            b'0'..=b'9' => {
+                let last = values.last_mut().expect("seeded with one parameter");
+                *last = last.saturating_mul(10).saturating_add(u32::from(b - b'0'));
+            }
+            b';' => values.push(0),
+            _ => break,
+        }
+    }
+    match (values.get(2), values.get(3)) {
+        (Some(&width), Some(&height)) if width > 0 && height > 0 => Some((width, height)),
+        _ => None,
+    }
+}
+
+/// The raw value of `name` in a kitty control block (`a=T,i=3,f=32`).
+fn key<'a>(control: &'a [u8], name: &[u8]) -> Option<&'a [u8]> {
+    control.split(|&b| b == b',').find_map(|pair| {
+        let (found, value) = split_once(pair, b'=')?;
+        (found == name).then_some(value)
+    })
+}
+
+/// The numeric value of `name`, if it carries one.
+fn number(control: &[u8], name: &[u8]) -> Option<u32> {
+    std::str::from_utf8(key(control, name)?).ok()?.parse().ok()
+}
+
+fn split_once(bytes: &[u8], separator: u8) -> Option<(&[u8], &[u8])> {
+    let at = bytes.iter().position(|&b| b == separator)?;
+    Some((&bytes[..at], &bytes[at + 1..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kitty_payload(control: &[u8], data: &[u8]) -> GraphicsPayload {
+        let mut builder = GraphicsBuilder::default();
+        builder.kitty(control);
+        builder.chunk(data.len() as u64, data, true);
+        builder.finish().expect("a payload")
+    }
+
+    #[test]
+    fn a_kitty_control_block_yields_every_fact_it_states() {
+        let payload = kitty_payload(b"a=T,q=2,f=32,o=z,s=954,v=133,i=7,c=106,r=7", b"AAAA");
+        assert_eq!(payload.protocol(), GraphicsProtocol::Kitty);
+        assert_eq!(payload.action(), GraphicsAction::TransmitAndPlace);
+        assert_eq!(payload.format(), GraphicsFormat::Rgba);
+        assert!(payload.compressed());
+        assert_eq!(payload.id(), Some(7));
+        assert_eq!(payload.size(), Some((954, 133)));
+        assert_eq!(payload.cells(), Some((106, 7)));
+        assert_eq!(payload.data(), Some(&b"AAAA"[..]));
+    }
+
+    #[test]
+    fn the_protocols_defaults_are_the_protocols_defaults() {
+        // A transmission naming neither action nor format is `a=T,f=32`.
+        let payload = kitty_payload(b"s=1,v=1", b"AAAA");
+        assert_eq!(payload.action(), GraphicsAction::TransmitAndPlace);
+        assert_eq!(payload.format(), GraphicsFormat::Rgba);
+        assert!(!payload.compressed());
+    }
+
+    #[test]
+    fn a_delete_is_not_an_image() {
+        let payload = kitty_payload(b"a=d,d=I,i=1,q=2", b"");
+        assert_eq!(payload.action(), GraphicsAction::Delete);
+        assert!(!payload.action().carries_image());
+    }
+
+    #[test]
+    fn an_unknown_action_is_not_guessed_to_carry_one() {
+        let payload = kitty_payload(b"a=z,i=1", b"");
+        assert_eq!(payload.action(), GraphicsAction::Other);
+        assert!(!payload.action().carries_image());
+    }
+
+    #[test]
+    fn chunks_join_into_one_payload() {
+        let mut builder = GraphicsBuilder::default();
+        builder.kitty(b"a=T,f=32,s=2,v=1,m=1");
+        builder.chunk(20, b"AAAA", true);
+        builder.chunk(10, b"BBBB", true);
+        let payload = builder.finish().expect("a payload");
+        assert_eq!(payload.chunks(), 2);
+        assert_eq!(payload.bytes(), 30);
+        assert_eq!(payload.data(), Some(&b"AAAABBBB"[..]));
+    }
+
+    #[test]
+    fn a_payload_past_the_bound_is_counted_and_not_kept() {
+        let mut builder = GraphicsBuilder::default();
+        builder.kitty(b"a=T,f=32,s=2,v=1");
+        builder.chunk(64, b"AAAABBBB", false);
+        let payload = builder.finish().expect("a payload");
+        assert_eq!(payload.bytes(), 64, "the cost is still known");
+        assert_eq!(payload.data(), None, "and the bytes are not kept");
+    }
+
+    #[test]
+    fn a_sixel_reads_its_size_off_its_raster_attributes() {
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(30, b"\"1;1;18;12#0;2;100;100;100~", true);
+        let payload = builder.finish().expect("a payload");
+        assert_eq!(payload.protocol(), GraphicsProtocol::Sixel);
+        assert_eq!(payload.size(), Some((18, 12)));
+        assert_eq!(payload.format(), GraphicsFormat::Sixel);
+    }
+
+    #[test]
+    fn a_sixel_that_declares_no_size_says_so_rather_than_guessing() {
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(10, b"#0;2;100;100;100~~~", true);
+        assert_eq!(builder.finish().expect("a payload").size(), None);
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn a_kitty_rgba_transmission_decodes_to_its_pixels() {
+        // Two pixels: opaque red, half-transparent blue.
+        let raw = [0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x80];
+        let data = base64(&raw);
+        let payload = kitty_payload(b"a=T,f=32,s=2,v=1", data.as_bytes());
+        let bitmap = payload.decode().expect("decodes");
+        assert_eq!((bitmap.width(), bitmap.height()), (2, 1));
+        assert_eq!(bitmap.pixel(0, 0), Some([0xff, 0, 0, 0xff]));
+        assert_eq!(bitmap.pixel(1, 0), Some([0, 0, 0xff, 0x80]));
+        assert_eq!(bitmap.pixel(2, 0), None, "out of bounds is None");
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn an_rgb_transmission_is_opaque() {
+        let data = base64(&[0x11, 0x22, 0x33]);
+        let payload = kitty_payload(b"a=T,f=24,s=1,v=1", data.as_bytes());
+        let bitmap = payload.decode().expect("decodes");
+        assert_eq!(bitmap.pixel(0, 0), Some([0x11, 0x22, 0x33, 0xff]));
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn a_compressed_transmission_is_inflated_first() {
+        let raw = vec![0x40u8; 4 * 16 * 16];
+        let data = base64(&miniz_oxide::deflate::compress_to_vec_zlib(&raw, 6));
+        let payload = kitty_payload(b"a=T,f=32,o=z,s=16,v=16", data.as_bytes());
+        let bitmap = payload.decode().expect("decodes");
+        assert_eq!((bitmap.width(), bitmap.height()), (16, 16));
+        assert_eq!(bitmap.pixel(15, 15), Some([0x40, 0x40, 0x40, 0x40]));
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn every_refusal_names_its_reason() {
+        let png = kitty_payload(b"a=T,f=100,s=1,v=1", b"AAAA");
+        assert!(matches!(png.decode(), Err(DecodeError::Unsupported(_))));
+
+        let delete = kitty_payload(b"a=d,i=1", b"");
+        assert!(matches!(
+            delete.decode(),
+            Err(DecodeError::NoImage(GraphicsAction::Delete))
+        ));
+
+        let short = kitty_payload(b"a=T,f=32,s=64,v=64", b"AAAA");
+        assert!(matches!(short.decode(), Err(DecodeError::Malformed(_))));
+
+        let sizeless = kitty_payload(b"a=T,f=32", b"AAAA");
+        assert!(matches!(sizeless.decode(), Err(DecodeError::Malformed(_))));
+
+        let mut builder = GraphicsBuilder::default();
+        builder.kitty(b"a=T,f=32,s=2,v=1");
+        builder.chunk(64, b"AAAABBBB", false);
+        let dropped = builder.finish().expect("a payload");
+        assert_eq!(dropped.decode(), Err(DecodeError::NotCaptured));
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn a_sixel_decodes_into_the_pixels_it_paints() {
+        // A 4x6 image: register 0 is white, and `~` sets all six rows of the
+        // band, so a run of four fills the whole thing.
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(40, b"\"1;1;4;6#0;2;100;100;100!4~-", true);
+        let bitmap = builder
+            .finish()
+            .expect("a payload")
+            .decode()
+            .expect("decodes");
+        assert_eq!((bitmap.width(), bitmap.height()), (4, 6));
+        for y in 0..6 {
+            for x in 0..4 {
+                assert_eq!(bitmap.pixel(x, y), Some([255, 255, 255, 255]), "({x},{y})");
+            }
+        }
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn a_sixel_pixel_nothing_painted_is_transparent_rather_than_black() {
+        // `@` sets only the top row of the band; the five below it were
+        // never written, and sixel has no alpha to say so with.
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(30, b"\"1;1;1;6#0;2;0;100;0@-", true);
+        let bitmap = builder
+            .finish()
+            .expect("a payload")
+            .decode()
+            .expect("decodes");
+        assert_eq!(bitmap.pixel(0, 0), Some([0, 255, 0, 255]));
+        assert_eq!(bitmap.pixel(0, 1), Some([0, 0, 0, 0]));
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn sixel_bands_stack_downwards_and_carriage_returns_overprint() {
+        // Two bands, and a `$` that goes back to paint the second colour
+        // over the first band's second column.
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(60, b"\"1;1;2;12#0;2;100;0;0~~$#1;2;0;0;100?~-#0??-", true);
+        let bitmap = builder
+            .finish()
+            .expect("a payload")
+            .decode()
+            .expect("decodes");
+        assert_eq!((bitmap.width(), bitmap.height()), (2, 12));
+        assert_eq!(bitmap.pixel(0, 0), Some([255, 0, 0, 255]), "first colour");
+        assert_eq!(bitmap.pixel(1, 0), Some([0, 0, 255, 255]), "overprinted");
+        assert_eq!(bitmap.pixel(0, 6), Some([0, 0, 0, 0]), "second band");
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn a_sixel_without_raster_attributes_takes_its_size_from_its_data() {
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(20, b"#0;2;100;100;100!3~-", true);
+        let bitmap = builder
+            .finish()
+            .expect("a payload")
+            .decode()
+            .expect("decodes");
+        assert_eq!((bitmap.width(), bitmap.height()), (3, 6));
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn colours_are_counted_most_common_first() {
+        let mut raw = vec![0u8; 0];
+        for _ in 0..3 {
+            raw.extend_from_slice(&[1, 2, 3, 255]);
+        }
+        raw.extend_from_slice(&[9, 9, 9, 255]);
+        let data = base64(&raw);
+        let payload = kitty_payload(b"a=T,f=32,s=4,v=1", data.as_bytes());
+        let colours = payload.decode().expect("decodes").colours();
+        assert_eq!(colours[0], ([1, 2, 3, 255], 3));
+        assert_eq!(colours[1], ([9, 9, 9, 255], 1));
+    }
+
+    #[cfg(feature = "decode")]
+    #[test]
+    fn hls_colours_are_refused_rather_than_converted() {
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(30, b"\"1;1;1;6#0;1;120;50;100~-", true);
+        assert!(matches!(
+            builder.finish().expect("a payload").decode(),
+            Err(DecodeError::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn the_debug_rendering_stays_short_enough_for_a_log() {
+        let payload = kitty_payload(b"a=T,f=32,o=z,s=954,v=133,i=7,c=106,r=7", &[b'A'; 4096]);
+        let rendered = format!("{payload:?}");
+        assert!(rendered.len() < 120, "{rendered}");
+        assert!(rendered.contains("954x133px"), "{rendered}");
+        assert!(rendered.contains("106x7cells"), "{rendered}");
+        assert!(!rendered.contains("AAAA"), "the data must not be in it");
+    }
+
+    /// The encoder side of what `decode_base64` undoes — tests only.
+    #[cfg(feature = "decode")]
+    fn base64(data: &[u8]) -> String {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = String::new();
+        for group in data.chunks(3) {
+            let mut bits = 0u32;
+            for (index, byte) in group.iter().enumerate() {
+                bits |= u32::from(*byte) << (16 - 8 * index);
+            }
+            for index in 0..=group.len() {
+                out.push(ALPHABET[(bits >> (18 - 6 * index) & 0x3f) as usize] as char);
+            }
+            for _ in group.len()..3 {
+                out.push('=');
+            }
+        }
+        out
+    }
+}

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -93,14 +93,20 @@
 
 mod emu;
 mod error;
+mod graphics;
 mod keys;
 mod screen;
 mod terminal;
 mod wait;
 
 pub use error::{Error, Result};
+#[cfg(feature = "decode")]
+pub use graphics::{Bitmap, DecodeError};
+pub use graphics::{
+    GraphicsAction, GraphicsFormat, GraphicsPayload, GraphicsProtocol, GraphicsSeen,
+};
 pub use keys::{Chord, Input, Key};
-pub use screen::{Cell, Clipboard, Color, GraphicsSeen, MouseMode, Screen, Style};
+pub use screen::{Cell, Clipboard, Color, MouseMode, Screen, Style};
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use unicode_normalization::UnicodeNormalization;
 
+use crate::graphics::GraphicsSeen;
+
 /// A terminal color, as reported by the emulator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Color {
@@ -80,71 +82,6 @@ pub enum MouseMode {
     /// Any-event tracking (`CSI ?1003 h`): presses, releases, and all
     /// motion.
     AnyMotion,
-}
-
-/// Inline graphics payloads the application transmitted, as counted at one
-/// snapshot.
-///
-/// Read it from a snapshot via [`Screen::graphics`]. Counting is not
-/// rendering and not a claim of support: DA1 still declines both protocols,
-/// which is exactly why an application that emits them anyway is worth
-/// catching.
-///
-/// The assertion this exists for is as often the negative one — "this must
-/// render as text and **never** be transmitted as an image, so it looks the
-/// same in every terminal" — which is why [`is_empty`](Self::is_empty) is a
-/// method rather than something to spell out.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct GraphicsSeen {
-    kitty: u32,
-    sixel: u32,
-    bytes: u64,
-}
-
-impl GraphicsSeen {
-    /// Kitty graphics payloads (`APC G … ST`) seen so far.
-    #[must_use]
-    pub fn kitty(&self) -> u32 {
-        self.kitty
-    }
-
-    /// Sixel payloads (`DCS q … ST`) seen so far.
-    #[must_use]
-    pub fn sixel(&self) -> u32 {
-        self.sixel
-    }
-
-    /// Payloads of either protocol.
-    #[must_use]
-    pub fn total(&self) -> u32 {
-        self.kitty + self.sixel
-    }
-
-    /// True when the application has transmitted no inline graphics at all.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.total() == 0
-    }
-
-    /// Total payload bytes across both protocols: everything between the
-    /// introducer and the terminator, counted the same way for each.
-    ///
-    /// A size rather than the data itself: a test asserts that an image was
-    /// or was not sent, and how big it was — not what it depicted, which
-    /// nothing here can decode.
-    #[must_use]
-    pub fn bytes(&self) -> u64 {
-        self.bytes
-    }
-
-    pub(crate) fn record(&mut self, kitty: bool, bytes: u64) {
-        if kitty {
-            self.kitty += 1;
-        } else {
-            self.sixel += 1;
-        }
-        self.bytes += bytes;
-    }
 }
 
 /// What an application copied with `OSC 52`, as observed at one snapshot.
@@ -530,9 +467,13 @@ impl Screen {
     /// Observing is not rendering, and not a claim of support: DA1 goes on
     /// declining both protocols, which is precisely why an application that
     /// transmits one anyway is worth catching.
+    ///
+    /// The payloads themselves — placement, declared size, format, and with
+    /// the `decode` feature the pixels — are on
+    /// [`GraphicsSeen::payloads`](crate::GraphicsSeen::payloads).
     #[must_use]
     pub fn graphics(&self) -> GraphicsSeen {
-        self.state.graphics
+        self.state.graphics.clone()
     }
 
     /// The cell at `(row, col)`, or `None` when out of bounds.
@@ -1417,12 +1358,7 @@ mod tests {
             clipboard: Some(Arc::new(Clipboard::new("c", Some("copied".into())))),
             bells: 3,
             focus_events: true,
-            graphics: {
-                let mut g = GraphicsSeen::default();
-                g.record(true, 120);
-                g.record(false, 40);
-                g
-            },
+            graphics: GraphicsSeen::for_test(1, 1, 2, 160),
             repaints: 9,
             scrollback: Arc::from([Arc::from("scrolled away")]),
         };
@@ -1440,6 +1376,7 @@ mod tests {
         assert_eq!(s.graphics().kitty(), 1);
         assert_eq!(s.graphics().sixel(), 1);
         assert_eq!(s.graphics().total(), 2);
+        assert_eq!(s.graphics().deletes(), 2);
         assert_eq!(s.graphics().bytes(), 160);
         assert!(!s.graphics().is_empty());
         assert!(GraphicsSeen::default().is_empty());

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -129,6 +129,8 @@ impl FrameTiming {
 /// string rather than a grid of cells.
 const DEFAULT_SCROLLBACK: usize = 1000;
 
+use crate::graphics::DEFAULT_CAPTURE;
+
 /// Reply bytes that may be waiting for the writer thread before the drain
 /// starts discarding query replies.
 ///
@@ -862,6 +864,7 @@ pub struct TerminalBuilder {
     scrollback: usize,
     cell_size: Option<(u16, u16)>,
     graphics: Graphics,
+    capture_graphics: usize,
 }
 
 impl Default for TerminalBuilder {
@@ -880,6 +883,7 @@ impl Default for TerminalBuilder {
             scrollback: DEFAULT_SCROLLBACK,
             cell_size: None,
             graphics: Graphics::None,
+            capture_graphics: DEFAULT_CAPTURE,
         }
     }
 }
@@ -1016,6 +1020,25 @@ impl TerminalBuilder {
     #[must_use]
     pub fn scrollback(mut self, rows: usize) -> Self {
         self.scrollback = rows;
+        self
+    }
+
+    /// How many bytes of inline graphics payload to keep for inspection.
+    ///
+    /// [`GraphicsSeen::payloads`](crate::GraphicsSeen::payloads) hands back
+    /// the images an application transmitted — where each was placed, how
+    /// big it declared itself, and with the `decode` feature what it
+    /// depicted. Keeping them costs memory, so the newest are kept within
+    /// this budget and older ones are dropped; a single payload larger than
+    /// the whole budget is counted but not kept, and says so rather than
+    /// decoding a prefix of itself into a plausible wrong picture.
+    ///
+    /// The default is 4 MiB. `0` keeps no data at all — the counters and
+    /// every declared fact stay exact, which is all a test that only asks
+    /// "did an image go out?" ever reads.
+    #[must_use]
+    pub fn capture_graphics(mut self, bytes: usize) -> Self {
+        self.capture_graphics = bytes;
         self
     }
 
@@ -1220,7 +1243,12 @@ impl TerminalBuilder {
         // memory bound instead of on a queue-slot count.
         let queued_bytes = Arc::new(AtomicUsize::new(0));
         let shared = Arc::new(Monitor::new(EmuState::new(
-            Box::new(Vt100Emulator::new(self.rows, self.cols, self.scrollback)),
+            Box::new(Vt100Emulator::new(
+                self.rows,
+                self.cols,
+                self.scrollback,
+                self.capture_graphics,
+            )),
             Responder {
                 respond: self.answer_queries,
                 background: self.background,

--- a/crates/termlens/tests/graphics.rs
+++ b/crates/termlens/tests/graphics.rs
@@ -1,0 +1,268 @@
+//! Inline graphics, end to end: a real program transmits a real image into a
+//! real PTY, and the test asserts what came off the wire.
+//!
+//! The `image-echo` fixture draws a 4×2 image whose every pixel is known, at
+//! a known cursor position, with labels above and below it. That makes three
+//! classes of claim assertable that no content predicate can reach, because
+//! none of them changes a cell:
+//!
+//! - **that** an image went out, and how many — counted as images rather
+//!   than as escapes, so the protocol's 4096-byte chunking cannot inflate it
+//!   and a delete cannot pose as a transmission;
+//! - **where** it landed and how big it declared itself, which is what keeps
+//!   a picture in step with the text laid out around it;
+//! - **what it depicted**, with the `decode` feature.
+
+use std::time::Duration;
+
+use termlens::{GraphicsAction, GraphicsFormat, GraphicsProtocol, Screen, Terminal};
+
+mod common;
+use common as util;
+
+fn spawn(mode: &str) -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .size(40, 10)
+        .timeout(Duration::from_secs(30))
+        .env_clear()
+        .arg(mode)
+        .spawn(util::fixture_bin("image-echo"))
+}
+
+/// The fixture draws its lower label last, so a screen carrying it carries
+/// the payload above it too.
+fn drawn(screen: &Screen) -> bool {
+    screen.contains("done")
+}
+
+/// Drive one mode to completion and hand back the settled screen.
+fn run(mode: &str) -> termlens::Result<(Terminal, Screen)> {
+    let mut terminal = spawn(mode)?;
+    terminal.wait_until(drawn)?;
+    let screen = terminal.screen();
+    Ok((terminal, screen))
+}
+
+#[test]
+fn a_transmitted_image_is_counted_and_described() -> termlens::Result<()> {
+    let (_terminal, screen) = run("kitty")?;
+    let seen = screen.graphics();
+    assert_eq!(seen.kitty(), 1, "one image: {seen:?}");
+    assert_eq!(seen.sixel(), 0);
+    assert_eq!(seen.deletes(), 0);
+    assert!(!seen.is_empty());
+
+    let image = seen.last().expect("a payload");
+    assert_eq!(image.protocol(), GraphicsProtocol::Kitty);
+    assert_eq!(image.action(), GraphicsAction::TransmitAndPlace);
+    assert_eq!(image.format(), GraphicsFormat::Rgba);
+    assert!(image.compressed(), "the fixture zlib's it");
+    assert_eq!(image.id(), Some(7));
+    assert_eq!(image.size(), Some((4, 2)), "the size it declared");
+    assert_eq!(image.cells(), Some((2, 1)), "pinned to the cells reserved");
+    assert!(image.bytes() > 0);
+    Ok(())
+}
+
+#[test]
+fn an_image_is_stamped_with_the_cell_it_was_placed_on() -> termlens::Result<()> {
+    // The fixture moves to row 2, column 5 (1-based) and transmits there.
+    // This is the one fact about an image that lives in the grid rather than
+    // in the payload — and the one an application gets wrong when a picture
+    // drifts out from under its own labels.
+    for mode in ["kitty", "sixel"] {
+        let (_terminal, screen) = run(mode)?;
+        let seen = screen.graphics();
+        let image = seen.last().expect("a payload");
+        assert_eq!(image.at(), (1, 4), "{mode} landed at {:?}", image.at());
+    }
+    Ok(())
+}
+
+#[test]
+fn a_chunked_transmission_is_one_image_not_three() -> termlens::Result<()> {
+    // The protocol caps a payload at 4096 bytes and continues with `m=1`, so
+    // every image of consequence arrives in several escapes. Counting each
+    // one reported a single chart as several pictures — and the
+    // continuations carry no control block, so nothing could be said about
+    // those "pictures" either.
+    let (_terminal, chunked) = run("kitty-chunks")?;
+    let (_terminal, whole) = run("kitty-plain")?;
+
+    let chunked_seen = chunked.graphics();
+    let whole_seen = whole.graphics();
+    assert_eq!(chunked_seen.kitty(), 1, "{chunked_seen:?}");
+    assert_eq!(whole_seen.kitty(), 1, "{whole_seen:?}");
+
+    let split = chunked_seen.last().expect("a payload");
+    let single = whole_seen.last().expect("a payload");
+    assert!(split.chunks() > 1, "the fixture split it: {split:?}");
+    assert_eq!(single.chunks(), 1);
+    // Same image, so the same data — however it was cut up on the way.
+    assert_eq!(split.data(), single.data());
+    assert_eq!(split.size(), single.size());
+    Ok(())
+}
+
+#[test]
+fn a_delete_is_not_an_image_transmitted() -> termlens::Result<()> {
+    // An application that tears down what it drew and one that draws twice
+    // as much are opposite behaviours; folding a delete into the image count
+    // made them the same number.
+    let (_terminal, screen) = run("delete")?;
+    let seen = screen.graphics();
+    assert_eq!(seen.kitty(), 1, "one image: {seen:?}");
+    assert_eq!(seen.deletes(), 1, "and one teardown: {seen:?}");
+    assert_eq!(seen.total(), 1);
+
+    let payloads = seen.payloads();
+    assert_eq!(
+        payloads.len(),
+        2,
+        "both are still on the wire: {payloads:?}"
+    );
+    assert_eq!(payloads[1].action(), GraphicsAction::Delete);
+    assert_eq!(payloads[1].id(), Some(7));
+    assert!(!payloads[1].action().carries_image());
+    Ok(())
+}
+
+#[test]
+fn a_program_that_draws_no_image_reports_none() -> termlens::Result<()> {
+    // The negative assertion, which is the one this exists for as often as
+    // not: "this must render as text in every terminal, and never go out as
+    // an image".
+    let (_terminal, screen) = run("none")?;
+    let seen = screen.graphics();
+    assert!(seen.is_empty(), "{seen:?}");
+    assert_eq!(seen.bytes(), 0);
+    assert!(seen.payloads().is_empty());
+    assert!(seen.last().is_none());
+    Ok(())
+}
+
+#[test]
+fn the_image_leaves_the_text_around_it_alone() -> termlens::Result<()> {
+    // Nothing about a payload touches the grid, which is exactly why the
+    // counters exist — and it is worth one assertion that the emulator did
+    // not quietly start rendering one.
+    let (_terminal, screen) = run("kitty")?;
+    assert!(screen.contains("label above"), "{screen}");
+    assert!(screen.contains("label below"), "{screen}");
+    // The payload was transmitted at row 1, and the row is untouched.
+    assert_eq!(screen.row_text(1).trim(), "", "{screen}");
+    Ok(())
+}
+
+#[test]
+fn a_bounded_capture_keeps_the_counts_and_drops_the_bytes() -> termlens::Result<()> {
+    // The budget is a memory bound, not an observation bound: every count
+    // and every declared fact survives it, and only the data goes.
+    let mut terminal = Terminal::builder()
+        .size(40, 10)
+        .timeout(Duration::from_secs(30))
+        .env_clear()
+        .capture_graphics(0)
+        .arg("kitty")
+        .spawn(util::fixture_bin("image-echo"))?;
+    terminal.wait_until(drawn)?;
+    let screen = terminal.screen();
+    let seen = screen.graphics();
+
+    assert_eq!(seen.kitty(), 1, "still counted: {seen:?}");
+    let image = seen.last().expect("a payload");
+    assert_eq!(image.size(), Some((4, 2)), "still described");
+    assert!(image.bytes() > 0, "still measured");
+    assert_eq!(image.data(), None, "and not kept");
+    Ok(())
+}
+
+#[cfg(feature = "decode")]
+mod decoded {
+    use super::*;
+    use termlens::DecodeError;
+
+    /// GitHub Primer's brightest contribution green — the fixture's colour,
+    /// and the reason this crate can now say "the image was green" at all.
+    const GREEN: [u8; 4] = [0x39, 0xd3, 0x53, 0xff];
+    const BLUE: [u8; 4] = [0x00, 0x00, 0xff, 0xff];
+
+    #[test]
+    fn a_kitty_image_decodes_into_the_pixels_that_were_drawn() -> termlens::Result<()> {
+        // The claim the whole feature exists for: not "an image of about the
+        // right size went out", but "*this* image went out".
+        for mode in ["kitty", "kitty-plain", "kitty-chunks"] {
+            let (_terminal, screen) = run(mode)?;
+            let seen = screen.graphics();
+            let bitmap = seen
+                .last()
+                .expect("a payload")
+                .decode()
+                .unwrap_or_else(|error| panic!("{mode}: {error}"));
+
+            assert_eq!((bitmap.width(), bitmap.height()), (4, 2), "{mode}");
+            assert_eq!(bitmap.pixel(0, 0), Some(GREEN), "{mode}");
+            assert_eq!(bitmap.pixel(1, 1), Some(GREEN), "{mode}");
+            assert_eq!(bitmap.pixel(2, 0), Some(BLUE), "{mode}");
+            // The fourth column is transparent, and kitty has the alpha
+            // channel to say so.
+            assert_eq!(bitmap.pixel(3, 0), Some([0, 0, 0, 0]), "{mode}");
+            assert_eq!(bitmap.pixel(4, 0), None, "out of bounds is None");
+
+            let colours = bitmap.colours();
+            assert_eq!(colours[0], (GREEN, 4), "{mode}: {colours:?}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn a_sixel_decodes_into_the_pixels_that_were_painted() -> termlens::Result<()> {
+        let (_terminal, screen) = run("sixel")?;
+        let seen = screen.graphics();
+        let image = seen.last().expect("a payload");
+        assert_eq!(image.protocol(), GraphicsProtocol::Sixel);
+        assert_eq!(image.format(), GraphicsFormat::Sixel);
+        assert_eq!(image.size(), Some((4, 2)), "from its raster attributes");
+
+        let bitmap = image.decode().expect("decodes");
+        assert_eq!((bitmap.width(), bitmap.height()), (4, 2));
+        assert_eq!(bitmap.pixel(0, 0), Some([0, 255, 0, 255]));
+        assert_eq!(bitmap.pixel(1, 1), Some([0, 255, 0, 255]));
+        assert_eq!(bitmap.pixel(2, 0), Some([0, 0, 255, 255]));
+        // Sixel has no alpha, so a pixel nothing painted reads as
+        // transparent rather than as a colour we would have to invent.
+        assert_eq!(bitmap.pixel(3, 0), Some([0, 0, 0, 0]));
+        Ok(())
+    }
+
+    #[test]
+    fn a_delete_refuses_to_decode_and_says_why() -> termlens::Result<()> {
+        let (_terminal, screen) = run("delete")?;
+        let seen = screen.graphics();
+        let delete = &seen.payloads()[1];
+        assert_eq!(
+            delete.decode().unwrap_err(),
+            DecodeError::NoImage(GraphicsAction::Delete)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn an_uncaptured_payload_names_the_bound_rather_than_guessing() -> termlens::Result<()> {
+        let mut terminal = Terminal::builder()
+            .size(40, 10)
+            .timeout(Duration::from_secs(30))
+            .env_clear()
+            .capture_graphics(0)
+            .arg("kitty")
+            .spawn(util::fixture_bin("image-echo"))?;
+        terminal.wait_until(drawn)?;
+        let screen = terminal.screen();
+        let seen = screen.graphics();
+        assert_eq!(
+            seen.last().expect("a payload").decode().unwrap_err(),
+            DecodeError::NotCaptured
+        );
+        Ok(())
+    }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -483,6 +483,45 @@ Rules:
    declining both protocols, which is why an application that transmits one
    anyway is worth catching.
 
+   Those counters count **images**, which is not the same as counting
+   escapes, and the difference is not a detail. The kitty protocol caps a
+   payload at 4096 bytes and continues with `m=1`, so every image of
+   consequence arrives in several escapes and the continuations carry no
+   control block at all; and `a=d` deletes an image rather than sending one.
+   Counted per escape, a 4.9 KB chart read as two pictures and a teardown
+   read as a third — so "how many images did this frame send?", the question
+   that distinguishes a diffing painter from one that re-sends the year,
+   could not be asked. `GraphicsBuilder` joins the chunks and classifies the
+   action; `deletes` is counted separately, because an application that
+   takes down what it drew and one that draws twice as much are opposite
+   behaviours.
+
+   The payloads themselves land on the same slot, as `GraphicsSeen::payloads`.
+   This is the position `OSC 52` already takes and for the same reason: a
+   transmission is not a question, the only other evidence is the
+   application's own output, and the payload is usually the behaviour under
+   test. What each one states — format, compression, id, declared pixel size,
+   declared cell extent — is parsed from the control block; *where* it landed
+   is the one fact that lives in the grid instead, so the emulator stamps the
+   cursor position at the terminator. That is why `process` now feeds the
+   parser in pieces: the tracker runs a byte ahead of the grid, and a
+   placement read before the grid caught up would be the position from before
+   the whole read. Neither protocol's escape moves the cursor, so the position
+   after the terminator is the image's top-left corner.
+
+   Decoding sits behind the `decode` feature and runs on demand, never as the
+   bytes arrive: a suite that only asks whether an image went out should pay
+   neither the inflate nor the dependency (zlib, for kitty's `o=z`). It is
+   still not rendering — a `Bitmap` is handed to the test and never
+   composited onto the grid, so nothing termlens reports about the screen
+   changes because an image was decoded. Retention is bounded like scrollback
+   (4 MiB and 512 payloads by default, `TerminalBuilder::capture_graphics`),
+   and a payload past the bound reports `None` data and refuses to decode
+   with `DecodeError::NotCaptured` rather than handing back a prefix that
+   would decode into a plausible-looking wrong picture. `f=100` (PNG) is
+   refused for the same reason a guessed query reply is: termlens carries no
+   image codec, and inventing one answer is worse than naming the gap.
+
    Per-frame **cost** is the one observation that does not fit a snapshot: a
    `Screen` is an instant, and a performance line is a series. So
    `Terminal::frame_timings` keeps one `FrameTiming` per repaint — the span

--- a/fixtures/image-echo/Cargo.toml
+++ b/fixtures/image-echo/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "image-echo"
+description = "termlens fixture: transmits a known inline image over kitty or sixel"
+publish = false
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+miniz_oxide.workspace = true
+
+[lints]
+workspace = true

--- a/fixtures/image-echo/src/main.rs
+++ b/fixtures/image-echo/src/main.rs
@@ -1,0 +1,153 @@
+//! termlens fixture: transmits one known inline image, so a test can assert
+//! what came off the wire against what was drawn.
+//!
+//! Fixture rules: deterministic by construction — no clocks, no animation,
+//! no randomness. The same bytes go out on every run.
+//!
+//! ```text
+//! image-echo kitty        one 4x2 RGBA image, zlib'd, placed on 2x1 cells
+//! image-echo kitty-plain  the same image uncompressed
+//! image-echo kitty-chunks the same image, split across the protocol's chunks
+//! image-echo sixel        the same image as a sixel
+//! image-echo delete       an image, then the delete that takes it away
+//! ```
+//!
+//! Every mode ends by printing `done` and blocking on stdin, which is the
+//! instant-exit guard the suite requires of a program that writes and stops.
+
+use std::io::{self, Read, Write};
+
+/// Four pixels across, two down. Two flat colours and one transparent
+/// column, so an assertion can name an exact pixel rather than a tolerance.
+const WIDTH: u32 = 4;
+const HEIGHT: u32 = 2;
+/// GitHub Primer's brightest contribution green, which is where this
+/// fixture's colours came from.
+const GREEN: [u8; 4] = [0x39, 0xd3, 0x53, 0xff];
+const BLUE: [u8; 4] = [0x00, 0x00, 0xff, 0xff];
+const CLEAR: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
+
+/// Column 0–1 green, column 2 blue, column 3 transparent.
+fn pixels() -> Vec<[u8; 4]> {
+    let mut out = Vec::new();
+    for _ in 0..HEIGHT {
+        out.extend_from_slice(&[GREEN, GREEN, BLUE, CLEAR]);
+    }
+    out
+}
+
+fn rgba() -> Vec<u8> {
+    pixels().iter().flatten().copied().collect()
+}
+
+const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn base64(data: &[u8]) -> String {
+    let mut out = String::new();
+    for group in data.chunks(3) {
+        let mut bits = 0u32;
+        for (index, byte) in group.iter().enumerate() {
+            bits |= u32::from(*byte) << (16 - 8 * index);
+        }
+        for index in 0..=group.len() {
+            out.push(char::from(
+                ALPHABET[(bits >> (18 - 6 * index) & 0x3f) as usize],
+            ));
+        }
+        for _ in group.len()..3 {
+            out.push('=');
+        }
+    }
+    out
+}
+
+/// `a=T` with the placement pinned in cells, the way an application that
+/// lays out in characters and draws in pixels has to.
+fn kitty(compress: bool, chunk: usize) -> String {
+    let raw = rgba();
+    let payload = base64(&if compress {
+        miniz_oxide::deflate::compress_to_vec_zlib(&raw, 6)
+    } else {
+        raw
+    });
+    let control = format!(
+        "a=T,q=2,f=32,{}s={WIDTH},v={HEIGHT},i=7,c=2,r=1",
+        if compress { "o=z," } else { "" }
+    );
+
+    let mut out = String::new();
+    let mut chunks = payload.as_bytes().chunks(chunk.max(1)).peekable();
+    let mut first = true;
+    while let Some(part) = chunks.next() {
+        out.push_str("\x1b_G");
+        if first {
+            out.push_str(&control);
+            out.push(',');
+            first = false;
+        }
+        out.push_str(&format!("m={};", u8::from(chunks.peek().is_some())));
+        out.push_str(std::str::from_utf8(part).unwrap_or_default());
+        out.push_str("\x1b\\");
+    }
+    out
+}
+
+/// The same shape as a sixel: one band, two colour registers, raster
+/// attributes declaring the size. The transparent column is simply never
+/// painted — sixel has no alpha to say it with.
+///
+/// The colours are pure rather than Primer's, and deliberately: a sixel
+/// register is a *percentage* of 255, so most 8-bit values do not survive
+/// the round trip. Choosing ones that do keeps the assertion exact instead
+/// of approximate, which is the difference between a test that catches a
+/// wrong colour and one that tolerates it.
+fn sixel() -> String {
+    let mut out = format!("\x1bP0;1;0q\"1;1;{WIDTH};{HEIGHT}");
+    out.push_str("#0;2;0;100;0"); // green
+    out.push_str("#1;2;0;0;100"); // blue
+                                  // Both pixel rows sit in the one six-row band, so bits 0 and 1 are set:
+                                  // `?` + 0b11 = `B`. `$` returns to the left margin between colours, and
+                                  // `?` advances a column without painting it.
+    out.push_str("#0BB$");
+    out.push_str("#1??B$");
+    out.push('-');
+    out.push_str("\x1b\\");
+    out
+}
+
+fn main() -> io::Result<()> {
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "kitty".into());
+    let mut out = io::stdout();
+
+    // A label above and below, at known rows, so a test can see that the
+    // text layer left the image's cells alone.
+    write!(out, "\x1b[H\x1b[2Jlabel above\r\n")?;
+    // Row 2, column 5 (1-based), which is where every payload below lands.
+    write!(out, "\x1b[2;5H")?;
+
+    match mode.as_str() {
+        "kitty" => write!(out, "{}", kitty(true, 4096))?,
+        "kitty-plain" => write!(out, "{}", kitty(false, 4096))?,
+        // Small enough that the payload takes three escapes.
+        "kitty-chunks" => write!(out, "{}", kitty(false, 16))?,
+        "sixel" => write!(out, "{}", sixel())?,
+        "delete" => {
+            write!(out, "{}", kitty(true, 4096))?;
+            write!(out, "\x1b_Ga=d,d=I,i=7,q=2\x1b\\")?;
+        }
+        "none" => {}
+        other => {
+            write!(out, "unknown mode {other}")?;
+        }
+    }
+
+    write!(out, "\x1b[4;1Hlabel below\r\ndone\r\n")?;
+    out.flush()?;
+
+    // The instant-exit guard: a child that writes and exits within its first
+    // milliseconds can lose output to the OS pty teardown, so hold until the
+    // test has asserted and releases us.
+    let mut byte = [0u8; 1];
+    let _ = io::stdin().read(&mut byte)?;
+    Ok(())
+}


### PR DESCRIPTION
Inline graphics were observable only as a count and a size — and the count was of **escapes**, not of images. Two consequences, both found by driving [mossaic](https://github.com/vyncint/mossaic), which draws a year of contribution art over kitty and sixel:

- kitty caps a payload at 4096 bytes and continues with `m=1`, so mossaic's 4.9 KB chart counted as **two** images — and the continuation carries no control block, so nothing could be said about that second "image" either;
- `a=d` deletes an image, and counted as one more transmitted.

Reproduced against published 0.5.0 before a line was written: one chunked image plus one delete reported `kitty=4`.

## What this adds

**`GraphicsSeen::payloads`** — the transmissions themselves. Each `GraphicsPayload` carries its protocol, action, format, compression, image id, the pixel size and cell extent the application declared, the bytes it cost, the chunks it took, and the data. Placement is the one fact that does *not* live in the payload, so `at()` is stamped from the grid: the cursor position at the terminator, which is the image's top-left corner for both protocols. That is why `process` now feeds the parser in pieces — the tracker runs a byte ahead of the grid, and a position read before the grid caught up is the position from before the whole read.

**`GraphicsSeen::deletes`**, counting `a=d` apart from images transmitted. An application that tears down what it drew and one that draws twice as much are opposite behaviours; folding them together made them the same number.

**The `decode` feature: `GraphicsPayload::decode` and `Bitmap`.** kitty `f=24`/`f=32`, zlib'd or not, and the sixel data stream decode into pixels. Off by default — it is the one thing here that needs a dependency of its own (zlib, for `o=z`), and every other fact about a payload stays free. Decoding is still not rendering: the bitmap goes to the test and never to the grid, so nothing termlens reports about the screen changes because an image was decoded. Every refusal names its reason (`f=100` is unsupported rather than guessed; a delete carries no image; a payload past the capture bound says so) instead of returning an empty picture.

**`TerminalBuilder::capture_graphics`**, the retention budget — 4 MiB and 512 payloads by default, `0` to keep counts and drop every byte. Bounded like scrollback, and the counters stay exact whatever the bound. Past it a payload is counted and described but its bytes are dropped, rather than decoding a prefix of itself into a plausible-looking wrong picture.

This is the position `OSC 52` already takes, for the same reason: a transmission is not a question, the only other evidence is the application's own output, and the payload is usually the behaviour under test.

## Breaking

`GraphicsSeen` is `Clone` rather than `Copy`, since it now carries the payload list. Reading a counter is unaffected; code that copied the value into two bindings needs a `clone`.

## Tests

New `image-echo` fixture transmits a known 4×2 image over kitty (compressed, plain, and chunked), over sixel, and with a delete after it — so the assertions run against a real program in a real PTY, not against hand-fed bytes. `tests/graphics.rs` covers counting, placement, chunk joining, the delete distinction, the capture bound, and decoding both protocols to exact pixels; `emu/seq.rs` and `graphics.rs` carry the unit-level cases.

`cargo test --workspace --all-features`: 292 pass. clippy clean with and without the feature; `cargo doc` clean.

> `--no-default-features` fails on an `assert_screen_snapshot` doctest — **pre-existing on `main`**, verified by stashing this branch. Not touched here.

## Downstream

mossaic's companion PR uses this to assert its pixel path as a picture rather than a byte count — including checking the year *drawn* against the year *described*: the number of days in Primer's brightest green must equal the number its footer calls active. It is blocked on a 0.6.0 release.
