### PR TITLE
fix: Remove unused workspace termlens dependency pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ repository = "https://github.com/vyncint/termlens"
 authors = ["Vyncint Ng <vyncint@icloud.com>"]
 
 [workspace.dependencies]
-termlens = { path = "crates/termlens", version = "0.6.0" }
 
 portable-pty = "0.9"
 vt100 = "0.16"


### PR DESCRIPTION
## Summary

Remove unused workspace termlens dependency pin

## Changes

- Remove unused workspace.dependencies.termlens pin (was 0.6.0 vs package 0.6.1)

Fixes #162
