### PR TITLE
fix: support no-default-features builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,19 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --all-features
 
+  no-default-features:
+    name: no-default-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - run: cargo test --workspace --no-default-features
+
   msrv:
     name: msrv
     runs-on: ubuntu-latest
@@ -136,7 +149,7 @@ jobs:
   required-green:
     name: required-green
     if: always()
-    needs: [fmt, clippy, test, msrv, docs, deny, zizmor]
+    needs: [fmt, clippy, test, no-default-features, msrv, docs, deny, zizmor]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every needed job succeeded

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -83,8 +83,11 @@
 //! ```no_run
 //! # fn main() -> termlens::Result<()> {
 //! # let mut t = termlens::Terminal::builder().spawn("true")?;
-//! insta::assert_snapshot!(t.screen());        // plain insta…
-//! termlens::assert_screen_snapshot!(t.screen()); // …or the bundled macro
+//! #[cfg(feature = "insta")]
+//! {
+//!     insta::assert_snapshot!(t.screen());        // plain insta…
+//!     termlens::assert_screen_snapshot!(t.screen()); // …or the bundled macro
+//! }
 //! # Ok(())
 //! # }
 //! ```
@@ -127,7 +130,10 @@ pub use insta;
 /// ```no_run
 /// # fn main() -> termlens::Result<()> {
 /// # let t = termlens::Terminal::builder().spawn("true")?;
-/// termlens::assert_screen_snapshot!(t.screen());
+/// #[cfg(feature = "insta")]
+/// {
+///     termlens::assert_screen_snapshot!(t.screen());
+/// }
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
## What & why

Closes #143.

The crate-level snapshot doctests referenced `insta`-gated APIs unconditionally, so `cargo test --workspace --no-default-features` failed even though `insta` is documented as optional. The CI workflow also did not exercise that supported configuration.

This change keeps the doctest entry points valid without `insta` by placing the snapshot calls behind `#[cfg(feature = "insta")]` blocks. It also adds a dedicated `no-default-features` CI job and makes `required-green` wait for it, preventing this configuration from regressing unnoticed.

## Checklist

- [x] Linked an issue (`Closes #143`)

- [x] Tests added/updated for the change (the affected doctest now exercises both feature configurations)

- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean

- [x] `cargo test --workspace --no-default-features` passes

- [x] `cargo test --workspace --all-features` passes

- [x] `cargo doc --no-deps --all-features` passes with `RUSTDOCFLAGS=-D warnings`

- [x] `cargo check --workspace --locked` passes

- [x] All commits are signed off (`git commit -s`)

- [x] No AI attribution trailers are present

- [x] `CHANGELOG.md` not updated; this is a developer-facing CI and doctest correctness fix

- [x] No snapshot changes

## Notes

The baseline failure was reproduced before the fix: `cargo test --workspace --no-default-features` reported 20 passing tests and 1 failing doctest. The final verification passed after the fix. The branch contains one signed-off commit and changes only `crates/termlens/src/lib.rs` and `.github/workflows/ci.yml`.