### PR TITLE
fix(pty): retry openpty when the machine is briefly out of devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`spawn` no longer fails when the machine is briefly out of PTY devices.**
+  On macOS a PTY is torn down with `revoke()` and its device recycled, and a
+  suite asking for devices faster than the kernel returns them gets `ENXIO` —
+  "Device not configured", which reads like a broken machine and is really a
+  queue. `cargo test` runs one test per core by default, so this is what a
+  sixteen-core Mac does with any suite of this shape; the failure was not
+  exotic, it was Tuesday. `openpty` is now retried for about 1.6 seconds
+  before giving up, **releasing the PTY lifecycle lock between attempts** —
+  that lock is the one a teardown also takes, so waiting under it would have
+  blocked the only work capable of freeing a device.
+
+  Found by the stress workflow the first time it ran the suite at sixteen
+  threads, on macOS; Linux had run the same suite twenty-five times over
+  without noticing. `tests/concurrency.rs` now applies the same pressure on
+  purpose — two dozen terminals at once, and eight rounds of open-and-recycle
+  — so it is reproducible rather than a matter of which shard drew the short
+  straw.
+
 ## [0.6.0] - 2026-08-21
 
 What an application *drew*, as against how many bytes it spent drawing it.

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -16,7 +16,7 @@ use std::sync::{mpsc, Arc, Mutex, PoisonError};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use portable_pty::{native_pty_system, CommandBuilder, PtyPair, PtySize};
 
 use crate::emu::{Emulator, InputModes, MouseEncoding, Query, Stop, Vt100Emulator};
 use crate::error::{Error, Result};
@@ -189,6 +189,55 @@ static PTY_LIFECYCLE: Mutex<()> = Mutex::new(());
 
 fn pty_lifecycle_guard() -> std::sync::MutexGuard<'static, ()> {
     PTY_LIFECYCLE.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Attempts to open a PTY before giving up, and the step between them. The
+/// ceiling is the sum, about 1.6s — long enough to outlast a burst of
+/// teardowns, short enough that a genuinely broken environment still reports
+/// promptly.
+const PTY_OPEN_ATTEMPTS: u32 = 12;
+const PTY_OPEN_BACKOFF: Duration = Duration::from_millis(25);
+
+/// Open a PTY, handing back the lifecycle lock for the caller to hold through
+/// spawn.
+///
+/// Retried, because on macOS `openpty` is not merely racy but transiently
+/// **exhausted**. Devices are torn down with `revoke()` and recycled, and a
+/// suite running one test per core — which is what `cargo test` does by
+/// default, so sixteen on a sixteen-core machine — can ask for a device faster
+/// than the kernel gives them back. The failure is `ENXIO`, "Device not
+/// configured", which reads like a broken machine and is really a queue.
+/// Found by the stress workflow at sixteen threads on macOS, where Linux ran
+/// the same suite twenty-five times over without noticing.
+///
+/// **The lock is released between attempts, and that is the point.** It is the
+/// same lock a teardown takes, so waiting for a device while holding it would
+/// block the only work that can produce one — the retry would be guaranteed to
+/// fail exactly when it was needed.
+///
+/// Every failure is retried rather than only the ones that look transient:
+/// classifying an `anyhow` error by its text is guesswork, a permanent fault
+/// still reports its own message at the end, and the cost of being wrong is
+/// under two seconds on a spawn that was going to fail anyway.
+fn open_pty(size: PtySize) -> Result<(PtyPair, std::sync::MutexGuard<'static, ()>)> {
+    let pty = native_pty_system();
+    let mut last = String::new();
+    for attempt in 0..PTY_OPEN_ATTEMPTS {
+        let lifecycle = pty_lifecycle_guard();
+        match pty.openpty(size) {
+            Ok(pair) => return Ok((pair, lifecycle)),
+            Err(error) => {
+                drop(lifecycle);
+                last = error.to_string();
+                if attempt + 1 < PTY_OPEN_ATTEMPTS {
+                    thread::sleep(PTY_OPEN_BACKOFF * (attempt + 1));
+                }
+            }
+        }
+    }
+    Err(Error::Pty(format!(
+        "openpty failed after {PTY_OPEN_ATTEMPTS} attempts: {last}"
+    )))
 }
 
 /// The PTY writer, shared between `Terminal` (typed input) and the reader
