### PR TITLE
feat!: OSC 8 links, cursor shape, Key::Insert, and non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,69 @@ listed under a **Changed** or **Removed** heading.
   iterator of key-value pairs.** Values keep their iteration and builder-call
   order, and remain explicit when `env_clear` disables inherited variables.
 
+- **`Screen::links` reports the `OSC 8` hyperlinks an application emitted.**
+  A hyperlink changes no cell — its label renders exactly as unlinked text
+  would — so the URL existed nowhere a test could reach, and an assertion
+  that a TUI linked an issue, a file or a doc page **passed identically
+  against an application that emitted no link at all, or linked the wrong
+  target**. Captured rather than answered, on the same grounds as the
+  `OSC 52` clipboard: the only evidence otherwise available is the
+  application's own visible output, which proves the code path ran and
+  nothing about where it points.
+
+  Each span reports its `uri`, its `id` (spans sharing one are one logical
+  link), the `label` it wrapped, and whether the application ever `closed`
+  it — an unterminated link is a real defect, because in a real terminal
+  every character written afterwards joins it. Two bounds keep the capture
+  honest: the log holds the most recent 64 spans and evicts oldest-first, so
+  a TUI that redraws its links every frame still reports the current
+  frame's; and a label past the capture bound is reported as *unknown*
+  rather than as a prefix, since a prefix of the wrong length is a wrong
+  answer.
+
+- **`Screen::cursor_shape` and `Screen::cursor_blink` report `DECSCUSR`.**
+  A screen where the application asked for a bar and one where it never
+  asked used to be the same `Screen`. The shape is load-bearing behaviour
+  rather than decoration — a modal editor switches to a bar for insert and
+  back to a block for normal, and "the mode indicator says INSERT" and "the
+  terminal was actually put into insert" are different claims. It also makes
+  the *restore* assertable, which is the half that ships broken: a program
+  that changes the cursor and never changes it back leaves the user's
+  terminal wrong after exit, the same class of defect `alternate_screen()`
+  already catches.
+
+  Shape and blink are one `DECSCUSR` parameter but two facts, so they are
+  reported apart. `CursorShape::Default` — the application never sent the
+  escape — is a third state and is reported as itself rather than folded
+  into `Block`.
+
+- **`Key::Insert`**, encoding `ESC [ 2 ~`, and chording like its
+  neighbours (`Key::Insert.shift()` → `ESC [ 2 ; 2 ~`). It was the `2`
+  missing from a navigation run that already had `3`, `5` and `6`, so an
+  application binding Insert could not be tested without hand-writing the
+  escape.
+
+### Changed
+
+- **`Key` and `Signal` are now `#[non_exhaustive]`.** This is breaking for
+  downstream code that `match`es either without a wildcard arm; adding a
+  `_ => …` fixes it, and equality and construction are unaffected.
+
+  Worth doing now rather than later. Adding a variant to an exhaustive
+  public enum is itself a breaking change, so every future key and every
+  future signal would have cost a version of its own — `Key` has no F13+ and
+  no keypad, and `Signal` carries seven of POSIX's thirty, missing
+  `SIGWINCH` and `SIGCONT`, which are exactly what a terminal application
+  reacts to. Both types are *constructed* far more often than matched
+  (`t.send(Key::Enter)`, `t.signal(Signal::Int)`), so the cost falls almost
+  entirely on the crate and not on its users. `#[non_exhaustive]` is
+  breaking to add, which makes the cheapest moment the earliest one.
+
+  `Color` is deliberately left exhaustive. Default, palette index and 24-bit
+  RGB is the whole terminal colour model — there is no fourth variant
+  waiting — and `Color` is the one enum here that downstream code really
+  does match on.
+
 ### Fixed
 
 - **The crate's doctests build with default features disabled.** The bundled

--- a/README.md
+++ b/README.md
@@ -104,9 +104,15 @@ the emulator knows which modes the app enabled. A `drag` reports one
 motion **per cell crossed**, so an application that paints along the path
 sees the path. The same knowledge is
 readable from every `Screen`: the window title, the alternate-screen
-flag, the input modes and the last `OSC 52` clipboard write are plain
-accessors, so "did the app enter the alt screen?" and "did it copy the
-right text?" are assertions, not inferences. Focus events go the other way:
+flag, the input modes, the last `OSC 52` clipboard write, the cursor
+shape the app asked for with `DECSCUSR`, and the `OSC 8` hyperlinks it
+emitted are plain accessors, so "did the app enter the alt screen?",
+"did it copy the right text?", "did it put the terminal into insert
+mode — and put it back?" and "did it link the right URL?" are
+assertions, not inferences. The last two matter because neither changes
+a cell: a hyperlink's label renders as ordinary text with its URL
+nowhere on the screen, so before `links()` a test asserting a link
+passed identically against an application that emitted none. Focus events go the other way:
 `focus_out()` reaches an application that enabled mode 1004, so the
 unfocused branch of a UI can be driven at all.
 

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -21,12 +21,29 @@
 use std::sync::Arc;
 
 use crate::graphics::{GraphicsBuilder, GraphicsCounts, GraphicsPayload};
-use crate::screen::Clipboard;
+use crate::screen::{Clipboard, Link};
 
 /// OSC strings are captured whole (titles must not truncate), but bounded:
 /// a buggy or hostile stream must not grow memory without limit. No real
 /// title comes anywhere near this.
 const OSC_CAPTURE_MAX: usize = 64 * 1024;
+
+/// How many `OSC 8` spans to keep, oldest evicted.
+///
+/// Bounded rather than unbounded because a TUI redraws: an application that
+/// links five things every frame would otherwise grow this forever. Sixty-four
+/// holds many screens' worth of links, so the current frame's are always
+/// present, which is what a test asserts on.
+const LINK_HISTORY: usize = 64;
+
+/// How many label bytes one span may accumulate.
+///
+/// This is the bound that stops an *unterminated* link from bleeding into the
+/// rest of the stream: without it, one missing `OSC 8 ; ; ST` makes every
+/// byte the application writes afterwards part of one label. Past it the
+/// label is reported as unknown rather than as a prefix — a prefix of the
+/// wrong length is still a wrong answer.
+const LINK_LABEL_MAX: usize = 4 * 1024;
 
 /// Decode standard base64 (`OSC 52` payloads). `None` for anything that is
 /// not valid: an out-of-alphabet byte, a bad length, or padding in the
