### PR TITLE
fix: support tests without default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,19 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --all-features
 
+  no-default-features:
+    name: no-default-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - run: cargo test --workspace --no-default-features
+
   msrv:
     name: msrv
     runs-on: ubuntu-latest
@@ -136,7 +149,7 @@ jobs:
   required-green:
     name: required-green
     if: always()
-    needs: [fmt, clippy, test, msrv, docs, deny, zizmor]
+    needs: [fmt, clippy, test, no-default-features, msrv, docs, deny, zizmor]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every needed job succeeded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The crate's doctests build with default features disabled.** The bundled
+  snapshot macro example is compiled only when its `insta` feature exists,
+  and CI now runs `cargo test --workspace --no-default-features` so this
+  supported configuration cannot silently rot again.
+
 ## [0.6.1] - 2026-08-23
 
 ### Fixed

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -84,6 +84,7 @@
 //! # fn main() -> termlens::Result<()> {
 //! # let mut t = termlens::Terminal::builder().spawn("true")?;
 //! insta::assert_snapshot!(t.screen());        // plain insta…
+//! # #[cfg(feature = "insta")]
 //! termlens::assert_screen_snapshot!(t.screen()); // …or the bundled macro
 //! # Ok(())
 //! # }


### PR DESCRIPTION
## What & why

Fixes #143.

The crate-level snapshot example compiled `termlens::assert_screen_snapshot!`
when the `insta` feature was disabled, even though that macro is feature-gated.
The example now compiles the bundled macro call only with `insta`.

CI also runs `cargo test --workspace --no-default-features` in its own required
job so the supported configuration stays covered. The direct
`insta::assert_snapshot!` example and default/all-features behavior are
unchanged.

## Validation

- `cargo check --workspace --all-targets --no-default-features --target x86_64-unknown-linux-gnu`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --target x86_64-unknown-linux-gnu -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --target x86_64-unknown-linux-gnu`
- `cargo +1.85.0 check --workspace --locked`
- `zizmor --persona=pedantic .github/workflows/`
- `cargo deny check`

The target crate-level doctest compiles with both `--no-default-features` and
`--all-features`. I could not complete the runtime doctest/workspace suites on
Windows because existing tests and examples require Unix APIs and `sh`; the new
CI job runs the full no-default-features command on Ubuntu.

## Checklist

- [x] Linked an issue (or explained above why none exists)
- [x] Tests added/updated for the change
- [ ] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`) — see [CONTRIBUTING.md §5](../CONTRIBUTING.md)
- [x] **No AI attribution trailers** (no AI co-authors, "Generated with" footers, or bot identities) — see [CONTRIBUTING.md §6](../CONTRIBUTING.md)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (user-facing changes only)
- [x] Snapshot changes (if any) were reviewed with `cargo insta review`, not blind-accepted — none
