### PR TITLE
fix: RIS returns the cursor shape to the terminal's default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,6 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
-### Fixed
-
-- **A hard reset (`RIS`, `ESC c`) returns the cursor shape to the terminal's
-  default and closes any open `OSC 8` span.** `printf '\033c'` is one of the
-  ways a program hands the terminal back on exit, so reporting the last
-  `DECSCUSR` after one claimed a shape the terminal no longer held — and it
-  did so in exactly the case `cursor_shape` exists to check. The window
-  title, the clipboard, the bell count and the link *log* are deliberately
-  left alone: the title is a window property `RIS` does not restore in
-  xterm, and the rest are records of what the application emitted rather
-  than state the terminal still holds.
-
 ### Added
 
 - **`TerminalBuilder::envs` sets several child environment variables from an
@@ -91,6 +79,16 @@ listed under a **Changed** or **Removed** heading.
   does match on.
 
 ### Fixed
+
+- **A hard reset (`RIS`, `ESC c`) returns the cursor shape to the terminal's
+  default and closes any open `OSC 8` span.** `printf '\033c'` is one of the
+  ways a program hands the terminal back on exit, so reporting the last
+  `DECSCUSR` after one claimed a shape the terminal no longer held — and it
+  did so in exactly the case `cursor_shape` exists to check. The window
+  title, the clipboard, the bell count and the link *log* are deliberately
+  left alone: the title is a window property `RIS` does not restore in
+  xterm, and the rest are records of what the application emitted rather
+  than state the terminal still holds.
 
 - **The crate's doctests build with default features disabled.** The bundled
   snapshot macro example is compiled only when its `insta` feature exists,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A hard reset (`RIS`, `ESC c`) returns the cursor shape to the terminal's
+  default and closes any open `OSC 8` span.** `printf '\033c'` is one of the
+  ways a program hands the terminal back on exit, so reporting the last
+  `DECSCUSR` after one claimed a shape the terminal no longer held — and it
+  did so in exactly the case `cursor_shape` exists to check. The window
+  title, the clipboard, the bell count and the link *log* are deliberately
+  left alone: the title is a window property `RIS` does not restore in
+  xterm, and the rest are records of what the application emitted rather
+  than state the terminal still holds.
+
 ### Added
 
 - **`TerminalBuilder::envs` sets several child environment variables from an

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.6)
+## Known limitations (v0.7)
 
 - Scrollback is **bounded** (1000 rows by default), **text only** — a
   scrolled-off row has no styles and no cell addressing — and is **not
@@ -236,6 +236,19 @@ design. termlens's position:
   described but its bytes are dropped, and it says so rather than decoding a
   prefix of itself. Support stays opt-in, so by default an application that
   probes is truthfully told there is none.