@@ -253,6 +270,19 @@ pub(crate) struct SeqTracker {
     title: Arc<str>,
     /// The most recent `OSC 52` clipboard write, decoded.
     clipboard: Option<Arc<Clipboard>>,
+    /// `OSC 8` spans seen, oldest first. A span is pushed when it *opens* —
+    /// the URI is known then, and a test waiting for a link should not have
+    /// to wait for the application to close it — and completed in place when
+    /// it closes.
+    links: Arc<Vec<Link>>,
+    /// Label bytes of the span currently open. Held outside `links` so the
+    /// shared vector is touched twice per span (open, close) rather than
+    /// once per character written.
+    link_label: Vec<u8>,
+    /// True while a span is open, so printable bytes know where to go.
+    link_open: bool,
+    /// Set when the open span's label passed [`LINK_LABEL_MAX`].
+    link_label_truncated: bool,
     /// Bells rung in ground state. A `BEL` closing an OSC string is a
     /// terminator and one inside a DCS-class string is payload; neither is
     /// a bell, and both are handled by the state machine rather than here.
@@ -274,6 +304,12 @@ pub(crate) struct SeqTracker {
     /// Tracked here because vt100 does not model 1004 at all — the same
     /// reason the window title is tracked here.
     focus_events: bool,
+    /// The raw `DECSCUSR` parameter the application last asked for, or
+    /// `None` while it has never asked. Kept as the parameter rather than
+    /// as a decoded shape so the one place that knows what `5` means is
+    /// the accessor on `Screen`, and "never asked" stays distinguishable
+    /// from every value it could have asked for.
+    cursor_style: Option<u8>,
     /// Which introducer opened the current DCS-class string: `P` (DCS),
     /// `X` (SOS), `^` (PM) or `_` (APC). Sixel and kitty graphics differ
     /// only by this, so consuming all four alike — which is all the tracker
@@ -326,12 +362,17 @@ impl SeqTracker {
             osc_truncated: false,
             title: Arc::from(""),
             clipboard: None,
+            links: Arc::new(Vec::new()),
+            link_label: Vec::new(),
+            link_open: false,
+            link_label_truncated: false,
             bells: 0,
             counts: GraphicsCounts::default(),
             building: GraphicsBuilder::default(),
             capture,
             frame_printable: 0,
             focus_events: false,
+            cursor_style: None,
             dcs_introducer: 0,
             dcs_final: 0,
             dcs_intermediate: 0,
@@ -376,6 +417,54 @@ impl SeqTracker {
         self.bells
     }
 
+    /// The `OSC 8` hyperlinks seen so far, oldest first.
+    pub(crate) fn links(&self) -> Arc<Vec<Link>> {
+        Arc::clone(&self.links)
+    }
+
+    /// Begin an `OSC 8` span. Any span still open is closed first: a new
+    /// URI supersedes the current one in a real terminal, so treating it as
+    /// nested would attribute the new label to the old target.
+    fn open_link(&mut self, params: &[u8], uri: &[u8]) {
+        self.close_link();
+        // `id=` is the one standard parameter; the list is `:`-separated.
+        let id = params
+            .split(|&b| b == b':')
+            .find_map(|pair| pair.strip_prefix(b"id="))
+            .map(|value| String::from_utf8_lossy(value).into_owned());
+        let uri = String::from_utf8_lossy(uri).into_owned();
+        let links = Arc::make_mut(&mut self.links);
+        links.push(Link::open(&uri, id.as_deref()));
+        while links.len() > LINK_HISTORY {
+            links.remove(0);
+        }
+        self.link_open = true;
+        self.link_label.clear();
+        self.link_label_truncated = false;
+    }
+
+    /// Close the open `OSC 8` span, if any, recording the text it wrapped.
+    fn close_link(&mut self) {
+        if !self.link_open {
+            return;
+        }
+        self.link_open = false;
+        let raw = std::mem::take(&mut self.link_label);
+        let label = if self.link_label_truncated {
+            None
+        } else {
+            // Invalid UTF-8 is refused rather than replaced: a label with
+            // U+FFFD in it is not the text the user sees.
+            String::from_utf8(raw).ok()
+        };
+        self.link_label_truncated = false;
+        // The open span is the newest, and eviction only ever drops the
+        // oldest, so the one to complete is the last.
+        if let Some(link) = Arc::make_mut(&mut self.links).last_mut() {
+            link.close(label);
+        }
+    }
+
     /// Inline graphics counted so far.
     pub(crate) fn graphics(&self) -> GraphicsCounts {
         self.counts
@@ -384,6 +473,11 @@ impl SeqTracker {
     /// True while the application has focus reporting (mode 1004) enabled.
     pub(crate) fn focus_events(&self) -> bool {
         self.focus_events
+    }
+
+    /// The raw `DECSCUSR` parameter last requested, `None` if never.
+    pub(crate) fn cursor_style(&self) -> Option<u8> {
+        self.cursor_style
     }
 
     /// Printable characters written since the current frame began, cleared
@@ -462,10 +556,11 @@ impl SeqTracker {
                 self.csi_has_digits = true;
             }
             b';' => self.end_csi_param(),
-            // `$` is the intermediate of the DECRQM request (`CSI ? n $ p`);
-            // recording it keeps the sequence classifiable instead of
-            // discarding it as unrecognized.
-            b'$' => self.csi_intermediate = b'$',
+            // `$` is the intermediate of the DECRQM request (`CSI ? n $ p`)
+            // and `SP` of DECSCUSR (`CSI Ps SP q`); recording them keeps
+            // those sequences classifiable instead of discarding them as
+            // unrecognized.
+            b'$' | b' ' => self.csi_intermediate = b,
             // Sub-parameters or other intermediates: none of the sequences
             // we recognize use them.
             _ => self.csi_invalid = true,
@@ -496,6 +591,34 @@ impl SeqTracker {
                 (_, b'p' | b'y') => SeqEvent::Query(Query::Unanswerable(self.seq_printable())),
                 _ => SeqEvent::None,
             };
+        }
+
+        // DECSCUSR (`CSI Ps SP q`): the shape of the cursor, and whether it
+        // blinks. vt100 models neither, so a modal editor switching to a bar
+        // for insert mode is invisible without this — as is the program that
+        // switches and never switches back, which leaves the user's terminal
+        // wrong after exit.
+        //
+        // Also reached by the other `SP`-intermediate sequences (SL, SR).
+        // They are not ours to act on, and returning here keeps them out of
+        // the plain-CSI table below, which assumes no intermediate — exactly
+        // as they were kept out by `csi_invalid` before `SP` was accepted.
+        if self.csi_intermediate == b' ' {
+            if b == b'q' && self.csi_prefix == 0 && self.csi_param_count <= 1 {
+                // An omitted parameter means 0. Values above 6 are undefined
+                // and xterm ignores them; so do we, leaving the last style
+                // the application actually asked for rather than inventing
+                // one it did not.
+                let ps = if self.csi_param_count == 0 {
+                    0
+                } else {
+                    self.csi_first_param
+                };
+                if let Ok(style @ 0..=6) = u8::try_from(ps) {
+                    self.cursor_style = Some(style);
+                }
+            }
+            return SeqEvent::None;
         }
 
         // DEC private mode 1004 (focus reporting). vt100 does not model it,
@@ -609,6 +732,38 @@ impl SeqTracker {
                         .or_else(|| content.strip_prefix(b"2;"))
                     {
                         self.title = Arc::from(String::from_utf8_lossy(title));
+                    } else if let Some(rest) = content.strip_prefix(b"8;") {
+                        // `OSC 8 ; params ; URI` opens a hyperlink span and
+                        // `OSC 8 ; ; ` closes it. Captured rather than
+                        // answered, exactly as OSC 52 is below: the label
+                        // renders as ordinary text, so the URL exists
+                        // nowhere else and "did it link the right place?"
+                        // is otherwise unanswerable.
+                        //
+                        // Parameters cannot contain `;`, so the first one
+                        // ends them and everything after is the URI —
+                        // which may itself contain `;` in a query string.
+                        // No separator at all is malformed, and a malformed
+                        // sequence is not a close: silently ending the span
+                        // would attribute the text after it to nothing.
+                        if let Some(sep) = rest.iter().position(|&b| b == b';') {
+                            // A truncated OSC cannot be acted on in either
+                            // direction: the URI we hold is a prefix, and
+                            // opening a span on it would record a link the
+                            // application never emitted.
+                            if !self.osc_truncated {
+                                // Owned before the call: both helpers take
+                                // `&mut self`, and these slices point into
+                                // `osc_buf`, which is part of it.
+                                let params = rest[..sep].to_vec();
+                                let uri = rest[sep + 1..].to_vec();
+                                if uri.is_empty() {
+                                    self.close_link();
+                                } else {
+                                    self.open_link(&params, &uri);
+                                }
+                            }
+                        }
                     } else if let Some(rest) = content.strip_prefix(b"52;") {
                         // OSC 52 write: `targets ; base64`. The reads were
                         // classified above, so anything here is a write.
@@ -827,6 +982,17 @@ impl SeqTracker {
                     // printable.
                     if self.utf8_remaining == 0 && b >= 0x20 && b != 0x7f {
                         self.frame_printable = self.frame_printable.saturating_add(1);
+                    }
+                    // Text written inside an `OSC 8` span is that link's
+                    // label. Bytes rather than characters, so a multi-byte
+                    // grapheme survives the split — continuation bytes are
+                    // all >= 0x80 and pass the same test.
+                    if self.link_open && b >= 0x20 && b != 0x7f {
+                        if self.link_label.len() < LINK_LABEL_MAX {
+                            self.link_label.push(b);
+                        } else {
+                            self.link_label_truncated = true;
+                        }
                     }
                     self.track_utf8(b);
                     State::Ground
@@ -1144,6 +1310,216 @@ mod tests {
             "a transmit is not a question: {events:?}"
         );
         assert_eq!(t.graphics().kitty, 1);
+    }
+
+    /// The links a fed tracker holds, as `(uri, id, label, closed)`.
+    fn links(bytes: &[u8]) -> Vec<(String, Option<String>, Option<String>, bool)> {
+        fed(bytes)
+            .links()
+            .iter()
+            .map(|l| {
+                (
+                    l.uri().to_string(),
+                    l.id().map(str::to_string),
+                    l.label().map(str::to_string),
+                    l.closed(),
+                )
+            })
+            .collect()
+    }
+
+    /// The reproduction from the issue: the label renders as ordinary text
+    /// and the URL has to be somewhere a test can reach.
+    #[test]
+    fn an_osc8_span_records_its_uri_and_the_text_it_wrapped() {
+        let seen = links(b"see \x1b]8;;https://example.invalid/a\x1b\\docs\x1b]8;;\x1b\\ here");
+        assert_eq!(
+            seen,
+            vec![(
+                "https://example.invalid/a".to_string(),
+                None,
+                Some("docs".to_string()),
+                true
+            )]
+        );
+    }
+
+    #[test]
+    fn a_bel_terminated_span_and_a_multibyte_label_both_survive() {
+        // BEL is the other legal OSC terminator, and the one `printf` in a
+        // shell reaches for.
+        let seen = links("\x1b]8;;http://x/\x07café\x1b]8;;\x07".as_bytes());
+        assert_eq!(seen[0].2, Some("café".to_string()));
+        assert!(seen[0].3);
+    }
+
+    #[test]
+    fn the_id_parameter_is_kept_so_multi_span_links_can_be_grouped() {
+        let seen = links(
+            b"\x1b]8;id=42:x=y;http://x/\x1b\\one\x1b]8;;\x1b\\               \x1b]8;id=42;http://x/\x1b\\two\x1b]8;;\x1b\\",
+        );
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen[0].1.as_deref(), Some("42"));
+        assert_eq!(seen[1].1.as_deref(), Some("42"));
+        assert_eq!(seen[0].2.as_deref(), Some("one"));
+        assert_eq!(seen[1].2.as_deref(), Some("two"));
+    }
+
+    /// A URI with a query string contains `;` of its own. Splitting on the
+    /// last separator, or on all of them, truncates the target silently —
+    /// which is precisely the wrong-URL failure this feature exists to catch.
+    #[test]
+    fn only_the_first_separator_ends_the_parameters() {
+        let seen = links(b"\x1b]8;;http://x/?a=1;b=2\x1b\\t\x1b]8;;\x1b\\");
+        assert_eq!(seen[0].0, "http://x/?a=1;b=2");
+    }
+
+    /// An unterminated span is a real defect — in a real terminal every
+    /// character after it joins the link — so it is reported rather than
+    /// dropped, and its label is bounded rather than allowed to swallow the
+    /// stream.
+    #[test]
+    fn an_unterminated_span_is_reported_open_and_cannot_bleed() {
+        let mut bytes = b"\x1b]8;;http://x/\x1b\\".to_vec();
+        bytes.extend(std::iter::repeat_n(b'z', LINK_LABEL_MAX + 100));
+        let seen = links(&bytes);
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].0, "http://x/");
+        assert!(!seen[0].3, "the application never closed it");
+        // Still open, so there is no final label — and the bound means the
+        // captured bytes are a prefix, which is not an answer either.
+        assert_eq!(seen[0].2, None);
+    }
+
+    #[test]
+    fn a_label_past_the_bound_is_unknown_rather_than_a_prefix() {
+        let mut bytes = b"\x1b]8;;http://x/\x1b\\".to_vec();
+        bytes.extend(std::iter::repeat_n(b'z', LINK_LABEL_MAX + 1));
+        bytes.extend_from_slice(b"\x1b]8;;\x1b\\");
+        let seen = links(&bytes);
+        assert!(seen[0].3, "closed");
+        assert_eq!(
+            seen[0].2, None,
+            "a prefix of the wrong length is a wrong answer"
+        );
+    }
+
+    /// A real terminal replaces the current target rather than nesting, so a
+    /// second open closes the first — otherwise the second label would be
+    /// attributed to the first URI.
+    #[test]
+    fn a_new_span_supersedes_one_left_open() {
+        let seen = links(b"\x1b]8;;http://a/\x1b\\one\x1b]8;;http://b/\x1b\\two\x1b]8;;\x1b\\");
+        assert_eq!(seen.len(), 2);
+        assert_eq!(
+            (seen[0].0.as_str(), seen[0].2.as_deref()),
+            ("http://a/", Some("one"))
+        );
+        assert_eq!(
+            (seen[1].0.as_str(), seen[1].2.as_deref()),
+            ("http://b/", Some("two"))
+        );
+    }
+
+    /// A URI past the OSC capture bound is a *prefix*, and opening a span on
+    /// a prefix records a link pointing somewhere the application never
+    /// named — the wrong-URL failure this feature exists to catch, only
+    /// manufactured by termlens rather than by the program under test.
+    /// Refused outright, exactly as a truncated `OSC 52` payload is.
+    #[test]
+    fn an_osc8_past_the_capture_bound_is_refused_rather_than_truncated() {
+        let mut bytes = b"\x1b]8;;http://x/".to_vec();
+        bytes.extend(std::iter::repeat_n(b'a', OSC_CAPTURE_MAX));
+        bytes.extend_from_slice(b"\x1b\\label\x1b]8;;\x1b\\");
+        assert!(
+            links(&bytes).is_empty(),
+            "a truncated URI must not become a link"
+        );
+    }
+
+    #[test]
+    fn a_malformed_osc8_neither_opens_nor_closes() {
+        // No second `;` at all: not a link, and not a close either —
+        // silently closing would attribute what follows to nothing.
+        let seen = links(b"\x1b]8;http://x/\x1b\\t");
+        assert!(seen.is_empty());
+        // An open, then a malformed one, then text: the text still belongs
+        // to the span that is actually open.
+        let seen = links(b"\x1b]8;;http://x/\x1b\\a\x1b]8;junk\x1b\\b\x1b]8;;\x1b\\");
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].2.as_deref(), Some("ab"));
+    }
+
+    #[test]
+    fn control_characters_are_not_part_of_a_label() {
+        // A newline moves the cursor; it does not spell anything.
+        let seen = links(b"\x1b]8;;http://x/\x1b\\a\r\nb\x1b]8;;\x1b\\");
+        assert_eq!(seen[0].2.as_deref(), Some("ab"));
+    }
+
+    #[test]
+    fn the_link_log_is_bounded_and_evicts_the_oldest() {
+        let mut bytes = Vec::new();
+        for n in 0..LINK_HISTORY + 10 {
+            bytes
+                .extend_from_slice(format!("\x1b]8;;http://x/{n}\x1b\\l\x1b]8;;\x1b\\").as_bytes());
+        }
+        let seen = links(&bytes);
+        assert_eq!(seen.len(), LINK_HISTORY);
+        // Oldest evicted, newest kept.
+        assert_eq!(seen[0].0, "http://x/10");
+        assert_eq!(
+            seen[LINK_HISTORY - 1].0,
+            format!("http://x/{}", LINK_HISTORY + 9)
+        );
+    }
+
+    #[test]
+    fn an_application_that_emits_no_links_reports_none() {
+        assert!(links(b"plain text\x1b]0;title\x07").is_empty());
+    }
+
+    #[test]
+    fn decscusr_records_the_parameter_the_application_asked_for() {
+        // Never asked is its own state, and not the same as any value.
+        assert_eq!(fed(b"hello").cursor_style(), None);
+        for ps in 0u8..=6 {
+            let bytes = format!("\x1b[{ps} q");
+            assert_eq!(
+                fed(bytes.as_bytes()).cursor_style(),
+                Some(ps),
+                "DECSCUSR {ps} was not recorded"
+            );
+        }
+        // An omitted parameter is 0 (a blinking block), per xterm.
+        assert_eq!(fed(b"\x1b[ q").cursor_style(), Some(0));
+        // The last one wins, which is what makes a restore assertable.
+        assert_eq!(fed(b"\x1b[5 q\x1b[2 q").cursor_style(), Some(2));
+    }
+
+    #[test]
+    fn an_undefined_or_misshapen_decscusr_leaves_the_last_known_style() {
+        // 7+ is undefined; xterm ignores it, and inventing a shape here
+        // would report one the application never asked for.
+        assert_eq!(fed(b"\x1b[5 q\x1b[7 q").cursor_style(), Some(5));
+        assert_eq!(fed(b"\x1b[7 q").cursor_style(), None);
+        // A private prefix or a second parameter makes it a different
+        // sequence, not a DECSCUSR with extra decoration.
+        assert_eq!(fed(b"\x1b[?5 q").cursor_style(), None);
+        assert_eq!(fed(b"\x1b[5;2 q").cursor_style(), None);
+    }
+
+    /// `SP` is the intermediate of DECSCUSR *and* of SL/SR (`CSI Ps SP @`
+    /// / `A`), which scroll the screen sideways. Accepting the intermediate
+    /// must not turn those into a cursor style, nor let them fall through
+    /// into the query table below, which assumes no intermediate.
+    #[test]
+    fn the_other_space_intermediate_sequences_are_not_cursor_styles() {
+        for seq in [&b"\x1b[2 @"[..], b"\x1b[2 A", b"\x1b[1 t"] {
+            let mut t = fed(seq);
+            assert_eq!(t.cursor_style(), None, "{seq:?} set a cursor style");
+            assert_eq!(t.step(b'x'), SeqEvent::None);
+        }
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -252,6 +252,8 @@ impl Emulator for Vt100Emulator {
             clipboard: self.tracker.clipboard(),
             bells: self.tracker.bells(),
             focus_events: self.tracker.focus_events(),
+            cursor_style: self.tracker.cursor_style(),
+            links: self.tracker.links(),
             graphics: GraphicsSeen::new(self.tracker.graphics(), Arc::clone(&self.graphics)),
             // Filled in by the terminal, which owns the frame count.
             repaints: 0,

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -11,7 +11,42 @@
 /// A key press to send to the terminal.
 ///
 /// Encodings follow xterm defaults; see [`Key::encode`].
+///
+/// Marked `#[non_exhaustive]`: the keyboard is open-ended — F13+, the
+/// keypad and the media keys are all absent today — and a `Key` is
+/// something tests *construct* (`t.send(Key::Enter)`) far more often than
+/// they match on, so the attribute costs downstream code a `_ =>` arm in
+/// the rare match and buys every future key a place to land without a
+/// major release. The cost lands on `match`, which needs a wildcard arm even
+/// when it already names every variant that exists today:
+///
+/// ```compile_fail
+/// # use termlens::Key;
+/// fn arity(k: Key) -> u8 {
+///     match k {
+///         Key::Char(_) | Key::Ctrl(_) | Key::Alt(_) | Key::F(_) => 0,
+///         Key::Enter | Key::Esc | Key::Tab | Key::BackTab | Key::Backspace => 1,
+///         Key::Insert | Key::Delete | Key::Up | Key::Down | Key::Left => 2,
+///         Key::Right | Key::Home | Key::End | Key::PageUp | Key::PageDown => 3,
+///     }
+/// }
+/// ```
+///
+/// One `_` arm is the whole cost, and constructing is unaffected:
+///
+/// ```
+/// # use termlens::Key;
+/// fn arity(k: Key) -> u8 {
+///     match k {
+///         Key::Enter => 1,
+///         _ => 0,
+///     }
+/// }
+/// assert_eq!(arity(Key::Enter), 1);
+/// assert_eq!(arity(Key::Insert), 0);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Key {
     /// A literal character, sent as its UTF-8 bytes.
     Char(char),
@@ -44,6 +79,8 @@ pub enum Key {
     BackTab,
     /// Backspace. Sends DEL (`0x7F`), xterm's default erase byte.
     Backspace,
+    /// Insert (`ESC [ 2 ~`).
+    Insert,
     /// Forward delete (`ESC [ 3 ~`).
     Delete,
     /// Up arrow (`ESC [ A`).
@@ -97,6 +134,7 @@ impl Key {
             Key::Tab => vec![b'\t'],
             Key::BackTab => b"\x1b[Z".to_vec(),
             Key::Backspace => vec![0x7f],
+            Key::Insert => b"\x1b[2~".to_vec(),
             Key::Delete => b"\x1b[3~".to_vec(),
             Key::Up => b"\x1b[A".to_vec(),
             Key::Down => b"\x1b[B".to_vec(),
@@ -206,7 +244,7 @@ pub struct Chord {
 
 impl Key {
     /// A `Ctrl` chord over this special key (arrows, Home/End,
-    /// PageUp/Down, Delete, F1–F12).
+    /// PageUp/Down, Insert, Delete, F1–F12).
     ///
     /// # Panics
     ///
@@ -308,6 +346,7 @@ fn chord_base(key: Key) -> Option<ChordBase> {
         Key::Home => ChordBase::Letter('H'),
         Key::End => ChordBase::Letter('F'),
         Key::F(n @ 1..=4) => ChordBase::Letter(['P', 'Q', 'R', 'S'][usize::from(n) - 1]),
+        Key::Insert => ChordBase::Tilde(2),
         Key::Delete => ChordBase::Tilde(3),
         Key::PageUp => ChordBase::Tilde(5),
         Key::PageDown => ChordBase::Tilde(6),
@@ -366,6 +405,7 @@ mod tests {
             (Key::Tab, b"\t"),
             (Key::BackTab, b"\x1b[Z"),
             (Key::Backspace, b"\x7f"),
+            (Key::Insert, b"\x1b[2~"),
             (Key::Delete, b"\x1b[3~"),
             (Key::Up, b"\x1b[A"),
             (Key::Down, b"\x1b[B"),
@@ -413,6 +453,7 @@ mod tests {
             (Key::Home.ctrl(), b"\x1b[1;5H"),
             (Key::End.ctrl().shift(), b"\x1b[1;6F"),
             (Key::PageDown.alt(), b"\x1b[6;3~"),
+            (Key::Insert.shift(), b"\x1b[2;2~"),
             (Key::Delete.ctrl(), b"\x1b[3;5~"),
             (Key::F(1).ctrl(), b"\x1b[1;5P"),
             (Key::F(5).ctrl().shift(), b"\x1b[15;6~"),

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -60,8 +60,14 @@
 //! that enabled mode 1004 so the unfocused branch of a UI can be driven at
 //! all. The terminal's out-of-band state — the window title, the
 //! alternate-screen flag, the input modes, the last `OSC 52`
-//! [clipboard](Screen::clipboard) write — is readable from every
-//! [`Screen`] as plain accessors.
+//! [clipboard](Screen::clipboard) write, the
+//! [cursor shape](Screen::cursor_shape) the application asked for, and the
+//! `OSC 8` [hyperlinks](Screen::links) it emitted — is readable from every
+//! [`Screen`] as plain accessors. Both of those last two leave the grid
+//! identical: a bar cursor and a block cursor draw the same cells, and a
+//! hyperlink's label renders as ordinary text with its URL nowhere on the
+//! screen, so a test asserting a link used to pass against an application
+//! that emitted none.
 //!
 //! Behaviour that leaves the screen **identical** is assertable too, which
 //! no content predicate can manage: [`repaints`](Screen::repaints) counts
@@ -109,7 +115,7 @@ pub use graphics::{
     GraphicsAction, GraphicsFormat, GraphicsPayload, GraphicsProtocol, GraphicsSeen,
 };
 pub use keys::{Chord, Input, Key};
-pub use screen::{Cell, Clipboard, Color, MouseMode, Screen, Style};
+pub use screen::{Cell, Clipboard, Color, CursorShape, Link, MouseMode, Screen, Style};
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -13,6 +13,15 @@ use unicode_normalization::UnicodeNormalization;
 use crate::graphics::GraphicsSeen;
 
 /// A terminal color, as reported by the emulator.
+///
+/// Deliberately *not* `#[non_exhaustive]`, unlike [`Key`](crate::Key) and
+/// [`Signal`](crate::Signal). The terminal colour model is closed —
+/// default, a palette index, or 24-bit RGB, which is also exactly what
+/// every VT emulator reports — so there is no fourth variant waiting to be
+/// added, and `Color` is the one enum here that downstream code really
+/// does `match` on. Leaving it exhaustive keeps those matches complete;
+/// equality (`cell.style().fg == Color::Indexed(1)`) is unaffected either
+/// way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Color {
     /// The terminal's default foreground/background.
@@ -84,6 +93,40 @@ pub enum MouseMode {
     AnyMotion,
 }
 
+/// The shape of the cursor an application asked its terminal for with
+/// `DECSCUSR` (`CSI Ps SP q`).
+///
+/// Read it from a snapshot via [`Screen::cursor_shape`], and whether it
+/// blinks via [`Screen::cursor_blink`] — one parameter carries both, but
+/// they are two facts and a test usually wants only one of them.
+///
+/// The shape is load-bearing behaviour rather than decoration: a modal
+/// editor switches to a bar for insert and back to a block for normal, and
+/// "the mode indicator says INSERT" and "the terminal was actually put into
+/// insert" are different claims. It also makes the *restore* assertable — a
+/// program that changes the cursor and never changes it back leaves the
+/// user's terminal wrong after exit, the same class of defect
+/// [`Screen::alternate_screen`] already catches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum CursorShape {
+    /// The application never sent `DECSCUSR`, so the cursor is whatever the
+    /// terminal draws by default.
+    ///
+    /// Deliberately not folded into [`Block`](CursorShape::Block): a
+    /// terminal's default usually *is* a block, but "never asked" and
+    /// "asked for a block" are different claims about the program, and only
+    /// one of them survives a refactor that drops the escape.
+    #[default]
+    Default,
+    /// A filled block — `DECSCUSR` 0 and 1 (blinking) or 2 (steady).
+    Block,
+    /// An underline — `DECSCUSR` 3 (blinking) or 4 (steady).
+    Underline,
+    /// A vertical bar — `DECSCUSR` 5 (blinking) or 6 (steady).
+    Bar,
+}
+
 /// What an application copied with `OSC 52`, as observed at one snapshot.
 ///
 /// Read it from a snapshot via [`Screen::clipboard`]. A toast on screen
@@ -128,6 +171,88 @@ impl Clipboard {
     }
 }
 
+/// A hyperlink an application emitted with `OSC 8`, as observed at one
+/// snapshot.
+///
+/// Read them from a snapshot via [`Screen::links`]. A hyperlink changes no
+/// cell — the label is drawn exactly as unlinked text would be — so without
+/// this a test asserting that a TUI linked an issue, a file or a doc page
+/// **passes identically against an application that emitted no link at all,
+/// or linked the wrong URL**. That is the failure
+/// [`Screen::clipboard`] exists to prevent for `OSC 52`, in the same shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Link {
+    uri: Arc<str>,
+    id: Option<Arc<str>>,
+    label: Option<Arc<str>>,
+    closed: bool,
+}
+
+impl Link {
+    pub(crate) fn open(uri: &str, id: Option<&str>) -> Self {
+        Self {
+            uri: Arc::from(uri),
+            id: id.map(Arc::from),
+            label: None,
+            closed: false,
+        }
+    }
+
+    pub(crate) fn close(&mut self, label: Option<String>) {
+        self.label = label.map(Arc::from);
+        self.closed = true;
+    }
+
+    /// The URI the application linked to, as it wrote it.
+    ///
+    /// Bytes that are not valid UTF-8 are replaced rather than refused: an
+    /// `OSC 8` target is percent-encoded ASCII by construction, so a URI
+    /// that is not text is already malformed, and a replacement character
+    /// makes it compare unequal to whatever the test expected — which is
+    /// the right outcome — while still showing what arrived.
+    #[must_use]
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    /// The `id=` parameter, if the application gave one.
+    ///
+    /// Spans sharing an id are one logical link — the way a terminal knows
+    /// that a path broken across two lines highlights as a single target —
+    /// so grouping by this is how a multi-span link is asserted as one.
+    #[must_use]
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+
+    /// The text the link wrapped: what a reader sees and clicks.
+    ///
+    /// `None` means the label is not knowable, which is two situations that
+    /// [`closed`](Self::closed) tells apart: the span is still open and has
+    /// no final text yet, or the application wrote more while it was open
+    /// than termlens keeps, so what was captured is a prefix and returning
+    /// it as *the* label would be a lie. `Some("")` is a real link around
+    /// no text at all.
+    ///
+    /// Control characters are not part of a label: a newline inside a span
+    /// moves the cursor, it does not spell anything.
+    #[must_use]
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Whether the application closed the span (`OSC 8 ; ; ST`).
+    ///
+    /// False is worth asserting against. A link left open is not a
+    /// cosmetic slip: in a real terminal every character written afterwards
+    /// joins it, so a whole screen becomes clickable and points at the
+    /// wrong place.
+    #[must_use]
+    pub fn closed(&self) -> bool {
+        self.closed
+    }
+}
+
 /// Out-of-band terminal state captured with each snapshot. Deliberately
 /// invisible in the text rendering (existing snapshot files stay valid);
 /// exposed through the accessors on [`Screen`].
@@ -153,6 +278,13 @@ pub(crate) struct TermState {
     pub(crate) bells: u64,
     /// Whether the application enabled focus reporting (mode 1004).
     pub(crate) focus_events: bool,
+    /// The raw `DECSCUSR` parameter last requested; `None` until the
+    /// application asks. One `Option<u8>` rather than a shape and a blink
+    /// flag, because the parameter is what the application actually said.
+    pub(crate) cursor_style: Option<u8>,
+    /// `OSC 8` hyperlinks emitted, oldest first, behind an `Arc` so a
+    /// snapshot costs one refcount rather than a copy of every link.
+    pub(crate) links: Arc<Vec<Link>>,
     /// Inline graphics payloads transmitted.
     pub(crate) graphics: GraphicsSeen,
     /// Completed synchronized updates. Filled in by the terminal rather
@@ -178,6 +310,8 @@ impl Default for TermState {
             clipboard: None,
             bells: 0,
             focus_events: false,
+            cursor_style: None,
+            links: Arc::new(Vec::new()),
             graphics: GraphicsSeen::default(),
             repaints: 0,
             scrollback: Arc::from([] as [Arc<str>; 0]),
@@ -315,6 +449,77 @@ impl Screen {
     #[must_use]
     pub fn cursor(&self) -> (u16, u16, bool) {
         (self.cursor_row, self.cursor_col, self.cursor_visible)
+    }
+
+    /// The cursor shape the application asked for with `DECSCUSR`
+    /// (`CSI Ps SP q`), or [`CursorShape::Default`] while it has never
+    /// asked — which is a real state, and not the same as asking for a
+    /// block.
+    ///
+    /// Like all out-of-band state this is invisible in the
+    /// [`Display`](fmt::Display) rendering, so assert on it directly:
+    ///
+    /// ```text
+    /// t.wait_until(|s| s.cursor_shape() == CursorShape::Bar)?;   // insert mode
+    /// t.send(Key::Esc)?;
+    /// t.wait_until(|s| s.cursor_shape() == CursorShape::Block)?; // and back
+    /// ```
+    #[must_use]
+    pub fn cursor_shape(&self) -> CursorShape {
+        match self.state.cursor_style {
+            None => CursorShape::Default,
+            Some(0..=2) => CursorShape::Block,
+            Some(3..=4) => CursorShape::Underline,
+            Some(5..=6) => CursorShape::Bar,
+            // The tracker only ever stores 0..=6; anything else would be a
+            // value it declined to interpret, and guessing a shape here is
+            // the one thing this accessor must not do.
+            Some(_) => CursorShape::Default,
+        }
+    }
+
+    /// Whether the cursor the application asked for blinks.
+    ///
+    /// `None` while [`cursor_shape`](Self::cursor_shape) is
+    /// [`CursorShape::Default`]: the application never said, and the
+    /// terminal's own default rate is not ours to claim. Shape and blink
+    /// travel in one `DECSCUSR` parameter but are two independent facts —
+    /// an editor that wants a steady bar and gets a blinking one has a real
+    /// bug, and it is invisible in the grid.
+    #[must_use]
+    pub fn cursor_blink(&self) -> Option<bool> {
+        match self.state.cursor_style {
+            Some(0 | 1 | 3 | 5) => Some(true),
+            Some(2 | 4 | 6) => Some(false),
+            _ => None,
+        }
+    }
+
+    /// The `OSC 8` hyperlinks the application emitted, oldest first.
+    ///
+    /// A hyperlink leaves the grid identical, so this is the only place the
+    /// URL exists — the label renders as ordinary text and
+    /// [`row_text`](Self::row_text) never sees the target:
+    ///
+    /// ```text
+    /// $ printf 'see \033]8;;https://example.invalid/a\033\\docs\033]8;;\033\\ here\n'
+    /// s.row_text(0)                      == "see docs here"
+    /// s.links()[0].label()               == Some("docs")
+    /// s.links()[0].uri()                 == "https://example.invalid/a"
+    /// ```
+    ///
+    /// One entry per span *emitted*, not per distinct target: an
+    /// application that redraws its links on every repaint appends them
+    /// again each time. The log is bounded at the most recent 64 spans and
+    /// evicts oldest-first, so the current frame's links are always present
+    /// and an application that leaks links cannot grow this without limit.
+    /// Assert with `.iter().any(…)` rather than on the length.
+    ///
+    /// Like all out-of-band state, links are invisible in the
+    /// [`Display`](fmt::Display) rendering.
+    #[must_use]
+    pub fn links(&self) -> &[Link] {
+        &self.state.links
     }
 
     /// The window title, as the application most recently set it (`OSC 0`
@@ -1339,6 +1544,51 @@ mod tests {
         assert_eq!(format!("{s}"), "size: 10x2  cursor: 1,2\nhi\n");
     }
 
+    /// The whole point of `TermState` is that it is invisible in the text
+    /// rendering, so a release adding a fact to it cannot invalidate a
+    /// checked-in snapshot. Asserted exactly, on two screens that differ in
+    /// nothing else — the integration test cannot make this claim, because
+    /// driving a shell to the second state also echoes a newline.
+    #[test]
+    fn the_cursor_shape_is_invisible_in_the_rendering() {
+        let render = |cursor_style| {
+            let state = TermState {
+                cursor_style,
+                ..TermState::default()
+            };
+            let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
+            Screen::from_parts(1, 1, 0, 0, true, cells, state).to_string()
+        };
+        let plain = render(None);
+        for ps in 0u8..=6 {
+            assert_eq!(
+                render(Some(ps)),
+                plain,
+                "DECSCUSR {ps} changed the rendering"
+            );
+        }
+        // The same claim for the other fact this release captures.
+        let linked = TermState {
+            links: Arc::new(vec![Link::open("https://example.invalid/a", Some("7"))]),
+            ..TermState::default()
+        };
+        let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
+        assert_eq!(
+            Screen::from_parts(1, 1, 0, 0, true, cells, linked).to_string(),
+            plain,
+            "a hyperlink changed the rendering"
+        );
+        // …and the fact itself is still there to assert on.
+        let state = TermState {
+            cursor_style: Some(5),
+            ..TermState::default()
+        };
+        let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
+        let s = Screen::from_parts(1, 1, 0, 0, true, cells, state);
+        assert_eq!(s.cursor_shape(), CursorShape::Bar);
+        assert_eq!(s.cursor_blink(), Some(true));
+    }
+
     #[test]
     fn state_accessors_report_the_captured_state_and_stay_out_of_display() {
         let default = screen(4, 1, &["x"]);
@@ -1348,6 +1598,9 @@ mod tests {
         assert!(!default.application_cursor());
         assert_eq!(default.mouse_mode(), MouseMode::None);
         assert!(default.clipboard().is_none());
+        assert_eq!(default.cursor_shape(), CursorShape::Default);
+        assert_eq!(default.cursor_blink(), None);
+        assert!(default.links().is_empty());
 
         let state = TermState {
             title: Arc::from("my app"),
@@ -1358,6 +1611,12 @@ mod tests {
             clipboard: Some(Arc::new(Clipboard::new("c", Some("copied".into())))),
             bells: 3,
             focus_events: true,
+            cursor_style: Some(6),
+            links: Arc::new(vec![{
+                let mut l = Link::open("https://example.invalid/a", Some("7"));
+                l.close(Some("docs".into()));
+                l
+            }]),
             graphics: GraphicsSeen::for_test(1, 1, 2, 160),
             repaints: 9,
             scrollback: Arc::from([Arc::from("scrolled away")]),
@@ -1371,6 +1630,15 @@ mod tests {
         assert_eq!((clip.targets(), clip.text()), ("c", Some("copied")));
         assert_eq!(s.scrollback_rows(), 1);
         assert_eq!(s.bells(), 3);
+        // 6 is a steady bar: the shape and the blink are read apart.
+        assert_eq!(s.cursor_shape(), CursorShape::Bar);
+        assert_eq!(s.cursor_blink(), Some(false));
+        let link = &s.links()[0];
+        assert_eq!(link.uri(), "https://example.invalid/a");
+        assert_eq!(
+            (link.id(), link.label(), link.closed()),
+            (Some("7"), Some("docs"), true)
+        );
         assert!(s.focus_events());
         assert_eq!(s.repaints(), 9);
         assert_eq!(s.graphics().kitty(), 1);

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -430,8 +430,32 @@ fn no_mouse_tracking() -> Error {
 /// mode the line discipline turns it into `SIGINT`), while
 /// `signal(Signal::Int)` delivers the signal directly via `kill(2)`,
 /// bypassing the terminal entirely.
+///
+/// Marked `#[non_exhaustive]`: these seven are the graceful-shutdown set,
+/// not the signal set — POSIX has around thirty, and `SIGWINCH`,
+/// `SIGCONT`, `SIGTSTP` and `SIGPIPE` are all things a terminal
+/// application reacts to. Like [`Key`](crate::Key), a `Signal` is
+/// constructed rather than matched, so the attribute leaves room for those
+/// without spending a major version on each. Naming every variant is
+/// therefore still not exhaustive:
+///
+/// ```compile_fail
+/// # use termlens::Signal;
+/// fn number(s: Signal) -> u8 {
+///     match s {
+///         Signal::Int => 2,
+///         Signal::Quit => 3,
+///         Signal::Kill => 9,
+///         Signal::Term => 15,
+///         Signal::Hup => 1,
+///         Signal::Usr1 => 10,
+///         Signal::Usr2 => 12,
+///     }
+/// }
+/// ```
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Signal {
     /// `SIGINT` — interactive interrupt (what Ctrl-C means).
     Int,

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -57,6 +57,7 @@ fn form_echo_round_trips_typed_input_and_special_keys() -> termlens::Result<()> 
         (Key::End, "last: end"),
         (Key::PageUp, "last: pageup"),
         (Key::PageDown, "last: pagedown"),
+        (Key::Insert, "last: insert"),
         (Key::Delete, "last: delete"),
         (Key::BackTab, "last: backtab"),
         (Key::F(1), "last: f:1"),

--- a/crates/termlens/tests/state.rs
+++ b/crates/termlens/tests/state.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use termlens::{Key, MouseMode, Terminal};
+use termlens::{CursorShape, Key, MouseMode, Screen, Terminal};
 
 /// One script walks the whole state surface: set everything, assert, then
 /// unwind everything and assert the way back.
@@ -53,6 +53,103 @@ fn screen_reports_title_alternate_screen_and_input_modes() -> termlens::Result<(
 }
 
 /// The tracking mode the app enabled is reported by name, not collapsed.
+/// `DECSCUSR` leaves the grid identical, so without an accessor a screen
+/// where the application asked for a bar and one where it never asked are
+/// the same `Screen`. The script walks all three states an editor moves
+/// through: never asked, switched, switched back.
+#[test]
+fn screen_reports_the_cursor_shape_the_application_asked_for() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                r"printf 'ready'; read _; ",
+                // DECSCUSR 5: a blinking bar, the insert-mode cursor.
+                r"printf '\033[5 q'; printf ' insert'; read _; ",
+                // DECSCUSR 2: a steady block, the way back.
+                r"printf '\033[2 q'; printf ' normal'; read _",
+            ),
+        ])
+        .spawn("sh")?;
+
+    // Never asked. Distinct from a block, which is what most terminals
+    // happen to draw by default — the point is that the program did not say.
+    t.wait_until(|s| s.contains("ready"))?;
+    let before = t.screen();
+    assert_eq!(before.cursor_shape(), CursorShape::Default);
+    assert_eq!(before.cursor_blink(), None);
+
+    t.send(Key::Enter)?;
+    t.wait_until(|s| {
+        s.contains("insert")
+            && s.cursor_shape() == CursorShape::Bar
+            && s.cursor_blink() == Some(true)
+    })?;
+
+    // The restore, which is the half that ships broken.
+    t.send(Key::Enter)?;
+    t.wait_until(|s| {
+        s.contains("normal")
+            && s.cursor_shape() == CursorShape::Block
+            && s.cursor_blink() == Some(false)
+    })?;
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+
+    // After exit is where this matters: a program that switches the cursor
+    // and never switches back leaves the user's terminal wrong, and the
+    // final screen is the evidence.
+    let after = t.screen();
+    assert_eq!(after.cursor_shape(), CursorShape::Block);
+    assert_eq!(after.cursor_blink(), Some(false));
+    Ok(())
+}
+
+/// The failure the issue is built on, stated as the comparison it is: two
+/// applications whose grids are byte-identical, one of which linked and one
+/// of which did not. Before `Screen::links` no assertion could tell them
+/// apart, so a test for "it linked the docs" passed against the one that
+/// emitted nothing.
+#[test]
+fn an_osc8_hyperlink_is_observable_and_a_missing_one_is_not() -> termlens::Result<()> {
+    fn run(script: &str) -> termlens::Result<Screen> {
+        let mut t = Terminal::builder()
+            .timeout(Duration::from_secs(10))
+            .args(["-c", script])
+            .spawn("sh")?;
+        t.wait_until(|s| s.contains("see docs here"))?;
+        let screen = t.screen();
+        assert!(t.wait_exit()?.success());
+        Ok(screen)
+    }
+
+    let linked =
+        run(r"printf 'see \033]8;;https://example.invalid/a\033\\docs\033]8;;\033\\ here\n'")?;
+    let plain = run(r"printf 'see docs here\n'")?;
+
+    // The grids agree exactly — this was never a rendering bug, and the URL
+    // must not leak into the cells.
+    assert_eq!(linked.text(), plain.text());
+    assert_eq!(linked.row_text(0).trim_end(), "see docs here");
+    assert!(!linked.text().contains("example.invalid"));
+
+    // And now they are distinguishable.
+    assert!(plain.links().is_empty());
+    let link = &linked.links()[0];
+    assert_eq!(linked.links().len(), 1);
+    assert_eq!(link.uri(), "https://example.invalid/a");
+    assert_eq!(link.label(), Some("docs"));
+    assert!(link.closed());
+    assert_eq!(link.id(), None);
+
+    // A wrong target fails a test the right one passes, which is the whole
+    // point of capturing it.
+    assert_ne!(link.uri(), "https://example.invalid/b");
+    Ok(())
+}
+
 #[test]
 fn mouse_mode_reports_the_exact_tracking_mode() -> termlens::Result<()> {
     let mut t = Terminal::builder()

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -466,10 +466,38 @@ Rules:
    captured with every snapshot and read through plain accessors —
    `Screen::title`, `Screen::alternate_screen`, `Screen::bracketed_paste`,
    `Screen::application_cursor`, `Screen::mouse_mode`,
-   `Screen::focus_events`, `Screen::clipboard`. Keeping them out of
+   `Screen::focus_events`, `Screen::clipboard`, `Screen::cursor_shape`,
+   `Screen::cursor_blink`, `Screen::links`. Keeping them out of
    the rendering means existing snapshot files stay valid, and state
    assertions read as ordinary predicates:
    `wait_until(|s| s.alternate_screen())`.
+
+   Two of those are the terminal holding a fact **on the application's
+   behalf**, in the same sense the alternate-screen flag is. `DECSCUSR`
+   (`CSI Ps SP q`) sets the cursor's shape — a bar for insert, a block for
+   normal — and the parameter carries the blink rate along with it, so the
+   two are reported apart: they are one parameter and two facts, and a test
+   usually wants only one. "Never asked" is a third state and is reported as
+   itself: a terminal's default usually *is* a block, but a program that
+   stopped emitting the escape is not a program that asked for one. This is
+   also what makes the *restore* assertable, which is the half that ships
+   broken — a program that switches the cursor and never switches back
+   leaves the user's terminal wrong after exit, exactly as one that never
+   leaves the alternate screen does.
+
+   `OSC 8` hyperlinks are **captured**, on the same grounds as `OSC 52`
+   below: a link changes no cell, its label renders as ordinary text, and
+   the URL therefore exists nowhere a content predicate can reach. A test
+   asserting that a TUI linked an issue or a file passes identically against
+   one that emitted no link, or linked the wrong target. `Screen::links`
+   reports each span with its URI, its `id=` (so spans that are one logical
+   link can be grouped) and the text it wrapped. Two bounds keep it honest
+   rather than merely bounded: the span log evicts oldest-first, so an
+   application that redraws its links every frame still reports the current
+   frame's; and a label that runs past the capture bound is reported as
+   *unknown* rather than as a prefix, since a prefix of the wrong length is
+   a wrong answer. A span the application never closed is reported open —
+   in a real terminal every character written afterwards joins it.
 
    The same slot holds three **cumulative counters**, for behaviour that by
    definition leaves the grid unchanged: `Screen::repaints` (completed DEC

--- a/fixtures/form-echo/src/main.rs
+++ b/fixtures/form-echo/src/main.rs
@@ -92,6 +92,7 @@ fn describe(key: &KeyEvent) -> String {
         KeyCode::Tab => "tab".into(),
         KeyCode::BackTab => "backtab".into(),
         KeyCode::Backspace => "backspace".into(),
+        KeyCode::Insert => "insert".into(),
         KeyCode::Delete => "delete".into(),
         KeyCode::Up => "up".into(),
         KeyCode::Down => "down".into(),


### PR DESCRIPTION
Closes the four open items of the **v0.7** milestone. Three are the shape the
arc since v0.4 has been closing: behaviour that leaves the grid identical and
is therefore invisible to every content predicate.

## `Screen::links` — `OSC 8` hyperlinks (#144)

A link changes no cell; the label renders exactly as unlinked text would. So
the URL existed nowhere a test could reach, and an assertion that a TUI linked
an issue or a file **passed identically against an application that emitted no
link at all, or linked the wrong target**. The test in `state.rs` states that
as the comparison it is: two applications whose grids are byte-identical, one
of which linked and one of which did not.

Captured rather than answered, on the same grounds as the `OSC 52` clipboard
the issue names as its model. Each span carries `uri`, `id` (so spans that are
one logical link can be grouped), the `label` it wrapped, and whether it was
ever `closed` — an unterminated span is reported open, because in a real
terminal every character written afterwards joins it.

Two bounds keep the capture honest rather than merely bounded:

- the log holds 64 spans and evicts oldest-first, so a TUI that redraws its
  links every frame still reports the current frame's;
- a label past the capture bound, and a URI inside an OSC that was truncated,
  are reported **unknown** rather than as a prefix. A prefix of the wrong
  length is a wrong answer, and opening a span on a truncated URI would
  manufacture the exact wrong-URL failure this feature exists to catch.

**The cell would have been the more natural home, and this is not it.** Doing
that soundly needs either hand-attribution — which `emu/shadow.rs` rejects,
with reasons — or a third shadow parser carrying a link index through a colour
attribute, which `SGR 0` breaks. The screen-level list is the alternative the
issue offers, and it survives an overwrite the way `clipboard` does. Happy to
revisit if you'd rather have it on `Cell`.

## `Screen::cursor_shape` / `cursor_blink` — `DECSCUSR` (#145)

A screen where the application asked for a bar and one where it never asked
used to be the same `Screen`. Shape and blink are one parameter and two facts,
so they are read apart, and `CursorShape::Default` — never asked — is a third
state rather than a block. The tracker stores the raw parameter; only the
accessor knows what `5` means.

That is what makes the *restore* assertable, which is the half that ships
broken. The test asserts it **after process exit**, which is where it matters.

`SP` had been rejected as an invalid CSI intermediate, so accepting it needed
care: the other `SP` sequences (SL, SR) must not become cursor styles, nor fall
through into the query table, which assumes no intermediate. There is a test
for exactly that.

## `Key::Insert` (#166)

The `2` missing from a navigation run that already had `3`, `5` and `6`.
Encodes `ESC [ 2 ~`, chords like its neighbours, and the `form-echo` fixture
proves the bytes through a real PTY and crossterm's parser rather than only
through our own table.

## `Key` and `Signal` are `#[non_exhaustive]` (#165) — breaking

Adding a variant to an exhaustive public enum is itself breaking, so every
future key and signal would have cost a version of its own. Both types are
*constructed* far more often than matched, so the cost falls on the crate
rather than its users, and the attribute is breaking to add — which makes the
cheapest moment the earliest one.

**`Color` is deliberately left exhaustive.** Default, palette index and 24-bit
RGB is the whole terminal colour model, and it is the one enum here downstream
really does match on. Recorded in `Color`'s own doc comment as well as the
CHANGELOG, so it reads as a decision rather than an oversight.

`cargo-semver-checks` flags this as requiring a major bump, exactly as the
issue predicted. I confirmed the release gate is satisfied at `0.7.0` (for a
0.x crate the minor *is* the breaking bump) by bumping locally and reverting —
**no version change is in this PR.**

## Verification

Every CI gate: fmt, clippy `-D warnings`, **319 tests** all-features, **304**
no-default-features, docs with `-D warnings`, MSRV 1.85, `cargo deny`.

The stress suite ran **22 iterations at 1/2/4/8/16 threads with no flake**,
weighted by wall time the way `stress.yml`'s matrix is.

Every new guard was mutation-checked — broken one at a time, with the suite
watched going red. That found a real gap: **nothing covered the truncated-OSC
refusal**, which is now tested. The two `#[non_exhaustive]` attributes are
compile-time, so they are proven by `compile_fail` doctests, which I confirmed
fail when the attribute is removed — they test the attribute and nothing
incidental.

No checked-in snapshot changed, which independently confirms the new state
stays out of the rendering; `Screen` is still 40 bytes, both facts living
behind the `Arc<TermState>`.

## What this does not cover

- **Linux only.** The stress sweep did not run on macOS, which is where the
  0.6.1 `openpty` bug surfaced after Linux had run the same suite clean
  twenty-five times. `stress.yml` should be triggered on this branch.
- No version bump, and `Cargo.toml` / `Cargo.lock` are untouched.
- The label a link wrapped is the text written while the span was open, so a
  span the application never closes has no final label — reported as unknown,
  with `closed()` false to say which of the two "unknown"s it is.

---

Closes #144, closes #145, closes #165, closes #166
