### PR TITLE
docs: one contributor pattern across the four projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# Working on termlens
+
+Instructions for coding agents — and useful to humans. **termlens** is a headless PTY test harness: spawn a terminal program in a real pseudo-terminal, render its output with a VT emulator, and assert on the screen grid a user would see.
+
+This file is the canonical brief; `CLAUDE.md` points here. `CONTRIBUTING.md`
+is the full contributor document and wins wherever the two disagree.
+
+## Layout
+
+- `crates/termlens/` — the published library. `terminal.rs` is the runtime,
+  `screen.rs` the snapshot types, `emu/` the VT emulation behind a small
+  internal trait, `graphics.rs` the inline-image capture and decoder.
+- `fixtures/` — deterministic terminal programs the integration suite spawns
+  in real PTYs. Never published; `publish = false`.
+- `docs/DESIGN.md` — four layers, the wait-semantics contract, the snapshot
+  format. **Read it before touching `wait.rs`, `terminal.rs`, or `emu/`.**
+
+## Build and test
+
+```sh
+cargo test --workspace --all-features   # the whole suite
+cargo test -p termlens --test graphics  # one integration file
+cargo insta review                      # snapshots, after an intended change
+```
+
+Stable toolchain, MSRV 1.85 (checked in CI against the committed lockfile).
+
+## Things that will bite you here
+
+- **Wait and timing changes must pass the stress workflow.** `stress.yml`
+  runs the suite many times over, split across five machines at different
+  `--test-threads`. It has found real bugs on its first run more than once.
+  Trigger it on your branch before asking for review.
+- **Never blind-accept a snapshot.** `cargo insta review` and look at every
+  diff. A snapshot change you cannot explain is a bug report.
+- **A `Screen` is embedded in every error**, so its size is load-bearing.
+  Adding a field is not free.
+- **Nothing is claimed that the emulator cannot render.** A query is answered
+  truthfully or left unanswered and named in the next timeout. Do not invent
+  a reply to make a test pass.
+
+## The rules that will fail CI
+
+Three, and they are the same in every one of these repositories.
+
+1. **Conventional Commits.** `feat:`, `fix:`, `docs:`, `test:`, `ci:`,
+   `chore:`, `refactor:`, `perf:` — imperative mood, subject line under 72
+   characters, scope optional (`fix(screen): …`).
+2. **DCO sign-off.** `git commit -s`, and the `Signed-off-by:` email must
+   match the commit author's. Forgot? `git commit --amend -s --no-edit`, or
+   `git rebase --signoff main` for a branch.
+3. **No AI attribution.** See below — this one is about you, and it is the
+   rule most likely to catch an agent out.
+
+Run them yourself before pushing; both scripts take a commit range:
+
+```sh
+.github/scripts/check-dco.sh main..HEAD
+.github/scripts/check-no-ai-attribution.sh main..HEAD
+```
+
+## Using AI here
+
+**You are welcome.** Every one of these projects was built with AI assistance
+and says so in its CONTRIBUTING. Use whatever helps.
+
+**You are not a contributor.** Do not add yourself to the history:
+
+- no `Co-Authored-By:` trailer naming an assistant, a model, or a vendor,
+- no "Generated with …" footer, no robot emoji,
+- no bot account as author or committer.
+
+The human who opens the pull request is the author of record and takes
+responsibility for the change under the DCO. That is what the sign-off
+certifies, and it cannot be certified by a tool. `.claude/settings.json`
+turns co-author trailers off for agents that read it; the check in CI is the
+boundary, and it reads every commit in the range.
+
+If CI catches one, the fix is to rewrite the message, not to argue with it:
+
+```sh
+git commit --amend            # the last commit
+git rebase -i main            # several, marking each `reword`
+git push --force-with-lease
+```
+
+## What good work looks like here
+
+These repositories share a house style, and it is stricter than most:
+
+- **Evidence over assertion.** A bug report says what was measured against
+  which released version. "Reproduced against 0.4.0" is the standard; "the
+  code looks wrong" is not. Issues in these repos read *Today / Why it is
+  worth fixing / Fix / Done when*, with a concrete reproduction.
+- **Every change lands with a test**, and the test must be able to fail. If
+  you add a guard, prove it catches the thing — break it once and watch it go
+  red before you commit.
+- **Comments say *why*, never *what*.** The diff shows what. A comment earns
+  its place by recording the reason, the alternative rejected, or the failure
+  that motivated the line.
+- **Say what you did not do.** A pull request that lists what it left out and
+  why is worth more than one that implies completeness. If something is
+  unverified, say so — an honest gap is cheap and a false claim is expensive.
+- **Documentation is checked, not maintained.** Where a README states a fact
+  the code owns, there is usually a test asserting the two agree. Do not
+  break that pattern by hand-editing the doc.
+
+## Pull requests
+
+Branch from `main` (`feat/…`, `fix/…`, `docs/…`, `ci/…`). PRs are
+**squash-merged**, so the PR title becomes the commit subject on `main` —
+write it as a Conventional Commit. Update `CHANGELOG.md` under
+`[Unreleased]` for anything user-facing.
+
+Direct pushes to `main` are blocked by a ruleset; everything goes through a
+pull request, including releases.
+
+## Releasing
+
+Tag `vX.Y.Z` on `main`; `release.yml` gates, publishes via Trusted Publishing, and cuts the GitHub Release. See `docs/RELEASING.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# termlens
+
+See **[AGENTS.md](AGENTS.md)** — one brief for every coding agent,
+so the instructions cannot drift apart per tool.
+
+The short version: Conventional Commits, `git commit -s` for the DCO,
+and **no AI attribution in the history** — you are welcome to use AI
+here, but the human opening the pull request is the author of record.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,13 @@
 Thanks for your interest! This document covers everything you need to get a
 change from your editor into `main`.
 
+> **These four projects share one contributor pattern** — the same commit
+> rules, the same DCO, the same AI policy, the same CI and release shape:
+> [termlens](https://github.com/vyncint/termlens),
+> [mossaic](https://github.com/vyncint/mossaic),
+> [launchbound](https://github.com/vyncint/launchbound),
+> [reconverge](https://github.com/vyncint/reconverge). Learn it once.
+
 ## 1. Dev setup
 
 ```sh