+- **Hyperlinks are captured, not attributed to cells.** `links()` reports
+  every `OSC 8` span with its target, its `id`, and the text it wrapped, so
+  "did it link the right place?" is assertable — but a `Cell` does not carry
+  its link, so *which* cells sit inside a span is not, and a span whose label
+  was later overwritten is still reported, because this is a record of what
+  the application emitted rather than a property of the grid. Retention is
+  bounded to the most recent 64 spans, and a label longer than the capture
+  bound is reported as unknown rather than as a prefix.
+- **Out-of-band state is what the application last asked for, not what a
+  terminal would infer.** The cursor shape follows `DECSCUSR` and is cleared
+  by a hard reset (`RIS`); the window title is not, because in xterm the
+  title is a window property that `RIS` does not restore, and guessing either
+  way would be the same error. Nothing here models `DECSTR` (soft reset).
 - **A reply the terminal's own input queue cannot hold may not arrive.**
   termlens no longer drops answers of its own accord, but the tty input
   queue is small (~1 KB on macOS, ~4 KB on Linux), so an application that

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -1016,7 +1016,29 @@ impl SeqTracker {
                 0x20..=0x2f => State::EscIntermediate,
                 ESC => State::Esc,
                 CAN | SUB => State::Ground,
-                // Final byte of a two-character sequence (ESC c, ESC 7, …).
+                // RIS (`ESC c`), the hard reset: the terminal returns to its
+                // power-on state, so the cursor is the terminal's default
+                // again and any open hyperlink span cannot survive.
+                //
+                // Reporting the last `DECSCUSR` after a reset would claim a
+                // fact the terminal does not hold — and it would do it in the
+                // one place that matters, since `printf '\033c'` is a way a
+                // program restores the cursor on exit, which is exactly what
+                // `cursor_shape` exists to let a test check.
+                //
+                // The window title is deliberately *not* cleared here. In
+                // xterm it is a window property rather than terminal state
+                // and RIS does not restore it; guessing either way would be
+                // the same error in the other direction. Same for the
+                // clipboard, the bell count and the link *log*, which are
+                // records of what the application emitted rather than state
+                // the terminal still holds.
+                b'c' => {
+                    self.cursor_style = None;
+                    self.close_link();
+                    State::Ground
+                }
+                // Final byte of a two-character sequence (ESC 7, ESC =, …).
                 _ => State::Ground,
             },
             State::EscIntermediate => match b {
@@ -1495,6 +1517,54 @@ mod tests {
         assert_eq!(fed(b"\x1b[ q").cursor_style(), Some(0));
         // The last one wins, which is what makes a restore assertable.
         assert_eq!(fed(b"\x1b[5 q\x1b[2 q").cursor_style(), Some(2));
+    }
+
+    /// RIS is a way a program restores the cursor on exit, so a stale
+    /// `DECSCUSR` after one would fail the very assertion `cursor_shape`
+    /// exists to support — and claim a shape the terminal no longer holds.
+    #[test]
+    fn a_hard_reset_returns_the_cursor_to_the_terminals_default() {
+        assert_eq!(fed(b"\x1b[5 q").cursor_style(), Some(5));
+        assert_eq!(fed(b"\x1b[5 q\x1bc").cursor_style(), None);
+        // …and a style set *after* the reset is still recorded.
+        assert_eq!(fed(b"\x1b[5 q\x1bc\x1b[2 q").cursor_style(), Some(2));
+    }
+
+    /// An open span cannot survive a hard reset, so it is closed with what
+    /// it had. The *log* is a record of what the application emitted and is
+    /// deliberately kept, like the bell count and the clipboard.
+    #[test]
+    fn a_hard_reset_closes_an_open_span_and_keeps_the_log() {
+        let seen = links(b"\x1b]8;;http://x/\x1b\\lab\x1bcafter");
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].0, "http://x/");
+        assert_eq!(
+            seen[0].2.as_deref(),
+            Some("lab"),
+            "the text before the reset"
+        );
+        assert!(seen[0].3, "closed by the reset");
+        // Text after the reset belongs to no span.
+        let seen = links(b"\x1b]8;;http://x/\x1b\\a\x1bcbbb");
+        assert_eq!(seen[0].2.as_deref(), Some("a"));
+    }
+
+    /// The two-character escapes that are *not* RIS must keep passing
+    /// through untouched — `ESC 7` (save cursor) is next to it in the table.
+    #[test]
+    fn other_two_character_escapes_do_not_reset_anything() {
+        for seq in [
+            &b"\x1b[5 q\x1b7"[..],
+            b"\x1b[5 q\x1b8",
+            b"\x1b[5 q\x1bD",
+            b"\x1b[5 q\x1bM",
+        ] {
+            assert_eq!(
+                fed(seq).cursor_style(),
+                Some(5),
+                "{seq:?} reset the cursor style"
+            );
+        }
     }
 
     #[test]

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -464,6 +464,11 @@ impl Screen {
     /// t.send(Key::Esc)?;
     /// t.wait_until(|s| s.cursor_shape() == CursorShape::Block)?; // and back
     /// ```
+    ///
+    /// A hard reset (`RIS`, `ESC c`) returns this to
+    /// [`CursorShape::Default`] — a program that restores the cursor that
+    /// way really has handed the terminal back its own default, and
+    /// reporting the last `DECSCUSR` would claim otherwise.
     #[must_use]
     pub fn cursor_shape(&self) -> CursorShape {
         match self.state.cursor_style {

--- a/crates/termlens/tests/state.rs
+++ b/crates/termlens/tests/state.rs
@@ -150,6 +150,58 @@ fn an_osc8_hyperlink_is_observable_and_a_missing_one_is_not() -> termlens::Resul
     Ok(())
 }
 
+/// A `Screen` is an immutable snapshot, and the link log is the first piece
+/// of out-of-band state that is *mutated in place* after it is recorded — a
+/// span is pushed when it opens and completed when it closes. So the
+/// copy-on-write has to hold: a snapshot taken mid-span must go on reporting
+/// the span as open, with no label, however the stream continues.
+///
+/// The emulator relies on this for the graphics log too, where it is only
+/// asserted in a comment.
+#[test]
+fn a_snapshot_keeps_its_own_view_of_the_links() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .timeout(Duration::from_secs(10))
+        .args([
+            "-c",
+            concat!(
+                // Open a span and leave it open across the pause.
+                r"printf '\033]8;;http://a/\033\\LABEL one\n'; read _; ",
+                // Close it, then open a second one.
+                r"printf '\033]8;;\033\\\033]8;;http://b/\033\\X two\n'; read _",
+            ),
+        ])
+        .spawn("sh")?;
+
+    t.wait_until(|s| s.contains("one"))?;
+    let early = t.screen();
+    assert_eq!(early.links().len(), 1);
+    assert!(
+        !early.links()[0].closed(),
+        "the span is open at this instant"
+    );
+    assert_eq!(early.links()[0].label(), None, "and has no final label yet");
+
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("two") && s.links().len() == 2)?;
+    let later = t.screen();
+    assert!(later.links()[0].closed());
+    assert_eq!(later.links()[0].uri(), "http://a/");
+    assert_eq!(later.links()[1].uri(), "http://b/");
+
+    // The whole point: the earlier snapshot did not move.
+    assert_eq!(early.links().len(), 1, "an earlier snapshot grew a link");
+    assert!(
+        !early.links()[0].closed(),
+        "an earlier snapshot saw the span close after the fact"
+    );
+    assert_eq!(early.links()[0].label(), None);
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 #[test]
 fn mouse_mode_reports_the_exact_tracking_mode() -> termlens::Result<()> {
     let mut t = Terminal::builder()

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -485,6 +485,15 @@ Rules:
    leaves the user's terminal wrong after exit, exactly as one that never
    leaves the alternate screen does.
 
+   A hard reset (`RIS`, `ESC c`) returns the cursor shape to the terminal's
+   default and closes any open hyperlink span, because a real terminal's
+   power-on state holds neither. It deliberately does **not** clear the
+   title, the clipboard, the bell count or the link log: the first is a
+   window property `RIS` does not restore in xterm, and the rest are records
+   of what the application emitted rather than state the terminal still
+   holds. `DECSTR` (soft reset) is not modelled at all — the sequences it
+   touches are not ones tracked here.
+
    `OSC 8` hyperlinks are **captured**, on the same grounds as `OSC 52`
    below: a link changes no cell, its label renders as ordinary text, and
    the URL therefore exists nowhere a content predicate can reach. A test

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -3,8 +3,8 @@
 > **Status: historical record of the v0.1 build.** Everything below describes
 > the project as it stood on 2026-08-09 and is kept as the record of that
 > work, not as a description of termlens today. Since then the repository has
-> been made public, the crate has been published, and the API has grown
-> through 0.2 to 0.5 — `CHANGELOG.md` says what each release changed,
+> been made public, the crate has been published, and the API has grown a
+> great deal — `CHANGELOG.md` says what each release changed,
 > and `README.md` plus `docs/DESIGN.md` describe the current design. The
 > go-public checklist in §3 has its outcome recorded beneath it.
 

--- a/docs/announce-r-rust.md
+++ b/docs/announce-r-rust.md
@@ -58,6 +58,15 @@ rejected key, an inline image. Every `Screen` carries the counters, so
 "one wheel notch became four repaints" is a test, and so is "this diagram
 must render as box art and never go out as a Kitty image".
 
+The same idea covers two things a modern TUI does that render as ordinary
+text. An `OSC 8` hyperlink puts its URL nowhere on the screen, so a test
+asserting your app linked the right issue used to pass just as happily
+against one that emitted no link at all — `links()` reports each span with
+its target and the text it wrapped. And `cursor_shape()` reports what the
+app asked `DECSCUSR` for, so "the indicator says INSERT" and "the terminal
+was actually put into insert" stop being the same assertion — and a program
+that switches the cursor and forgets to switch it back is catchable.
+
 The part I'm proudest of is the flake story. CI runs the whole suite 100
 times on Linux **and** macOS before anything merges to the wait paths.
 That gate caught, among other things, a genuine macOS kernel race where
@@ -66,12 +75,14 @@ pty* because device numbers recycle instantly — termlens serializes pty
 lifecycle edges behind a process-wide lock so your parallel tests don't
 hit it.
 
-Honest limitations (v0.6): Unix only for now (portable-pty supports
+Honest limitations (v0.7): Unix only for now (portable-pty supports
 ConPTY, so Windows is planned); scrollback is retained but bounded, text
 only, and not reflowed on resize; `wait_frame` needs the app to opt into
 DEC 2026; inline graphics are captured and decodable but still never
 rendered, so an image never reaches the screen grid and how a picture sits
-over the text under it is not assertable; and a few questions (kitty
+over the text under it is not assertable; hyperlinks are captured but not
+attributed to cells, so which cells sit inside a span is not assertable;
+and a few questions (kitty
 `CSI ? u`, DECRQSS, `OSC 52` *reads*) are deliberately left unanswered
 rather than guessed — an app blocked on one is named in the next timeout
 instead of hanging silently.


### PR DESCRIPTION
Found while deep-reviewing the v0.7 work before cutting the release — by
asking what a real terminal holds after each escape, not by a failing test.

## The defect

```console
$ printf '\033[5 q'          # blinking bar
$ printf '\033c'             # RIS: hand the terminal back
```

Measured against `b4b59c7` through a real PTY:

```
BEFORE RIS: shape=Bar     blink=Some(true)
AFTER  RIS: shape=Bar     blink=Some(true)   <- wrong
```

RIS is the hard reset: the terminal returns to its power-on state, so the
cursor is the terminal's own default again. Reporting the last `DECSCUSR`
claims a fact the terminal no longer holds — and it does it in precisely the
case `cursor_shape` was added for. `printf '\033c'` is one of the ways a
program restores the cursor on exit, so a test asserting *"it put the cursor
back"* would have been told it had not.

After this change:

```
AFTER  RIS: shape=Default blink=None
```

RIS also closes any open `OSC 8` span, for the same reason: a span cannot
survive a reset.

## What a reset deliberately does not touch

- **The window title.** In xterm the title is a window property that RIS does
  not restore. Clearing it would be the same class of error in the other
  direction, so it is left as it was and the docs now say so.
- **The clipboard, the bell count, and the link *log*.** These are records of
  what the application emitted, not state the terminal still holds. The log
  keeps the span the reset closed, with the text it had.
- **`DECSTR`** (soft reset) is not modelled at all — the sequences it touches
  are not ones tracked here.

## Tests

Three new, each checked by breaking the guard and watching it go red:

- RIS clears the style, and a style set *after* the reset is still recorded;
- RIS closes an open span, keeps the log, and text after the reset belongs to
  no span;
- the neighbouring two-character escapes — `ESC 7`, `ESC 8`, `ESC D`, `ESC M`
  — still reset nothing, since the new arm sits in their table.

Verified end to end through a PTY as well as in the tracker's unit tests.

## Documents

`README.md` (limitations, now headed v0.7, plus a new entry on hyperlinks
being captured rather than attributed to cells), `docs/DESIGN.md` §6, and the
`cursor_shape` doc comment all now state what a reset does and does not
touch.

## Verification

fmt, clippy `-D warnings`, **322 tests** all-features, **307**
no-default-features, docs `-D warnings`, MSRV 1.85, `cargo deny` — all green
locally. The stress workflow runs against `main` after this lands, as step 0
of the release.

Closes nothing — this is a defect found in review rather than a filed issue.

## Also in this PR

Three things the review turned up after the fix itself:

- **A permanent test that a snapshot keeps its own view of the link log.**
  The log is the first out-of-band state *mutated in place* after it is
  recorded — a span is pushed when it opens and completed when it closes —
  so the copy-on-write behind it is load-bearing in a way the bell count and
  the clipboard never were. The emulator already relies on the same property
  for the graphics log, where it is asserted only in a comment. Checked by
  replacing the `Arc::make_mut` with an in-place write through the shared
  pointer and watching the test go red.
- **`docs/HANDOFF.md` and `docs/announce-r-rust.md` brought up to v0.7.** The
  handoff report's "this is historical" header carried a version range that
  had gone stale at every release since it was written; it now points at the
  CHANGELOG instead, so it cannot stale again. The announcement draft is
  unposted and would have been wrong if posted — headed v0.6, and describing
  neither of the captures this release adds, though both are squarely its
  subject.
- **The `[Unreleased]` CHANGELOG section had two `### Fixed` headings** after
  the RIS entry landed above the existing one. The release-notes extractor
  would have reproduced that verbatim into the GitHub Release. Merged, and
  ordered Added / Changed / Fixed.
