### PR TITLE
fix(docs): check default feature documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - run: cargo doc --no-deps
       - run: cargo doc --no-deps --all-features
 
   deny:

--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -114,7 +114,7 @@ pub enum GraphicsFormat {
     /// kitty `f=32`: four bytes a pixel.
     Rgba,
     /// kitty `f=100`: a PNG file. Decoding one is out of scope — termlens
-    /// carries no image codec — so [`GraphicsPayload::decode`] reports it
+    /// carries no image codec — so `GraphicsPayload::decode` reports it
     /// as unsupported rather than guessing.
     Png,
     /// The sixel data stream itself.
@@ -226,7 +226,7 @@ impl GraphicsPayload {
     /// `s=`/`v=`, or a sixel's raster attributes.
     ///
     /// `None` when nothing declared one, which for sixel means the size is
-    /// implicit in the data; [`decode`](Self::decode) computes it there.
+    /// implicit in the data; `GraphicsPayload::decode` computes it there.
     #[must_use]
     pub fn size(&self) -> Option<(u32, u32)> {
         self.size

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -2714,7 +2714,7 @@ impl Terminal {
     /// belongs to the child until it has been reaped
     /// ([`wait_exit`](Self::wait_exit) or `Drop`) — after that the OS may
     /// reuse it, so don't deliver signals to a stored pid yourself;
-    /// [`signal`](Self::signal) has that guard built in.
+    /// `Terminal::signal` has that guard built in.
     #[must_use]
     pub fn pid(&self) -> Option<u32> {
         self.child.process_id()


### PR DESCRIPTION
Closes #156

## Background

cargo doc --no-deps with default features emitted unresolved intra-doc-link warnings for APIs gated behind the decode and Unix configurations. The existing docs CI job only built --all-features, so the default configuration was not checked.

## Changes

- Replace feature-gated intra-doc links with stable code-form references.
- Run cargo doc --no-deps in the existing docs CI job before the all-features build.

This keeps the public API and runtime behavior unchanged.

## Verification

- RUSTDOCFLAGS=-D warnings cargo doc --no-deps — passed
- RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features — passed
- cargo fmt --all -- --check — passed
- cargo test -p termlens --lib --all-features — 133 passed
- cargo check --workspace --all-features --locked — passed
- cargo check --workspace --no-default-features --locked — passed
- cargo clippy -p termlens --lib --all-features -- -D warnings — passed
- DCO and no-AI-attribution checks — passed

The full workspace test command was also attempted, but the repository's existing Unix-only crates/termlens/tests/process.rs fails to compile on this Windows host because Signal and Terminal::signal are cfg(unix).