### PR TITLE
fix: reject mouse coordinates outside the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mouse `click` / `click_with` / `drag` / `scroll` refuse coordinates
+  outside the current grid.** A real terminal cannot produce an off-window
+  mouse event; sending one was the same class of mistake as clicking with
+  no tracking enabled. The error names the position and the grid size at
+  the time of the call (so a post-`resize` rejection is obvious). `drag`
+  checks both endpoints only — the interpolated path cannot leave the
+  rectangle they span. Separately, the SGR encoder no longer wraps or
+  panics at `u16::MAX`: the 1-based `+ 1` is done in `u32`.
+
 ## [0.7.0] - 2026-08-27
 
 ### Added

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -359,9 +359,18 @@ fn chord_base(key: Key) -> Option<ChordBase> {
 }
 
 /// SGR (1006) mouse report. `press = false` is the release form.
+///
+/// Coordinates are 1-based on the wire. The `+ 1` is done in `u32` so a
+/// caller that somehow skips the grid check cannot wrap `u16::MAX` to
+/// column/row 0 in release builds.
 pub(crate) fn mouse_sgr(button: u8, col: u16, row: u16, press: bool) -> Vec<u8> {
     let suffix = if press { 'M' } else { 'm' };
-    format!("\x1b[<{button};{};{}{suffix}", col + 1, row + 1).into_bytes()
+    format!(
+        "\x1b[<{button};{};{}{suffix}",
+        u32::from(col) + 1,
+        u32::from(row) + 1
+    )
+    .into_bytes()
 }
 
 /// Legacy (X10/normal) mouse report: `ESC [ M Cb Cx Cy`, byte-valued.
@@ -489,6 +498,24 @@ mod tests {
         assert_eq!(mouse_sgr(64, 0, 0, true), b"\x1b[<64;1;1M");
         assert_eq!(mouse_legacy(0, 0, 0), b"\x1b[M\x20\x21\x21");
         assert_eq!(mouse_legacy(3, 9, 6,), b"\x1b[M\x23\x2a\x27");
+    }
+
+    /// `u16::MAX + 1` used to wrap to 0 in release and panic in debug.
+    /// The encoder must stay in range even if a caller skips the grid check.
+    #[test]
+    fn mouse_sgr_does_not_wrap_at_u16_max() {
+        let expected = format!(
+            "\x1b[<0;{};{}M",
+            u32::from(u16::MAX) + 1,
+            u32::from(u16::MAX) + 1
+        );
+        assert_eq!(mouse_sgr(0, u16::MAX, u16::MAX, true), expected.as_bytes());
+        let release = format!(
+            "\x1b[<0;{};{}m",
+            u32::from(u16::MAX) + 1,
+            u32::from(u16::MAX) + 1
+        );
+        assert_eq!(mouse_sgr(0, u16::MAX, u16::MAX, false), release.as_bytes());
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -423,6 +423,25 @@ fn no_mouse_tracking() -> Error {
     )
 }
 
+/// Refuse a mouse coordinate a real terminal cannot produce.
+///
+/// `cols`×`rows` is the grid **at the time of the call** — after a
+/// [`Terminal::resize`] that shrank the window, a coordinate that was
+/// in-bounds earlier is rejected against the new size, and the message
+/// says so rather than leaving the size implicit.
+fn check_mouse_in_grid(col: u16, row: u16, cols: u16, rows: u16) -> Result<()> {
+    if col < cols && row < rows {
+        return Ok(());
+    }
+    Err(Error::Input(format!(
+        "mouse at ({col}, {row}) is outside the {cols}x{rows} grid \
+         (columns x rows at the time of the call; valid cells are \
+         col 0..{}, row 0..{})",
+        cols.saturating_sub(1),
+        rows.saturating_sub(1),
+    )))
+}
+
 /// A POSIX signal for [`Terminal::signal`]: the graceful-shutdown set.
 ///
 /// Note the difference from typing: `send(Key::Ctrl('c'))` writes the
