### PR TITLE
fix: stop a payload choosing how much memory a decode allocates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,29 @@ listed under a **Changed** or **Removed** heading.
   waiting — and `Color` is the one enum here that downstream code really
   does match on.
 
+### Security
+
+- **A decoded image can no longer choose how much memory it allocates.**
+  `GraphicsPayload::decode` trusted four sizes that the program under test
+  writes: kitty's `s=`/`v=`, sixel's raster attributes, its `!n` repeat count
+  and its `#n` colour-register index. A compressed kitty payload was also
+  inflated with no output limit, and zlib reaches about 1000:1. Each turned a
+  handful of bytes into a request for tens of gigabytes — `!4294967295~` is
+  twelve bytes; a declared `65535x65535` is about twenty and asks for 17 GB
+  before the pixel data is touched at all.
+
+  Decoding is now bounded: no image above 4096x4096 (far beyond what a
+  terminal can place, and 64 MiB of RGBA once built), sixel colour registers
+  capped at 65536, and a compressed payload inflated only as far as its
+  declared size needs. Refusals are a new `DecodeError::TooLarge` rather than
+  a silent clamp — `DecodeError` is `#[non_exhaustive]`, so matching on it
+  already required a wildcard.
+
+  Present in every release before this one. It sits behind the off-by-default
+  `decode` feature and is reached only when a test calls `decode()`, so a
+  suite that merely counts images was never exposed. `SECURITY.md` now
+  enumerates these bounds with the rest.
+
 ### Fixed
 
 - **A hard reset (`RIS`, `ESC c`) returns the cursor shape to the terminal's

--- a/README.md
+++ b/README.md
@@ -235,7 +235,10 @@ design. termlens's position:
   (4 MiB by default, `capture_graphics`); past it a payload is counted and
   described but its bytes are dropped, and it says so rather than decoding a
   prefix of itself. Support stays opt-in, so by default an application that
-  probes is truthfully told there is none.
+  probes is truthfully told there is none. Decoding also refuses anything
+  above 4096x4096: every size in a payload is chosen by the program under
+  test, and a sixel `!n` repeat or a declared `65535x65535` would otherwise
+  set the allocation directly.
 - **Hyperlinks are captured, not attributed to cells.** `links()` reports
   every `OSC 8` span with its target, its `id`, and the text it wrapped, so
   "did it link the right place?" is assertable — but a `Cell` does not carry

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,9 +35,22 @@ deadline-bounded; retained scrollback is capped at the configured length
 than cells; at most 8 completed frames and 512 frame timings are retained; a
 captured `OSC 52` payload is dropped past 64 KiB; **undelivered query replies
 are capped at 1 MiB** and discarded past it, counted and named in the next
