### PR TITLE
release: v0.6.1 — the openpty retry, which never shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-23
+
 ### Fixed
 
 - **`spawn` no longer fails when the machine is briefly out of PTY devices.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crossterm",
 ]
@@ -181,14 +181,14 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crossterm",
 ]
 
 [[package]]
 name = "image-echo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "miniz_oxide",
 ]
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crossterm",
 ]
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -611,7 +611,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.6.0"
+version = "0.6.1"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.


### PR DESCRIPTION
The `openpty` retry landed in #140 and **has been sitting on main unreleased ever since**. Every consumer is still on 0.6.0 and still hits the bug it fixes.

## How it resurfaced

mossaic's stress run failed today on macOS at sixteen threads:

```
Error: Pty("openpty failed: failed to openpty: Os { code: 6, … \"Device not configured\" }")
```

That is the same ENXIO #140 fixed — and it is identifiable as *unfixed* rather than as a new bug, because the retry produces `openpty failed after 12 attempts:` and this message has no such wording.

Confirmed against the tags: `v0.4.2`, `v0.5.0` and `v0.6.0` all contain **zero** occurrences of `PTY_OPEN_ATTEMPTS`.

## Blast radius

Four repositories dev-depend on termlens, and all four are on 0.6.0 — `mossaic`, `reconverge`, `launchbound` and `termlens-demo`. All four have the flake, and it is the kind that shows up as one red shard in ten and gets re-run rather than diagnosed.

## The change

Publishing. The code has been ready for two days; this is a version bump and a changelog move, and the entry describing the fix was already written under `[Unreleased]`.
