### PR TITLE
Return a typed error for invalid terminal sizes

### DIFF
--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -61,6 +61,11 @@ pub enum Error {
     #[error("i/o error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// A terminal size argument is invalid and was rejected before anything
+    /// was spawned or sent to the child.
+    #[error("invalid terminal size: {0}")]
+    Size(String),
+
     /// Typed input or control the child cannot receive — e.g. a mouse
     /// click while the application never enabled mouse tracking (sending
     /// it anyway would feed the app bytes it would misparse as garbage

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1643,13 +1643,13 @@ fn pixel_span(cells: u16, per_cell: Option<u16>) -> u16 {
 /// the problem. A named error at the call site is the whole fix.
 fn check_size(cols: u16, rows: u16) -> Result<()> {
     if cols == 0 || rows == 0 {
-        return Err(Error::Input(format!(
+        return Err(Error::Size(format!(
             "a terminal needs at least one column and one row, got {cols}x{rows} \
              (columns x rows)"
         )));
     }
     if cols > MAX_DIMENSION || rows > MAX_DIMENSION {
-        return Err(Error::Input(format!(
+        return Err(Error::Size(format!(
             "{cols}x{rows} (columns x rows) is past the {MAX_DIMENSION}-per-axis \
              limit; a snapshot costs one entry per cell, so a grid this large \
              makes every wait slow enough to look like a hang"

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -78,7 +78,7 @@ fn a_zero_dimension_is_rejected_before_it_reaches_the_emulator() {
             .args(["-c", "read x"])
             .spawn("/bin/sh")
             .expect_err("a terminal cannot have a zero dimension");
-        assert!(matches!(err, Error::Input(_)), "{cols}x{rows}: got {err}");
+        assert!(matches!(err, Error::Size(_)), "{cols}x{rows}: got {err}");
         assert!(
             err.to_string().contains(&format!("{cols}x{rows}")),
             "the offending size belongs in the message: {err}"
@@ -99,7 +99,7 @@ fn resize_to_zero_is_refused_without_touching_the_pty_or_the_grid() -> termlens:
         let err = t
             .resize(cols, rows)
             .expect_err("a terminal cannot have a zero dimension");
-        assert!(matches!(err, Error::Input(_)), "{cols}x{rows}: got {err}");
+        assert!(matches!(err, Error::Size(_)), "{cols}x{rows}: got {err}");
     }
 
     // The grid is untouched and the terminal still works.
@@ -143,6 +143,7 @@ fn an_implausible_size_is_refused_with_the_limit_named() {
             .args(["-c", "true"])
             .spawn("/bin/sh")
             .expect_err("a terminal this large is refused");
+        assert!(matches!(err, Error::Size(_)), "{cols}x{rows}: got {err}");
         let msg = err.to_string();
         assert!(
             msg.contains("1000"),
@@ -168,6 +169,7 @@ fn the_limit_is_inclusive_and_resize_honours_it() -> termlens::Result<()> {
     assert_eq!(t.screen().size(), (1000, 1000));
 
     let err = t.resize(1001, 1000).expect_err("past the limit");
+    assert!(matches!(err, Error::Size(_)), "{err}");
     assert!(err.to_string().contains("1000"), "{err}");
     // Refused without disturbing the grid, like the zero case.
     assert_eq!(t.screen().size(), (1000, 1000));


### PR DESCRIPTION
## What & why

Fixes #175 by introducing a typed Error::Size variant for terminal dimensions rejected before spawn or resize. This keeps Error::Input focused on input or control that the child cannot receive.

## Checklist

- [x] Linked an issue: Closes #175
- [x] Tests added/updated for the change
- [x] cargo fmt --all -- --check is clean
- [x] cargo test -p termlens --test builder_validation passes (8 tests)
- [x] All commits are signed off (git commit -s)
- [x] No AI attribution trailers or bot identities
- [ ] CHANGELOG.md updated under [Unreleased] (not applicable: no CHANGELOG.md is present in this checkout)
- [x] No snapshot changes
