### PR TITLE
fix(ci): don't fail main on a squash message GitHub wrote

### DIFF
--- a/.github/scripts/check-dco.sh
+++ b/.github/scripts/check-dco.sh
@@ -6,18 +6,35 @@
 # (the repo is squash-merge only, so there should be none anyway).
 #
 # Usage:
-#   .github/scripts/check-dco.sh <base>..<head>
+#   .github/scripts/check-dco.sh <base>..<head> [composed-sha]
 #   .github/scripts/check-dco.sh <sha>          # single commit and ancestors
+#
+# The optional second argument names the one commit GitHub may have just
+# composed itself by squash-merging a pull request — the tip of a push to
+# main. See the web-flow block below for why that commit is treated
+# differently, and why naming it explicitly is what keeps the check honest.
 #
 # tests: exercise locally on a scratch branch before trusting it in CI —
 #   git checkout -b scratch/dco
 #   git commit --allow-empty -m "test: signed"  -s
 #   git commit --allow-empty -m "test: unsigned"
 #   .github/scripts/check-dco.sh main..HEAD   # must fail on the 2nd commit
+#   # and the composed-squash path, which must pass only when named:
+#   git -c user.email=noreply@github.com commit --allow-empty \
+#       -m "test: composed (#1)"
+#   .github/scripts/check-dco.sh main..HEAD            # must fail
+#   .github/scripts/check-dco.sh main..HEAD "$(git rev-parse HEAD)"  # passes
 #   git checkout - && git branch -D scratch/dco
 set -euo pipefail
 
-range="${1:?usage: check-dco.sh <range>}"
+range="${1:?usage: check-dco.sh <range> [composed-sha]}"
+composed="${2:-}"
+# Resolve it once, so the comparison below is sha-to-sha rather than
+# text-to-text. Empty (pull_request runs) or unresolvable leaves it empty,
+# which exempts nothing.
+if [ -n "$composed" ]; then
+  composed="$(git rev-parse --verify --quiet "${composed}^{commit}" || true)"
+fi
 
 fail=0
 count=0
@@ -34,11 +51,37 @@ while IFS= read -r sha; do
   # resulting merge commit we require a sign-off to be present but skip
   # the email match.
   if [ "$committer_email" = "noreply@github.com" ]; then
-    if ! git log -1 --format='%B' "$sha" | grep -qi '^signed-off-by:'; then
-      echo "::error::Merge/squash commit ${sha} carries no Signed-off-by at all."
-      echo "  subject: $(git log -1 --format='%s' "$sha")"
-      fail=1
+    if git log -1 --format='%B' "$sha" | grep -qi '^signed-off-by:'; then
+      continue
     fi
+
+    # ...except that GitHub composes the squash message itself, and drops
+    # the trailers of the commits it squashed whenever the branch contained
+    # a merge commit — someone pressing "Update branch" is enough. A pull
+    # request in which every commit was signed off then lands on main
+    # carrying no sign-off at all, and it cannot be repaired: main is linear
+    # history, non-fast-forward, and the ruleset has no bypass actors. The
+    # branch is red forever over a policy that was, in fact, met.
+    #
+    # It was met verifiably: `commit-policy` is a required status check on
+    # main, main accepts nothing except through a pull request, and the
+    # pull_request run checks every commit strictly — sign-off email against
+    # author email. So exempt this commit, and only this commit: the tip of
+    # the push, named by the caller, subject ending in the "(#123)" GitHub
+    # appends. A contributor cannot forge their way in here, because they
+    # cannot be the tip of a push to main without a pull request first.
+    if [ -n "$composed" ] && [ "$sha" = "$composed" ] \
+       && git log -1 --format='%s' "$sha" | grep -Eq '\(#[0-9]+\)$'; then
+      echo "::notice::${sha} is a squash-merge whose message GitHub composed" \
+           "without the trailers of the commits it replaced. Those commits" \
+           "were checked on the pull request."
+      echo "  subject: $(git log -1 --format='%s' "$sha")"
+      continue
+    fi
+
+    echo "::error::Merge/squash commit ${sha} carries no Signed-off-by at all."
+    echo "  subject: $(git log -1 --format='%s' "$sha")"
+    fail=1
     continue
   fi
 

--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -62,7 +62,14 @@ jobs:
       - name: DCO sign-off
         env:
           RANGE: ${{ steps.range.outputs.range }}
-        run: .github/scripts/check-dco.sh "$RANGE"
+          # On a push to main, the tip is the commit GitHub composed by
+          # squash-merging a pull request. Naming it lets the check tell that
+          # one commit apart from anything else with a web-flow committer, so
+          # a message GitHub wrote without the trailers it squashed does not
+          # fail a pull request that was, in fact, signed off. Empty on
+          # pull_request runs, where nothing is exempt.
+          COMPOSED: ${{ github.event_name == 'push' && github.event.after || '' }}
+        run: .github/scripts/check-dco.sh "$RANGE" "$COMPOSED"
 
       - name: No AI attribution
         # Run even when the DCO step failed, so one run reports everything.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,22 @@ construction. Such a commit must carry a sign-off, but is not matched against
 an author it did not choose. The commits that went into the PR were already
 checked, address and all, on the branch.
 