@@ -47,8 +54,9 @@ cargo insta review            # inspect and accept/reject each diff
 ## 4. Commit conventions
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):
-`feat:`, `fix:`, `docs:`, `test:`, `ci:`, `chore:`, `refactor:` — scope
-optional (`feat(screen): …`). Subject line: imperative mood, ≤ 72 characters.
+`feat:`, `fix:`, `docs:`, `test:`, `ci:`, `chore:`, `refactor:`, `perf:` —
+scope optional (`feat(screen): …`). Subject line: imperative mood,
+≤ 72 characters.
 
 ## 5. Developer Certificate of Origin (DCO)
 
@@ -69,38 +77,68 @@ match the commit author email; CI enforces this on every commit in a PR.
 Forgot to sign off? `git commit --amend -s` for the last commit, or
 `git rebase --signoff main` for a whole branch, then force-push.
 
+One exception, and it is GitHub's rather than ours: a pull request
+**squash-merged through the web UI** has its author email rewritten by GitHub
+*after* the sign-off was written, so an exact match is impossible by
+construction. Such a commit must carry a sign-off, but is not matched against
+an author it did not choose. The commits that went into the PR were already
+checked, address and all, on the branch.
+
 ## 6. AI tooling policy
 
-You may use any AI tool to write code for this project — we do too. Two
-rules:
+**AI assistance is welcome here — use whatever helps.** Every one of these
+projects was built with it. There is an [AGENTS.md](AGENTS.md) briefing coding
+agents on the layout, the commands, and the house style.
 
-1. **You are the author of record** and take full responsibility for what you
-   submit, per the DCO.
-2. **Do not add AI co-author trailers, "Generated with" footers, or bot
-   identities to commits.** CI rejects them.
+**AI attribution is not welcome.** No `Co-Authored-By` trailer naming an
+assistant, model or vendor; no "Generated with …" footer; no robot emoji; no
+bot identity as author or committer. Whoever opens the pull request is the
+author of record, takes responsibility under the DCO, and the history should
+say so — a tool cannot certify the DCO, which is the whole point of it.
 
-Contributions authored *by* an autonomous account (bot committer/author) are
-not accepted.
+This is enforced, not requested: `commit-policy.yml` runs
+[`check-no-ai-attribution.sh`](.github/scripts/check-no-ai-attribution.sh) and
+[`check-dco.sh`](.github/scripts/check-dco.sh) over every commit in a pull
+request. Run them yourself first — both take a range:
+
+```sh
+.github/scripts/check-dco.sh main..HEAD
+.github/scripts/check-no-ai-attribution.sh main..HEAD
+```
+
+If a check fails, rewrite the message rather than arguing with it:
+
+```sh
+git commit --amend            # the last commit
+git rebase -i main            # several, marking each `reword`
+git push --force-with-lease
+```
+
+`.claude/settings.json` turns co-author trailers off for agents that read
+repository settings. That is a courtesy; the check in CI is the boundary.
+Contributions authored *by* an autonomous account are not accepted.
 
 ## 7. PR flow
 
