### PR TITLE
test(styles): cover dim and italic attributes

### DIFF
--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -145,3 +145,31 @@ fn strikethrough_and_blink_appear_in_the_styled_rendering() -> termlens::Result<
     assert!(t.wait_exit()?.success());
     Ok(())
 }
+
+#[test]
+fn dim_and_italic_appear_without_shadow_collisions() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf '\033[2mfaint\033[0m ",
+        r"\033[3mslanted\033[0m\n'; read guard"
+    ))?;
+    t.wait_until(|s| s.contains("slanted") && s.cursor() == (1, 0, true))?;
+    let s = t.screen();
+
+    let faint = s.find("faint").expect("dim run");
+    let dim = *s.cell(faint.0, faint.1).unwrap().style();
+    assert!(dim.dim && !dim.italic);
+
+    let slanted = s.find("slanted").expect("italic run");
+    let italic = *s.cell(slanted.0, slanted.1).unwrap().style();
+    assert!(italic.italic && !italic.dim && !italic.conceal);
+
+    // These words deliberately do not name the attributes, so the style
+    // rendering cannot satisfy either assertion with visible text alone.
+    let styled = s.with_styles().to_string();
+    assert!(styled.contains("0: 0-4 dim"), "{styled}");
+    assert!(styled.contains("6-12 italic"), "{styled}");
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}


### PR DESCRIPTION
## What & why

Add a focused real-PTY regression for the two `Style` attributes that had no integration assertion:

- emit SGR 2 and SGR 3 runs and assert their cells report `dim` and `italic`
- assert the dim run is not italic and the italic run is neither dim nor conceal
- verify `with_styles()` names both attributes using visible text that cannot satisfy the style-name assertions by itself

This pins the primary italic flag separately from the shadow parser carrier used for conceal.

Closes #163

## Verification

- Red proof: temporarily made the emulator report both attributes as false; the new test failed at the dim assertion. Restored production code before committing.
- `cargo test --locked -p termlens --test styles dim_and_italic_appear_without_shadow_collisions -- --exact --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo test --workspace --no-default-features --locked`
- `cargo +1.85.0 check --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --locked`
- `.github/scripts/check-dco.sh upstream/main..HEAD`
- `.github/scripts/check-no-ai-attribution.sh upstream/main..HEAD`

## Deliberately not changed

No production behavior, snapshots, public API, or changelog entry changed; this PR only adds executable coverage for existing behavior.

## Checklist

- [x] Linked an issue
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] All commits are signed off (`git commit -s`)
- [x] No AI attribution trailers
- [x] `CHANGELOG.md` update is not applicable because this is test-only
- [x] Snapshot review is not applicable because no snapshots changed