### PR TITLE
release: v0.7.0 — links, cursor shape, and a bounded decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-27
+
 ### Added
 
 - **`TerminalBuilder::envs` sets several child environment variables from an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "crossterm",
 ]
@@ -181,14 +181,14 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "crossterm",
 ]
 
 [[package]]
 name = "image-echo"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "miniz_oxide",
 ]
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "crossterm",
 ]
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -611,7 +611,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.6.1"
+version = "0.7.0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.


### PR DESCRIPTION
Version bump and CHANGELOG move for **v0.7.0**. No code changes — everything
below already landed in #170, #171 and #172.

## What ships

| | |
|---|---|
| **Added** | `Screen::links` (`OSC 8`), `Screen::cursor_shape` / `cursor_blink` (`DECSCUSR`), `Key::Insert`, `TerminalBuilder::envs` |
| **Changed** | `Key` and `Signal` are `#[non_exhaustive]` — breaking for downstream exhaustive matches |
| **Security** | a decoded image can no longer choose how much memory it allocates |
| **Fixed** | `RIS` returns the cursor shape to the terminal's default; doctests build with default features off |

## Step 0 of docs/RELEASING.md is satisfied

The stress workflow ran on `e1be7d9`: **100 iterations across ten shards,
Linux and macOS, all green** ([run](https://github.com/vyncint/termlens/actions/runs/33031164414)).
Plus 29 local iterations at 1/2/4/8/16 threads, no flake.

## Gates on this commit

fmt · clippy `-D warnings` · **327 tests** all-features · **310**
no-default-features · docs `-D warnings` · MSRV 1.85 (checked with
`--all-features`, since `decode` is where the security fix is) · `cargo deny`.

`cargo-semver-checks` reports **no update required at 0.7.0**. The two
`#[non_exhaustive]` additions are breaking, and pre-1.0 the minor bump is
where breaking changes go — so the tag will satisfy the release gate.

## Checked by hand, because nothing automates it

Every constant the docs quote was verified against the code: scrollback,
frames, timings, the reply cap, OSC capture, DCS header, the link log and
label bounds, graphics capture, the new decode ceiling, and the MSRV. All
agree.

I also dry-ran `extract-changelog.sh` against the moved section on a copy
before committing: it finds **8 entries** for `0.7.0`, which is what the
GitHub Release notes will contain.

## One piece of doc drift, not fixed here

`docs/RELEASING.md` step 3 says `git commit -s -am "chore: release vX.Y.Z"`,
but every release in this history uses `release: vX.Y.Z — …`. The
commit-policy gate enforces DCO and no-AI-attribution only, not Conventional
Commit types, so both pass. I followed the history. Worth reconciling the doc
in a separate change rather than inside a release.

After merge: tag `v0.7.0` on `main`, which triggers `release.yml` —
version/tag check, full CI gates, `cargo-semver-checks`, publish via Trusted
Publishing (OIDC, no stored token), and the GitHub Release from the changelog
section.