-- Branch from `main`; name branches `feat/…`, `fix/…`, `docs/…`, etc.
+- Branch from `main`; name branches `feat/…`, `fix/…`, `docs/…`, `ci/…`.
 - PRs are **squash-merged** — keep the PR title in Conventional Commit form,
-  since it becomes the commit subject on `main`. Branches are deleted on
-  merge.
-- Required checks: `required-green` (fmt, clippy, tests on Ubuntu + macOS,
-  MSRV, docs, cargo-deny, zizmor) and `commit-policy` (DCO + attribution
-  policy). All must pass before merge.
-- **Contributing from a fork?** Two things are normal. First, on your
-  first PR the workflows wait for a maintainer to approve them (GitHub's
-  standard first-time-contributor safeguard — nothing you did wrong).
-  Second, when `commit-policy` fails on a fork PR it **cannot post its
-  explanatory comment** (fork PRs run with a read-only token); the job
-  log carries the full explanation instead, including the exact
-  offending commit and the command that fixes it.
+  since it becomes the commit subject on `main`. Branches are deleted on merge.
+- Required checks: `required-green` (fmt, clippy, tests on Ubuntu + macOS, MSRV, docs, cargo-deny, zizmor), plus `commit-policy` (DCO + attribution). All
+  must pass before merge; direct pushes to `main` are blocked by a ruleset.
+- **Every change lands with a test, and the test must be able to fail.** If
+  you add a guard, break it once and watch it go red before you commit.
+- **Say what you did not do.** A PR that lists what it left out and why is
+  worth more than one implying completeness. An honest gap is cheap; a false
+  claim is expensive.
+- **Contributing from a fork?** Two things are normal. On your first PR the
+  workflows wait for a maintainer to approve them — GitHub's standard
+  first-time-contributor safeguard, nothing you did wrong. And when
+  `commit-policy` fails on a fork PR it cannot post its explanatory comment
+  (fork PRs get a read-only token); the job log carries the full explanation,
+  including the offending commit and the command that fixes it.
 - Review: expect actionable review within a few days. Small, focused PRs get
-  reviewed faster than large ones. Update `CHANGELOG.md` under
-  `[Unreleased]` for any user-facing change.
+  reviewed faster. Update `CHANGELOG.md` under `[Unreleased]` for any
+  user-facing change.
 
 ## 8. Release process
 


### PR DESCRIPTION
One pattern across [termlens](https://github.com/vyncint/termlens), [mossaic](https://github.com/vyncint/mossaic), [launchbound](https://github.com/vyncint/launchbound) and [reconverge](https://github.com/vyncint/reconverge), so a contributor learns the rules once.

## `AGENTS.md` + `CLAUDE.md`

New in all four. `AGENTS.md` is the canonical brief — layout, the exact build and test commands, the things that bite in *this* repo, and the three rules that fail CI. `CLAUDE.md` points at it rather than duplicating it, so per-tool instructions cannot drift apart.

## Generated, not copied

The shared halves are produced from one string and are **byte-identical in all four repos** — verified by hash:

- `AGENTS.md` from "The rules that will fail CI" to the end
- `CONTRIBUTING.md` sections **4 Commit conventions**, **5 DCO**, **6 AI tooling policy**, **7 PR flow**, **8 Release process**

Copying prose four times is how four projects end up with four subtly different rules. Sections 1–3 and anything after 8 stay each repository's own.

## The AI policy, stated properly

It is the rule an agent is most likely to break, so it now says the whole thing in every repo:

> **AI assistance is welcome — use whatever helps.** Every one of these projects was built with it.
>
> **AI attribution is not.** No `Co-Authored-By` naming an assistant, no "Generated with" footer, no bot identity. The human who opens the PR is the author of record and takes responsibility under the DCO — **which is precisely why a tool cannot be credited: a tool cannot certify it.**

`.claude/settings.json` (now in all four) turns co-author trailers off for agents that read repository settings; the CI check is the boundary. The docs give the exact recovery commands, because the fix is to rewrite the message, not to argue with the check.

## Also standardized

- **DCO everywhere.** mossaic was the only repo without it and now has it, using the same script. It runs over a PR's own range, so pre-policy history is not retroactively failed.
- **Identical policy scripts** — `check-dco.sh` and `check-no-ai-attribution.sh`, byte-identical, both in `.github/scripts/`, both taking a commit range.
- **`docs/RELEASING.md` in all four**, same shape, honest about where the processes genuinely differ.
- **`MAINTAINERS.md` in all four**, so a contributor sees who reviews and how fast before they open a PR.
- A "what good work looks like here" section: evidence over assertion, every change lands with a test that can fail, comments say *why*, and say what you did not do.