@@ -1184,22 +1233,18 @@ impl TerminalBuilder {
         // diagnostic about something else.
         self.validate(&command_desc, program)?;
 
-        // Hold the lifecycle lock across openpty → spawn → slave close, so
+        // The lifecycle lock is held across openpty → spawn → slave close, so
         // no concurrent Terminal teardown can revoke our fresh PTY device.
-        let lifecycle = pty_lifecycle_guard();
-
-        let pty = native_pty_system();
-        let pair = pty
-            .openpty(PtySize {
-                rows: self.rows,
-                cols: self.cols,
-                // So TIOCGWINSZ agrees with the escape replies instead of
-                // contradicting them. Zero when no cell size was declared,
-                // which is what a real terminal reports when it has none.
-                pixel_width: pixel_span(self.cols, self.cell_size.map(|(w, _)| w)),
-                pixel_height: pixel_span(self.rows, self.cell_size.map(|(_, h)| h)),
-            })
-            .map_err(|e| Error::Pty(format!("openpty failed: {e}")))?;
+        // `open_pty` takes it, retries under it, and hands it back still held.
+        let (pair, lifecycle) = open_pty(PtySize {
+            rows: self.rows,
+            cols: self.cols,
+            // So TIOCGWINSZ agrees with the escape replies instead of
+            // contradicting them. Zero when no cell size was declared,
+            // which is what a real terminal reports when it has none.
+            pixel_width: pixel_span(self.cols, self.cell_size.map(|(w, _)| w)),
+            pixel_height: pixel_span(self.rows, self.cell_size.map(|(_, h)| h)),
+        })?;
 
         let mut cmd = CommandBuilder::new(program);
         cmd.args(&self.args);

--- a/crates/termlens/tests/concurrency.rs
+++ b/crates/termlens/tests/concurrency.rs
@@ -1,0 +1,100 @@
+//! Many terminals at once, which is what `cargo test` does by default.
+//!
+//! A suite runs one test per core, so a sixteen-core machine opens sixteen
+//! PTYs at once and closes them just as fast. On macOS that is not merely
+//! concurrent, it is a *queue*: devices are torn down with `revoke()` and
+//! recycled, and asking for one faster than the kernel returns it fails with
+//! `ENXIO` — "Device not configured", which reads like a broken machine.
+//!
+//! The stress workflow found it at sixteen threads on macOS while Linux ran
+//! the same suite twenty-five times over without noticing. This is that
+//! failure written down, so it is reproducible on demand rather than once in
+//! a while in whichever shard drew the short straw.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+/// More than any runner has cores, and more than the default `--test-threads`
+/// on the largest machine anyone is likely to be sitting at.
+const AT_ONCE: usize = 24;
+
+#[test]
+fn two_dozen_terminals_open_at_once() {
+    let (report, results) = mpsc::channel();
+    let mut threads = Vec::with_capacity(AT_ONCE);
+
+    for index in 0..AT_ONCE {
+        let report = report.clone();
+        threads.push(thread::spawn(move || {
+            let outcome = (|| -> termlens::Result<()> {
+                let mut terminal = Terminal::builder()
+                    .size(40, 10)
+                    .env_clear()
+                    .timeout(Duration::from_secs(30))
+                    .arg("-c")
+                    // The `read` is the instant-exit guard: a child that
+                    // writes and dies inside a millisecond can lose its
+                    // output to the PTY teardown.
+                    .arg(format!("printf 'terminal {index}\\n'; read _"))
+                    .spawn("/bin/sh")?;
+                terminal.wait_until(|screen| screen.contains(&format!("terminal {index}")))?;
+                terminal.send(Key::Enter)?;
+                terminal.wait_exit()?;
+                Ok(())
+            })();
+            report
+                .send((index, outcome))
+                .expect("the collector is alive");
+        }));
+    }
+    drop(report);
+
+    // Collected rather than asserted per thread, so one failure names itself
+    // instead of arriving as a panic from a thread nobody is watching.
+    let mut failures = Vec::new();
+    for (index, outcome) in results {
+        if let Err(error) = outcome {
+            failures.push(format!("terminal {index}: {error}"));
+        }
+    }
+    for thread in threads {
+        thread.join().expect("no thread panicked");
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {AT_ONCE} terminals failed to run:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// The same pressure applied in waves rather than all at once: open, tear
+/// down, open again. Recycling is what macOS is slow at, so churn is a
+/// different shape of the same question from a single wide burst.
+#[test]
+fn terminals_recycle_without_running_out_of_devices() {
+    for round in 0..8 {
+        let mut open = Vec::new();
+        for index in 0..6 {
+            let mut terminal = Terminal::builder()
+                .size(20, 5)
+                .env_clear()
+                .timeout(Duration::from_secs(30))
+                .arg("-c")
+                .arg(format!("printf 'round {round} {index}\\n'; read _"))
+                .spawn("/bin/sh")
+                .unwrap_or_else(|error| panic!("round {round}, terminal {index}: {error}"));
+            terminal
+                .wait_until(|screen| screen.contains(&format!("round {round} {index}")))
+                .unwrap_or_else(|error| panic!("round {round}, terminal {index}: {error}"));
+            open.push(terminal);
+        }
+        // Dropped together, which is the burst of teardowns the next round's
+        // opens have to survive.
+        drop(open);
+    }
+}


### PR DESCRIPTION
**Found by the stress workflow's first run at sixteen threads on macOS**, in [the very run](https://github.com/vyncint/termlens/actions/runs/32543589966) that introduced varying `--test-threads` across shards. Linux had run the same suite twenty-five times over without noticing.

```
Error: Pty("openpty failed: ... Os { code: 6, message: \"Device not configured\" }")
```

## What it is

`ENXIO` from `openpty`. macOS tears a PTY down with `revoke()` and recycles the device, so a process asking for devices faster than the kernel returns them is refused. It reads like a broken machine; it is really a queue.

**This is not an exotic configuration.** `cargo test` runs one test per core by default, so sixteen concurrent PTYs is what any suite of this shape does on a sixteen-core Mac. Anyone using termlens on Apple hardware is one `cargo test` away from it.

## The fix, and the part that matters

`openpty` is retried for about 1.6 seconds (12 attempts, 25ms × attempt) before giving up.

The load-bearing detail is that **the PTY lifecycle lock is released between attempts**. That lock is the one a *teardown* also takes — it exists so a teardown's `revoke()` cannot land on a sibling's freshly recycled device. Retrying while holding it would have blocked the only work capable of freeing a device, so the retry would have been guaranteed to fail exactly when it was needed. Sitting under the lock would have looked like a fix and been a deadlock with a timeout.

Every failure is retried rather than only the ones that look transient: classifying an `anyhow` error by its message text is guesswork, a permanent fault still reports its own message at the end, and being wrong costs under two seconds on a spawn that was going to fail anyway.

## Tests

`tests/concurrency.rs` applies the pressure on purpose rather than waiting for the right shard to draw it:

- **two dozen terminals at once** — more than any runner has cores, and more than the default `--test-threads` on the largest machine anyone is sitting at. Failures are collected and named, so one bad terminal reports itself instead of arriving as a panic from an unwatched thread.
- **eight rounds of open-and-recycle** — six terminals up, all dropped together, then six more. Recycling is the part macOS is slow at, so churn is a different shape of the same question from one wide burst.

`cargo test --workspace --all-features`: 295 pass, up from 293.

The stress workflow at 16 threads is the real regression test, and [#141](https://github.com/vyncint/termlens/pull/141) is what will run it.