### PR TITLE
feat: add TerminalBuilder::envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Added
+
+- **`TerminalBuilder::envs` sets several child environment variables from an
+  iterator of key-value pairs.** Values keep their iteration and builder-call
+  order, and remain explicit when `env_clear` disables inherited variables.
+
 ### Fixed
 
 - **The crate's doctests build with default features disabled.** The bundled

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1008,13 +1008,35 @@ impl TerminalBuilder {
         self
     }
 
+    /// Set several environment variables for the child.
+    ///
+    /// Variables are applied in iteration order, so a later value for the
+    /// same key wins, including across calls to [`env`](Self::env). Entries
+    /// set here always reach the child, regardless of call order relative to
+    /// [`env_clear`](Self::env_clear).
+    #[must_use]
+    pub fn envs<I, K, V>(mut self, vars: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.envs.extend(
+            vars.into_iter()
+                .map(|(key, value)| (key.as_ref().to_os_string(), value.as_ref().to_os_string())),
+        );
+        self
+    }
+
     /// Don't inherit the parent process environment: the child sees only
-    /// variables set via [`env`](Self::env) (plus the default `TERM`, see
-    /// [`spawn`](Self::spawn)). Strict control keeps tests hermetic — a
-    /// developer's exotic `LS_COLORS` should never change a snapshot.
+    /// variables set via [`env`](Self::env) or [`envs`](Self::envs) (plus the
+    /// default `TERM`, see [`spawn`](Self::spawn)). Strict control keeps tests
+    /// hermetic — a developer's exotic `LS_COLORS` should never change a
+    /// snapshot.
     ///
     /// Note this differs from `std::process::Command::env_clear`, which also
-    /// discards explicitly set variables; here `env()` entries survive.
+    /// discards explicitly set variables; here `env()` and `envs()` entries
+    /// survive.
     #[must_use]
     pub fn env_clear(mut self) -> Self {
         self.env_clear = true;

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -9,7 +9,10 @@
 //! teardown (docs/DESIGN.md §2); keeping the child alive until the harness
 //! has seen the bytes makes these tests deterministic on every platform.
 
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use termlens::{Error, Key, Terminal};
 
@@ -73,6 +76,36 @@ fn env_vars_reach_the_child() -> termlens::Result<()> {
 }
 
 #[test]
+fn envs_accepts_common_pair_iterators() {
+    let vec_vars = vec![(String::from("VEC_KEY"), String::from("vec-value"))];
+    let map_vars = HashMap::from([("MAP_KEY", "map-value")]);
+
+    let _ = Terminal::builder()
+        .envs([("ARRAY_KEY", "array-value")])
+        .envs(vec_vars)
+        .envs(map_vars)
+        .envs(std::env::vars().take(0));
+}
+
+#[test]
+fn envs_and_env_preserve_order_and_duplicates() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .env("VALUE", "env-first")
+        .envs([("VALUE", "envs-first"), ("SECOND", "two")])
+        .env("VALUE", "env-last")
+        .envs([("THIRD", "three"), ("VALUE", "envs-last")])
+        .args([
+            "-c",
+            r#"echo "value=$VALUE second=$SECOND third=$THIRD"; read guard"#,
+        ])
+        .spawn(SH)?;
+    t.wait_until(|s| s.contains("value=envs-last second=two third=three"))?;
+    t.send(Key::Enter)?;
+    t.wait_exit()?;
+    Ok(())
+}
+
+#[test]
 fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termlens::Result<()> {
     // Probe HOME, not PATH: shells synthesize a compiled-in default PATH
     // when none is inherited, so PATH can't distinguish "inherited" from
@@ -83,14 +116,15 @@ fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termlens::
         "test needs HOME in the parent env"
     );
     let mut t = Terminal::builder()
+        .envs([("KEPT_BEFORE", "yes")])
         .env_clear()
-        .env("KEPT", "yes")
+        .envs([("KEPT_AFTER", "also")])
         .args([
             "-c",
-            r#"echo "home=${HOME:-unset} term=$TERM kept=$KEPT"; read guard"#,
+            r#"echo "home=${HOME:-unset} term=$TERM before=$KEPT_BEFORE after=$KEPT_AFTER"; read guard"#,
         ])
         .spawn(SH)?;
-    t.wait_until(|s| s.contains("kept=yes"))?;
+    t.wait_until(|s| s.contains("before=yes after=also"))?;
     let screen = t.screen();
     assert!(
         screen.contains("home=unset"),


### PR DESCRIPTION
## What & why

Add `TerminalBuilder::envs` as the plural counterpart to `env`, accepting any iterator of key-value pairs while preserving iteration and builder-call order. This removes the need to manually rebind a builder when variables already live in an array, `Vec`, `HashMap`, or environment iterator.

The integration coverage verifies duplicate-key precedence across mixed `env`/`envs` calls and confirms that values added both before and after `env_clear` survive while inherited variables remain blocked.

Closes #164

## Verification

- `cargo test -p termlens --test basic` (13 passed)
- `cargo test --workspace --all-features`
- `cargo test --workspace --no-default-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo +1.85.0 check --workspace --locked`
- `.github/scripts/check-dco.sh upstream/main..HEAD`
- `.github/scripts/check-no-ai-attribution.sh upstream/main..HEAD`

The stress workflow was not run because this change does not touch wait or timing behavior. No snapshots changed.

## Checklist

- [x] Linked an issue (or explained above why none exists)
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`) — see [CONTRIBUTING.md §5](../CONTRIBUTING.md)
- [x] **No AI attribution trailers** (no AI co-authors, "Generated with" footers, or bot identities) — see [CONTRIBUTING.md §6](../CONTRIBUTING.md)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (user-facing changes only)
- [x] Snapshot changes (if any) were reviewed with `cargo insta review`, not blind-accepted
