### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-21
+
 What an application *drew*, as against how many bytes it spent drawing it.
 
 Inline graphics were observable only as a count and a size: an image had

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossterm",
 ]
@@ -181,14 +181,14 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossterm",
 ]
 
 [[package]]
 name = "image-echo"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "miniz_oxide",
 ]
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crossterm",
 ]
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -611,7 +611,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.
@@ -22,7 +22,7 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.5.0" }
+termlens = { path = "crates/termlens", version = "0.6.0" }
 
 portable-pty = "0.9"
 vt100 = "0.16"

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.5)
+## Known limitations (v0.6)
 
 - Scrollback is **bounded** (1000 rows by default), **text only** — a
   scrolled-off row has no styles and no cell addressing — and is **not

--- a/docs/announce-r-rust.md
+++ b/docs/announce-r-rust.md
@@ -66,14 +66,15 @@ pty* because device numbers recycle instantly — termlens serializes pty
 lifecycle edges behind a process-wide lock so your parallel tests don't
 hit it.
 
-Honest limitations (v0.5): Unix only for now (portable-pty supports
+Honest limitations (v0.6): Unix only for now (portable-pty supports
 ConPTY, so Windows is planned); scrollback is retained but bounded, text
 only, and not reflowed on resize; `wait_frame` needs the app to opt into
-DEC 2026; graphics are observed and offered but never rendered, so what an
-image *depicted* is not assertable; and a few questions (kitty `CSI ? u`,
-DECRQSS, `OSC 52` *reads*) are deliberately left unanswered rather than
-guessed — an app blocked on one is named in the next timeout instead of
-hanging silently.
+DEC 2026; inline graphics are captured and decodable but still never
+rendered, so an image never reaches the screen grid and how a picture sits
+over the text under it is not assertable; and a few questions (kitty
+`CSI ? u`, DECRQSS, `OSC 52` *reads*) are deliberately left unanswered
+rather than guessed — an app blocked on one is named in the next timeout
+instead of hanging silently.
 
 - crates.io: https://crates.io/crates/termlens (`cargo add termlens --dev`)
 - GitHub: https://github.com/vyncint/termlens


### PR DESCRIPTION
Cuts 0.6.0 — inline graphics payloads become inspectable and decodable (#137).

Per `docs/RELEASING.md`:

- `workspace.package.version` → `0.6.0`, lockfile refreshed
- `CHANGELOG.md`: `[Unreleased]` → `[0.6.0] - 2026-08-21`, fresh empty `[Unreleased]`
- `README.md`: "Known limitations **(v0.5)**" → **(v0.6)**
- `docs/announce-r-rust.md`: the unposted draft said "graphics are observed and offered but never rendered, so what an image *depicted* is not assertable" — 0.6 is exactly the release that stops being true. Corrected to what still holds: captured and decodable, but never rendered, so an image never reaches the screen grid and how a picture sits over the text under it is not assertable.

**Gates, run before this branch:** stress ×100 green on ubuntu and macOS ([run](https://github.com/vyncint/termlens/actions/runs/32483433267)); `cargo test --workspace --all-features` 293 pass; `cargo-semver-checks` against published 0.5.0 clean — `0.5.0 -> 0.6.0 (major change)`, which is the bump `GraphicsSeen` losing `Copy` requires under Cargo's 0.x rules.

Tagging `v0.6.0` after this merges publishes via Trusted Publishing.