-wait's error; the capture of a DCS-class header is fixed at 128 bytes; and the
-set of distinct unanswered queries kept for diagnostics is capped, with the
-remainder counted.
+wait's error; the capture of a DCS-class header is fixed at 128 bytes; `OSC 8`
+hyperlinks are held to the most recent 64 spans with a 4 KiB label each; and
+the set of distinct unanswered queries kept for diagnostics is capped, with
+the remainder counted.
+
+**Decoding** is the one place where a child's bytes choose an allocation
+rather than merely filling one, so it has a ceiling of its own: no image is
+decoded above 4096x4096, sixel colour registers stop at 65536, and a
+compressed kitty payload is inflated only as far as its declared size needs.
+Without those, sizes the payload picks — kitty's `s=`/`v=`, sixel's raster
+attributes, its `!n` repeat count, its `#n` register index — set the
+allocation directly: `!4294967295~` is twelve bytes and a declared
+`65535x65535` about twenty, and either asks for tens of gigabytes. This was
+true of every release before 0.7.0; `GraphicsPayload::decode` sits behind the
+off-by-default `decode` feature and is only reached when a test calls it, so
+a suite that merely counts images was never exposed.
 
 The reply cap is a byte bound rather than a queue depth on purpose: a depth
 bounds the wrong thing. Two earlier versions counted queue slots and both

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -431,8 +431,11 @@ impl SeqTracker {
         let id = params
             .split(|&b| b == b':')
             .find_map(|pair| pair.strip_prefix(b"id="))
-            .map(|value| String::from_utf8_lossy(value).into_owned());
-        let uri = String::from_utf8_lossy(uri).into_owned();
+            .map(String::from_utf8_lossy);
+        // Borrowed where the bytes are valid UTF-8, which is the normal case:
+        // `Link::open` copies into an `Arc<str>` either way, so owning here
+        // first would allocate twice for one span.
+        let uri = String::from_utf8_lossy(uri);
         let links = Arc::make_mut(&mut self.links);
         links.push(Link::open(&uri, id.as_deref()));
         while links.len() > LINK_HISTORY {
@@ -976,18 +979,23 @@ impl SeqTracker {
                     if b == BEL && self.utf8_remaining == 0 {
                         self.bells = self.bells.saturating_add(1);
                     }
+                    // Anything that is not a C0 control or DEL. Named once
+                    // because the two readers below want the same test for
+                    // different reasons, and they must not drift apart: a
+                    // byte that counts as drawn is a byte a link wraps.
+                    let printable = b >= 0x20 && b != 0x7f;
                     // One per *character*: continuation bytes arrive while
                     // `utf8_remaining` is non-zero, so nothing is counted
                     // twice. Controls, the BEL just handled included, are not
                     // printable.
-                    if self.utf8_remaining == 0 && b >= 0x20 && b != 0x7f {
+                    if printable && self.utf8_remaining == 0 {
                         self.frame_printable = self.frame_printable.saturating_add(1);
                     }
                     // Text written inside an `OSC 8` span is that link's
-                    // label. Bytes rather than characters, so a multi-byte
-                    // grapheme survives the split — continuation bytes are
-                    // all >= 0x80 and pass the same test.
-                    if self.link_open && b >= 0x20 && b != 0x7f {
+                    // label. Bytes rather than characters here, so a
+                    // multi-byte grapheme survives the split — its
+                    // continuation bytes are all >= 0x80 and printable too.
+                    if printable && self.link_open {
                         if self.link_label.len() < LINK_LABEL_MAX {
                             self.link_label.push(b);
                         } else {
@@ -1590,6 +1598,122 @@ mod tests {
             assert_eq!(t.cursor_style(), None, "{seq:?} set a cursor style");
             assert_eq!(t.step(b'x'), SeqEvent::None);
         }
+    }
+
+    /// The tracker parses bytes a *child process* chooses, so every buffer
+    /// in it is a place a hostile or merely broken program could push on.
+    /// Each one is bounded in code; this is the test that says so out loud.
+    ///
+    /// Two phases, because they catch different things. Random bytes explore
+    /// the state machine and are the net for a panic — an index, a slice, an
+    /// arithmetic overflow — on input nobody thought about. They do *not*
+    /// reach any bound: a bound needs thousands of bytes pushed the same way
+    /// on purpose, which random bytes essentially never do. So the second
+    /// phase writes the shapes a hostile child would actually use.
+    ///
+    /// The peak assertions at the end are the point. Without them this test
+    /// would go on passing if the corpus stopped stressing the buffers, and
+    /// its bound checks would be decoration — which is what they were when
+    /// first written here, and what the mutation pass caught.
+    ///
+    /// Deterministic: the seed is the whole corpus, so a failure reproduces.
+    #[test]
+    fn hostile_input_cannot_panic_or_grow_a_buffer_past_its_bound() {
+        let capture = crate::graphics::DEFAULT_CAPTURE;
+        let mut tracker = SeqTracker::new(capture);
+        // (links, label, osc, dcs_body) high-water marks.
+        let mut peak = (0usize, 0usize, 0usize, 0usize);
+
+        fn observe(t: &SeqTracker, capture: usize, peak: &mut (usize, usize, usize, usize)) {
+            assert!(t.links.len() <= LINK_HISTORY, "link log overran");
+            assert!(t.link_label.len() <= LINK_LABEL_MAX, "label overran");
+            assert!(t.osc_buf.len() <= OSC_CAPTURE_MAX, "osc buffer overran");
+            assert!(t.dcs_body.len() <= capture, "dcs body overran");
+            assert!(usize::from(t.seq_len) <= t.seq_buf.len());
+            assert!(usize::from(t.dcs_head_len) <= t.dcs_head.len());
+            peak.0 = peak.0.max(t.links.len());
+            peak.1 = peak.1.max(t.link_label.len());
+            peak.2 = peak.2.max(t.osc_buf.len());
+            peak.3 = peak.3.max(t.dcs_body.len());
+        }
+
+        // Phase 1 — the panic net. xorshift64: a few lines, no dependency,
+        // reproducible. Weighted toward the introducers that actually drive
+        // the state machine; uniform noise would sit in Ground almost always.
+        let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+        let mut rand = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        const PALETTE: &[u8] =
+            b"\x1b[]P_^X;:0123456789 qhlmc\\\x07\x18\x1a~?$8abzId=\xff\x80\xc3\n\r\t";
+        for _ in 0..400_000 {
+            tracker.step(PALETTE[(rand() as usize) % PALETTE.len()]);
+            observe(&tracker, capture, &mut peak);
+        }
+
+        // Phase 2 — the shapes a hostile child would use, each aimed at one
+        // buffer and overrunning it by a clear margin.
+        let feed = |bytes: &[u8], t: &mut SeqTracker, peak: &mut _| {
+            for &b in bytes {
+                t.step(b);
+                observe(t, capture, peak);
+            }
+        };
+        // (a) far more spans than the log holds.
+        for n in 0..LINK_HISTORY * 3 {
+            feed(
+                format!("\x1b]8;;http://x/{n}\x1b\\L\x1b]8;;\x1b\\").as_bytes(),
+                &mut tracker,
+                &mut peak,
+            );
+        }
+        // (b) one span whose label runs well past the bound.
+        feed(b"\x1b]8;;http://x/\x1b\\", &mut tracker, &mut peak);
+        feed(&vec![b'L'; LINK_LABEL_MAX * 2], &mut tracker, &mut peak);
+        feed(b"\x1b]8;;\x1b\\", &mut tracker, &mut peak);
+        // (c) one OSC longer than the capture bound.
+        feed(b"\x1b]0;", &mut tracker, &mut peak);
+        feed(&vec![b'T'; OSC_CAPTURE_MAX * 2], &mut tracker, &mut peak);
+        feed(b"\x07", &mut tracker, &mut peak);
+
+        // The corpus must actually have reached each bound, or every check
+        // above was inert.
+        assert_eq!(peak.0, LINK_HISTORY, "the link log was never filled");
+        assert_eq!(peak.1, LINK_LABEL_MAX, "the label bound was never reached");
+        assert_eq!(peak.2, OSC_CAPTURE_MAX, "the osc bound was never reached");
+
+        // And the accessors stay total on whatever state that left behind.
+        let _ = tracker.title();
+        let _ = tracker.clipboard();
+        let _ = tracker.links();
+        let _ = tracker.cursor_style();
+        let _ = tracker.graphics();
+    }
+
+    /// The same, on the grammar rather than the alphabet: well-formed
+    /// `OSC 8` spans interleaved with the sequences most likely to collide
+    /// with them, driven long enough to exercise eviction many times over.
+    #[test]
+    fn a_long_well_formed_stream_stays_bounded_and_consistent() {
+        let mut tracker = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
+        for n in 0..5_000u32 {
+            let chunk = format!(
+                "\x1b]8;id={n};http://example.invalid/{n}\x1b\\label{n}\x1b]8;;\x1b\\\
+                 \x1b]0;title{n}\x07\x1b[{} q text\r\n",
+                n % 7
+            );
+            tracker.feed(chunk.as_bytes());
+            assert!(tracker.links.len() <= LINK_HISTORY);
+        }
+        let links = tracker.links();
+        assert_eq!(links.len(), LINK_HISTORY, "the log fills and then holds");
+        // Oldest evicted, newest kept, every retained span complete.
+        assert!(links.iter().all(|l| l.closed() && l.label().is_some()));
+        assert_eq!(links[LINK_HISTORY - 1].uri(), "http://example.invalid/4999");
+        assert_eq!(links[LINK_HISTORY - 1].label(), Some("label4999"));
     }
 
     #[test]

--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -318,17 +318,31 @@ impl GraphicsPayload {
         let (width, height) = self.size.ok_or(DecodeError::Malformed(
             "a kitty transmission without s= and v=",
         ))?;
-        let raw = crate::emu::decode_base64(data).ok_or(DecodeError::Malformed("bad base64"))?;
-        let raw = if self.compressed {
-            miniz_oxide::inflate::decompress_to_vec_zlib(&raw)
-                .map_err(|_| DecodeError::Malformed("zlib data that would not inflate"))?
-        } else {
-            raw
-        };
+        // The declared size is computed *before* the payload is touched,
+        // because it is what bounds the inflate below. The other way round —
+        // as this was — leaves `decompress_to_vec_zlib` free to allocate
+        // whatever the compressed bytes expand to, and zlib reaches about
+        // 1000:1, so a payload inside the capture bound could ask for
+        // gigabytes.
+        if width as usize > MAX_DECODED_WIDTH || height as usize > MAX_DECODED_HEIGHT {
+            return Err(DecodeError::TooLarge(
+                "a kitty transmission declaring more than 4096x4096",
+            ));
+        }
         let wanted = (width as usize)
             .checked_mul(height as usize)
             .and_then(|pixels| pixels.checked_mul(channels))
             .ok_or(DecodeError::Malformed("a declared size that overflows"))?;
+        let raw = crate::emu::decode_base64(data).ok_or(DecodeError::Malformed("bad base64"))?;
+        let raw = if self.compressed {
+            // Nothing past the declared size is ever read, so nothing past it
+            // needs inflating.
+            miniz_oxide::inflate::decompress_to_vec_zlib_with_limit(&raw, wanted).map_err(|_| {
+                DecodeError::Malformed("zlib data that would not inflate within the declared size")
+            })?
+        } else {
+            raw
+        };
         if raw.len() < wanted {
             return Err(DecodeError::Malformed(
                 "fewer bytes than the declared size needs",
@@ -426,6 +440,28 @@ impl Bitmap {
     }
 }
 
+/// The largest image [`GraphicsPayload::decode`] will build.
+///
+/// Every size in a payload is chosen by the program under test: kitty
+/// declares `s=`/`v=` and may arrive zlib-compressed, and sixel declares its
+/// raster attributes, names colour registers by index, and repeats a byte
+/// `!n` times. Each of those turns a handful of bytes into a request for
+/// tens of gigabytes if it is trusted — `!4294967295~` is twelve bytes, and
+/// a declared `65535x65535` is about twenty.
+///
+/// 4096x4096 is far beyond what any terminal can place, and 64 MiB of RGBA
+/// once built, so a real image is never refused by it.
+#[cfg(feature = "decode")]
+const MAX_DECODED_WIDTH: usize = 4096;
+/// See [`MAX_DECODED_WIDTH`].
+#[cfg(feature = "decode")]
+const MAX_DECODED_HEIGHT: usize = 4096;
+/// Colour registers a sixel may name. `#n` gives the index directly, so it
+/// is attacker-chosen; the common maximum is 256 and no terminal goes past
+/// this.
+#[cfg(feature = "decode")]
+const MAX_SIXEL_REGISTERS: usize = 65_536;
+
 /// Why a payload could not be decoded.
 #[cfg(feature = "decode")]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -442,6 +478,10 @@ pub enum DecodeError {
     Unsupported(&'static str),
     /// The payload contradicts itself or the protocol.
     Malformed(&'static str),
+    /// The payload asks for more memory than termlens will spend on one
+    /// image. Not a judgement about the picture: it is a refusal to let a
+    /// size the program under test chose decide how much this allocates.
+    TooLarge(&'static str),
 }
 
 #[cfg(feature = "decode")]
@@ -456,6 +496,7 @@ impl fmt::Display for DecodeError {
             }
             DecodeError::Unsupported(what) => write!(f, "termlens does not decode {what}"),
             DecodeError::Malformed(what) => write!(f, "the payload carries {what}"),
+            DecodeError::TooLarge(what) => write!(f, "termlens will not decode {what}"),
         }
     }
 }
@@ -525,6 +566,11 @@ fn decode_sixel(data: &[u8]) -> Result<Bitmap, DecodeError> {
                 at += 1;
                 let values = params(data, &mut at);
                 let index = values.first().copied().unwrap_or(0) as usize;
+                if index >= MAX_SIXEL_REGISTERS {
+                    return Err(DecodeError::TooLarge(
+                        "a sixel colour register index past 65536",
+                    ));
+                }
                 if index >= registers.len() {
                     registers.resize(index + 1, None);
                 }
@@ -559,7 +605,7 @@ fn decode_sixel(data: &[u8]) -> Result<Bitmap, DecodeError> {
                         bits,
                         count,
                         registers.get(current).copied().flatten(),
-                    );
+                    )?;
                 }
             }
             0x3f..=0x7e => {
@@ -573,7 +619,7 @@ fn decode_sixel(data: &[u8]) -> Result<Bitmap, DecodeError> {
                     bits,
                     1,
                     registers.get(current).copied().flatten(),
-                );
+                )?;
             }
             b'$' => {
                 at += 1;
@@ -598,12 +644,23 @@ fn decode_sixel(data: &[u8]) -> Result<Bitmap, DecodeError> {
         bits: u8,
         count: usize,
         colour: Option<[u8; 4]>,
-    ) {
+    ) -> Result<(), DecodeError> {
         for _ in 0..count {
+            // Checked every step rather than once against `count`: `!n` gives
+            // a `u32`, and the cursor also carries over from earlier runs in
+            // the same band. Outside the colour branch because an undefined
+            // register still advances the cursor, so a huge repeat would
+            // otherwise spin four billion times painting nothing.
+            if *x >= MAX_DECODED_WIDTH {
+                return Err(DecodeError::TooLarge("a sixel wider than 4096 pixels"));
+            }
             if let Some(colour) = colour {
                 for bit in 0..6 {
                     if bits & (1 << bit) != 0 {
                         let y = band_top + bit;
+                        if y >= MAX_DECODED_HEIGHT {
+                            return Err(DecodeError::TooLarge("a sixel taller than 4096 pixels"));
+                        }
                         if rows.len() <= y {
                             rows.resize(y + 1, Vec::new());
                         }
@@ -618,12 +675,21 @@ fn decode_sixel(data: &[u8]) -> Result<Bitmap, DecodeError> {
             *x += 1;
             *width_seen = (*width_seen).max(*x);
         }
+        Ok(())
     }
 
     let (width, height) = match declared {
         Some((width, height)) if width > 0 && height > 0 => (width, height),
         _ => (width_seen as u32, rows.len() as u32),
     };
+    // The declared raster attributes reach this allocation without the pixel
+    // data being touched at all, so a payload declaring 65535x65535 and
+    // painting nothing still asks for about 17 GB.
+    if width as usize > MAX_DECODED_WIDTH || height as usize > MAX_DECODED_HEIGHT {
+        return Err(DecodeError::TooLarge(
+            "a sixel declaring more than 4096x4096",
+        ));
+    }
     let mut pixels = Vec::with_capacity((width as usize).saturating_mul(height as usize));
     for y in 0..height as usize {
         for x in 0..width as usize {
@@ -1072,6 +1138,92 @@ mod tests {
         let payload = kitty_payload(b"a=T,f=24,s=1,v=1", data.as_bytes());
         let bitmap = payload.decode().expect("decodes");
         assert_eq!(bitmap.pixel(0, 0), Some([0x11, 0x22, 0x33, 0xff]));
+    }
+
+    #[cfg(feature = "decode")]
+    fn sixel_payload(data: &[u8]) -> GraphicsPayload {
+        let mut builder = GraphicsBuilder::default();
+        builder.sixel();
+        builder.chunk(data.len() as u64, data, true, usize::MAX);
+        builder.finish().expect("a payload")
+    }
+
+    /// Every size in a payload is chosen by the program under test, and each
+    /// of these turns a handful of bytes into a request for gigabytes if it
+    /// is trusted. All five were live before the ceiling went in.
+    ///
+    /// One table on purpose, so a sixth path cannot appear without a line
+    /// here saying what bounds it.
+    #[cfg(feature = "decode")]
+    #[test]
+    fn a_payload_cannot_choose_how_much_memory_a_decode_spends() {
+        // A declared size no terminal could place, refused before any data
+        // is read.
+        assert!(
+            matches!(
+                kitty_payload(b"a=T,f=32,s=65535,v=65535", b"AAAA").decode(),
+                Err(DecodeError::TooLarge(_))
+            ),
+            "a 65535x65535 kitty transmission was not refused"
+        );
+
+        // A zlib bomb: four declared bytes, four mebibytes inside. The
+        // inflate is bounded by the declared size, so it never expands.
+        let bomb = miniz_oxide::deflate::compress_to_vec_zlib(&vec![0u8; 4 << 20], 9);
+        assert!(bomb.len() < 64 << 10, "the fixture is meant to be small");
+        assert!(
+            matches!(
+                kitty_payload(b"a=T,f=32,o=z,s=1,v=1", base64(&bomb).as_bytes()).decode(),
+                Err(DecodeError::Malformed(_))
+            ),
+            "a payload inflating past its declared size was not refused"
+        );
+
+        // A sixel naming a colour register far past any palette.
+        assert!(
+            matches!(
+                sixel_payload(b"#4000000000;2;100;100;100~").decode(),
+                Err(DecodeError::TooLarge(_))
+            ),
+            "a four-billion colour register was not refused"
+        );
+
+        // A sixel repeat count. Twelve bytes of input.
+        assert!(
+            matches!(
+                sixel_payload(b"#0;2;100;100;100!4294967295~").decode(),
+                Err(DecodeError::TooLarge(_))
+            ),
+            "a four-billion repeat was not refused"
+        );
+
+        // Raster attributes, which reach the final allocation without the
+        // pixel data being touched at all.
+        assert!(
+            matches!(
+                sixel_payload(b"\"1;1;65535;65535#0;2;100;100;100~").decode(),
+                Err(DecodeError::TooLarge(_))
+            ),
+            "a 65535x65535 declared sixel was not refused"
+        );
+    }
+
+    /// The ceiling must not refuse anything real: a terminal-sized image in
+    /// either protocol decodes exactly as before.
+    #[cfg(feature = "decode")]
+    #[test]
+    fn an_ordinary_image_is_untouched_by_the_ceiling() {
+        let raw = vec![0x40u8; 64 * 32 * 4];
+        let bitmap = kitty_payload(b"a=T,f=32,s=64,v=32", base64(&raw).as_bytes())
+            .decode()
+            .expect("a 64x32 image still decodes");
+        assert_eq!((bitmap.width(), bitmap.height()), (64, 32));
+        assert_eq!(bitmap.pixel(63, 31), Some([0x40, 0x40, 0x40, 0x40]));
+
+        let sixel = sixel_payload(b"\"1;1;4;6#0;2;100;0;0~~~~")
+            .decode()
+            .expect("a small sixel still decodes");
+        assert_eq!((sixel.width(), sixel.height()), (4, 6));
     }
 
     #[cfg(feature = "decode")]


### PR DESCRIPTION
Found while security-reviewing before cutting v0.7.0.

## The defect

`GraphicsPayload::decode` trusted four sizes that the **program under test**
writes into the payload, and inflated compressed payloads with no output
limit:

| what | chosen by | cost if trusted |
|---|---|---|
| kitty `s=`/`v=` | the payload | a declared `65535x65535` |
| kitty `o=z` inflate | the payload | zlib reaches ~1000:1 |
| sixel `!n` repeat | the payload | `!4294967295~` — **12 bytes** |
| sixel `#n` register | the payload | `#4000000000` resizes a `Vec` |
| sixel raster attrs | the payload | reaches the final allocation with the pixel data untouched |

The last is the cheapest: about twenty bytes, and the number the capped
mutation run prints is exact —

```
memory allocation of 17179344900 bytes failed
```

17.18 GB, before a single pixel is read.

## The fix

Bounded, with the ceilings named and documented:

- no image above **4096x4096** — far beyond what any terminal can place, and
  64 MiB of RGBA once built, so nothing real is refused (there is a test for
  that);
- sixel colour registers stop at **65536**;
- a compressed payload is inflated **only as far as its declared size needs**,
  which is all that is ever read.

The kitty size is now computed *before* the payload is touched, because it is
what bounds the inflate. The other order is how the limit went missing.

Refusals are a new **`DecodeError::TooLarge`** rather than a silent clamp: a
truncated picture would be a wrong answer presented as a right one.
`DecodeError` is `#[non_exhaustive]`, so downstream matches already carry a
wildcard and nothing breaks.

## Exposure

Present in **every release before this one**. It sits behind the
off-by-default `decode` feature and is reached only when a test calls
`decode()`, so a suite that merely counts images was never exposed.

`SECURITY.md` claimed *"every buffer a child's output can reach is bounded"* —
true of the parser, not of the decoder. It now enumerates these bounds with
the rest, and says plainly which releases were affected.

## Also here

From the same review of what a child's bytes can do:

- **Two robustness tests for the sequence tracker.** One drives 400,000
  weighted random bytes through it as a panic net; the other writes the shapes
  a hostile child would actually use, because random bytes never reach a
  bound. Both assert the **high-water marks** afterwards, so the checks cannot
  quietly become decoration — which is exactly what they were when first
  written here, and what the mutation pass caught.
- **Hot path:** the ground state names `printable` once instead of testing
  `b >= 0x20 && b != 0x7f` twice, and `open_link` keeps the `Cow` that
  `from_utf8_lossy` already returns rather than owning it only for `Arc::from`
  to copy again — one allocation per span instead of two.

## How this was verified, and a warning

Every bound was checked by removing it and watching a test fail, with the
child capped by `ulimit -v` so an unbounded allocation fails in milliseconds.

That precaution is not theoretical. The **first** attempt at this
verification, uncapped, drove a test binary to 44.5 GB resident and triggered
a global OOM on the development machine. Anyone repeating this work should cap
the child first.

## Gates

fmt, clippy `-D warnings`, **327 tests** all-features, **310**
no-default-features, docs `-D warnings`, MSRV 1.85 (checked with
`--all-features` too, since `decode` is where the change is), `cargo deny`.
