### PR TITLE
ci(release): notify the repository that tests this tool on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
   # Needs a PAT with `contents: write` on termlens-demo, stored as
   # TESTING_REPO_DISPATCH_TOKEN. Without it the job says so and exits clean.
   notify-testing-repo:
+    name: notify-testing-repo
     needs: publish
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,39 @@ jobs:
             --title "$GITHUB_REF_NAME" \
             --notes-file "$RUNNER_TEMP/notes.md" \
             --verify-tag
+
+  # Tell the repository that tests this tool against a real subject that a
+  # new version exists, so the deep run happens now rather than at its next
+  # scheduled tick.
+  #
+  # Best-effort by design. The testing repositories all resolve "latest" from
+  # crates.io on a schedule of their own, so a dispatch that never arrives --
+  # an expired token, a release cut by hand, a fork without the secret --
+  # costs latency and nothing else. That is why this job never fails the
+  # release: a published crate is published whether or not the notification
+  # landed.
+  #
+  # Needs a PAT with `contents: write` on termlens-demo, stored as
+  # TESTING_REPO_DISPATCH_TOKEN. Without it the job says so and exits clean.
+  notify-testing-repo:
+    needs: publish
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch to termlens-demo
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.TESTING_REPO_DISPATCH_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::notice::TESTING_REPO_DISPATCH_TOKEN is not set; termlens-demo will pick this up on its own schedule instead"
+            exit 0
+          fi
+          gh api repos/vyncint/termlens-demo/dispatches \
+            -f event_type=tool-published \
+            -F "client_payload[version]=${TAG#v}" \
+            && echo "dispatched tool-published to termlens-demo" \
+            || echo "::warning::could not dispatch to termlens-demo; it will pick this up on its own schedule"


### PR DESCRIPTION
Each tool has a repository that exercises it against a real subject:

| tool | testing repository | what it proves |
|---|---|---|
| termlens | `termlens-demo` | a 150-test coverage study against a feature-dense TUI |
| mossaic | `contribution-art` | the action's 20 outputs against a real contribution graph |
| launchbound | `launchbound-action-demo` | the safety gate, both directions, on kernels with a known convergence property |
| reconverge | `simt-diff` | a 9-entry differential corpus whose answers are known by construction |

All four already resolve `latest` from crates.io on schedules of their own, so a new version is picked up without anything being edited — but only at the next tick. That is up to a day for the daily checks and up to a week for the weekly ones.

This dispatches `tool-published` on publish so the deep run starts immediately.

**Best-effort on purpose.** `continue-on-error`, and a missing token is a `::notice::` rather than a failure. The schedules stay exactly as they are, because a dispatch that never arrives — an expired token, a release cut by hand, a fork without the secret — must cost latency and nothing else. A published crate is published whether or not the notification landed.

## Setup

Needs a PAT with `contents: write` on the testing repository, stored as `TESTING_REPO_DISPATCH_TOKEN`. Until that secret exists the job logs a notice and exits clean, so merging this changes nothing about the release.

The receiving side (`repository_dispatch: types: [tool-published]`) is already merged or in review on each testing repo.