+GitHub also *writes* that message, and it drops the trailers of the commits it
+squashed whenever the branch contained a merge commit — pressing **Update
+branch** is enough to cause it. The merge then lands on main carrying no
+sign-off, and main is linear and non-fast-forward, so it cannot be repaired.
+The check therefore exempts exactly one commit — the tip of a push to main,
+which can only get there through a pull request that was already checked
+strictly. **Keep your branch up to date by rebasing, not merging:**
+
+```sh
+git fetch origin && git rebase origin/main
+git push --force-with-lease
+```
+
+That also matches what main requires: linear history, so a merge commit on
+your branch is only ever going to be squashed away.
+
 ## 6. AI tooling policy
 
 **AI assistance is welcome here — use whatever helps.** Every one of these

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -107,8 +107,11 @@ Real-world findings the pipeline caught (working exactly as designed):
   isn't verified on the account — see §2.2). `check-dco.sh` now exempts
   GitHub web-flow merge commits from the email match (a sign-off must
   still be present; the underlying PR commits were already fully checked).
-  The one red `commit-policy` run on `main` from before that fix is
-  expected history, not an unresolved failure.
+  The two red `commit-policy` runs on `main` — one from before that fix,
+  one on `471df02` (#158, whose branch carried a merge commit, so GitHub
+  composed a squash message with no trailers at all) — are expected
+  history, not unresolved failures. Both commits are immutable; the check
+  was corrected forward instead.
 
 ## 2. Manual steps for you
 
@@ -234,6 +237,13 @@ announcements are still in flight, with the draft in
     construction; a sign-off must still be present, and the real commits
     were already checked by the required PR run. Found live on the first
     squash merge; the brief's DCO design predates this GitHub behavior.
+    Extended after #158: GitHub also *drops* the squashed commits' trailers
+    when the branch contained a merge commit, so "a sign-off must still be
+    present" is not something a contributor can guarantee. The workflow now
+    names the tip of the push (`github.event.after`) as the composed commit,
+    and that one commit — subject ending `(#123)`, web-flow committer, no
+    sign-off — is exempted with a `::notice::`. Nothing else is: a commit
+    can only be that tip by way of a pull request the strict check passed.
 13. **Stress workflow prebuilds `--all-targets`** (not `--tests`) and the
     fixture tests carry 30s deadlines — the first stress run proved that
     compiling fixture bins mid-iteration on a cold 2-vCPU runner blows a


### PR DESCRIPTION
## What & why

Closes #159.

`commit-policy` failed on `main` for #158 — a pull request in which every commit
was signed off and whose `pull_request` run was green. GitHub composes the
squash-merge message itself, and when the branch contains a merge commit it
emits an empty body, taking the trailers with it. `471df02` landed with no
`Signed-off-by`, and `main` is linear + non-fast-forward with no bypass actors,
so the run is red permanently over a policy that was met.

The issue has the evidence: all four multi-commit PRs compared, and a scratch
probe showing `web_commit_signoff_required` does not help (GitHub neither
appends a sign-off nor refuses the commit, for commits created through the API).

## The change

`check-dco.sh` takes an optional second argument naming the commit GitHub may
have just composed — the tip of the push, passed as `github.event.after`, empty
on `pull_request` runs. Exactly that commit is exempted, and only when it looks
like a composed squash merge: web-flow committer, subject ending `(#123)`, no
sign-off at all. It reports a `::notice::` rather than passing silently.

Deliberately narrow:

- `pull_request` runs pass no argument, so nothing is exempt there.
- Every other commit keeps the strict sign-off-email-matches-author check.
- A web-flow commit without `(#123)` still fails, even when named.
- A commit that merely *looks* composed but is not the named tip still fails.

A contributor cannot reach the exemption. Being the tip of a push to `main`
means having gone through a pull request, where the strict check already ran and
is a required status check.

## Verification

Against the real commit, replaying the CI invocation:

| case | want | got |
|---|---|---|
| `471df02` unnamed (reproduces the failure) | fail | fail |
| `471df02` named as composed | pass | pass |
| `471df02` with a different sha named | fail | fail |
| `471df02` with a bogus sha named | fail | fail |
| `0623620`, `7b2322f` (signed squashes, unnamed) | pass | pass |

Synthetic, on a throwaway branch:

| case | want | got |
|---|---|---|
| signed ordinary commit | pass | pass |
| unsigned ordinary commit | fail | fail |
| web-flow, unsigned, no `(#N)`, even when named | fail | fail |
| forged web-flow `(#999)` that is not the named tip | fail | fail |
| forged web-flow `(#999)` that is the named tip | pass | pass |

The last row is the residual, and it is the point: that commit can only exist by
way of a pull request that already passed the strict check.

`actionlint` is clean on the workflow. The script's header carries the manual
test recipe for both paths, matching the convention already there.

## Also

`CONTRIBUTING.md` §5 now explains the dropped-trailer case and says to rebase
rather than merge when updating a branch — what `main`'s linear history wants
anyway, and it avoids the trigger. `docs/HANDOFF.md` §4.12 and the §2 note are
brought up to date, including that `471df02`'s red run is expected history.

## Note for the other repos

This script is byte-identical in six more repos — mossaic, reconverge,
launchbound, launchbound-action-demo, contribution-art, termlens-demo — each
with the same latent failure. They need the same patch.

## Checklist

- [x] Linked an issue (`Closes #159`)
- [x] Tests added/updated for the change — verified against `471df02` itself and
      synthetic cases; recipe recorded in the script header, per the existing
      convention for these scripts
- [x] `cargo fmt --all` and `cargo clippy` — not applicable, no Rust changed
- [x] All commits are signed off
- [x] No AI attribution trailers
- [x] `CHANGELOG.md` not updated — CI-only, nothing user-facing
- [x] No snapshot changes