@@ -2107,8 +2126,9 @@ impl Terminal {
     /// reaped child is named as such instead of being reported as a
     /// missing tracking mode. Then [`Error::Input`] when the application
     /// has not enabled mouse tracking (feeding it mouse bytes anyway would
-    /// be misparsed as garbage keys), or when the position is
-    /// unrepresentable in the legacy encoding (columns/rows beyond 222).
+    /// be misparsed as garbage keys), when `(col, row)` is outside the
+    /// current grid, or when the position is unrepresentable in the legacy
+    /// encoding (columns/rows beyond 222).
     pub fn click(&mut self, col: u16, row: u16) -> Result<()> {
         self.click_with(MouseButton::Left, col, row)
     }
@@ -2142,6 +2162,8 @@ impl Terminal {
             MouseMode::Press => true,
             MouseMode::PressRelease | MouseMode::ButtonMotion | MouseMode::AnyMotion => false,
         };
+        let (cols, rows) = self.screen().size();
+        check_mouse_in_grid(col, row, cols, rows)?;
         let mut bytes = self.mouse_report(&modes, chord.code(), col, row, true)?;
         if !press_only {
             bytes.extend(self.mouse_report(&modes, chord.code(), col, row, false)?);
@@ -2172,9 +2194,13 @@ impl Terminal {
     ///
     /// [`Error::Write`] when the child is gone (checked first, as on
     /// [`click`](Self::click)), then [`Error::Input`] when no mouse
-    /// tracking is enabled, when the tracking mode is X10, or when a
-    /// position is unrepresentable in the encoding the application
-    /// selected.
+    /// tracking is enabled, when the tracking mode is X10, when either
+    /// endpoint is outside the current grid, or when a position is
+    /// unrepresentable in the encoding the application selected.
+    ///
+    /// Only the endpoints are checked against the grid. The interpolated
+    /// path stays between them on both axes, so an interior step cannot
+    /// leave the grid unless an endpoint already has.
     pub fn drag(
         &mut self,
         button: impl Into<MouseChord>,
@@ -2196,6 +2222,10 @@ impl Terminal {
             MouseMode::PressRelease => false,
             MouseMode::ButtonMotion | MouseMode::AnyMotion => true,
         };
+        let (cols, rows) = self.screen().size();
+        // Endpoints only — see the Errors section above.
+        check_mouse_in_grid(from.0, from.1, cols, rows)?;
+        check_mouse_in_grid(to.0, to.1, cols, rows)?;
         let mut bytes = self.mouse_report(&modes, chord.code(), from.0, from.1, true)?;
         if report_motion {
             // One motion report per cell crossed, which is what a terminal
@@ -2225,6 +2255,8 @@ impl Terminal {
         if modes.mouse == MouseMode::None {
             return Err(no_mouse_tracking());
         }
+        let (cols, rows) = self.screen().size();
+        check_mouse_in_grid(col, row, cols, rows)?;
         let button = match direction {
             Scroll::Up => 64,
             Scroll::Down => 65,
@@ -2994,7 +3026,25 @@ impl Drop for Terminal {
 
 #[cfg(test)]
 mod tests {
-    use super::cells_between;
+    use super::{cells_between, check_mouse_in_grid};
+    use crate::Error;
+
+    #[test]
+    fn mouse_in_grid_accepts_the_bottom_right_cell() {
+        assert!(check_mouse_in_grid(19, 4, 20, 5).is_ok());
+        assert!(check_mouse_in_grid(0, 0, 20, 5).is_ok());
+    }
+
+    #[test]
+    fn mouse_in_grid_refuses_one_past_each_edge() {
+        for (col, row) in [(20u16, 0), (0, 5), (20, 5), (u16::MAX, u16::MAX)] {
+            let err = check_mouse_in_grid(col, row, 20, 5).unwrap_err();
+            assert!(matches!(err, Error::Input(_)), "got: {err}");
+            let msg = err.to_string();
+            assert!(msg.contains(&format!("({col}, {row})")), "{msg}");
+            assert!(msg.contains("20x5"), "{msg}");
+        }
+    }
 
     #[test]
     fn a_horizontal_drag_visits_every_column() {

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -383,6 +383,57 @@ fn clicking_without_mouse_tracking_is_a_typed_error() {
     assert!(t.wait_exit().unwrap().success());
 }
 
+/// A real terminal cannot report a click outside its window. Off-grid
+/// coordinates used to encode and send anyway (and at `u16::MAX` the SGR
+/// path wrapped or panicked). Refuse with the position and the grid size
+/// at the time of the call — including after a shrink `resize`.
+#[test]
+fn mouse_events_outside_the_grid_are_refused() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(20, 5)
+        .timeout(Duration::from_secs(10))
+        .env_clear()
+        .spawn(util::fixture_bin("form-echo"))?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+
+    // Bottom-right cell is in bounds; one past each edge is not.
+    t.click(19, 4)?;
+    t.wait_frame(|s| s.contains("last: mouse:up:19,4"))?;
+
+    for (col, row) in [(20u16, 0), (0, 5), (20, 5), (9999, 9999)] {
+        let err = t.click(col, row).expect_err("off-grid click");
+        assert!(matches!(err, Error::Input(_)), "got: {err}");
+        let msg = err.to_string();
+        assert!(msg.contains(&format!("({col}, {row})")), "{msg}");
+        assert!(msg.contains("20x5"), "size at call time: {msg}");
+    }
+
+    let err = t.scroll(20, 0, Scroll::Up).expect_err("off-grid scroll");
+    assert!(matches!(err, Error::Input(_)), "got: {err}");
+    assert!(err.to_string().contains("20x5"), "{err}");
+
+    let err = t
+        .drag(termlens::MouseButton::Left, (0, 0), (20, 0))
+        .expect_err("off-grid drag endpoint");
+    assert!(matches!(err, Error::Input(_)), "got: {err}");
+    assert!(err.to_string().contains("(20, 0)"), "{err}");
+    assert!(err.to_string().contains("20x5"), "{err}");
+
+    // After a shrink, a coordinate that was valid earlier must name the
+    // *new* size — otherwise the error reads as a mystery.
+    t.resize(10, 3)?;
+    let err = t.click(19, 4).expect_err("pre-resize coordinate");
+    assert!(matches!(err, Error::Input(_)), "got: {err}");
+    let msg = err.to_string();
+    assert!(msg.contains("(19, 4)"), "{msg}");
+    assert!(msg.contains("10x3"), "post-resize size: {msg}");
+    assert!(!msg.contains("20x5"), "must not report the old size: {msg}");
+
+    t.send(Key::Esc)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 /// Both focus states, through crossterm's own event stream. Before this the
 /// unfocused branch of a UI was not merely unasserted, it was **unreachable**
 /// — no input existed that could enter it, so the code never ran.


### PR DESCRIPTION
## What & why

Mouse `click` / `click_with` / `drag` / `scroll` never checked coordinates against the live grid, so off-window positions encoded and sent as if valid. At `u16::MAX` the SGR encoder also overflowed (`col + 1` / `row + 1`): debug panicked, release wrapped to column 0.

This matches the existing `no_mouse_tracking` contract — a real terminal cannot produce these events, so the library refuses them with a typed `Error::Input` that names the position **and** the grid size at the time of the call (including after a shrink `resize`).

Fixes #176.

## Changes

1. **Grid bounds** on `click_with`, `scroll`, and `drag` (both endpoints only — the interpolated path cannot leave the rectangle they span).
2. **Non-wrapping SGR arithmetic** in `mouse_sgr` via `u32::from(coord) + 1`, so a future caller that skips the check still cannot wrap.
3. **Tests**: unit coverage for the guard and `u16::MAX` encoding; integration coverage for off-grid click/scroll/drag and post-`resize` size in the error message.

## Not in this PR

- No change to the legacy 222-column encoding limit path (still checked in `mouse_report` after the grid check).
- Drag interior steps are not individually re-checked; endpoints are enough because Bresenham-free interpolation stays between them.

## Checklist

- [x] Linked an issue (`Fixes #176`)
- [x] Tests added/updated for the change
- [x] `cargo fmt --all` clean
- [x] Unit tests for the guard + SGR `u16::MAX` path pass locally
- [x] **All commits are signed off** (`git commit -s`)
- [x] **No AI attribution trailers**
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] No snapshot changes