### PR TITLE
test: compile-check README example

### DIFF
--- a/crates/termlens/tests/readme_example.rs
+++ b/crates/termlens/tests/readme_example.rs
@@ -1,0 +1,25 @@
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+use common as util;
+
+/// Keep the README's first example compile-checked against a real fixture.
+/// The README uses `myapp`; this test uses the equivalent workspace fixture so
+/// Cargo can build and run it in CI.
+#[test]
+fn readme_example_compiles_and_runs() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(80, 24)
+        .env_clear()
+        .timeout(Duration::from_secs(5))
+        .spawn(util::fixture_bin("hello-tui"))?;
+
+    t.wait_until(|screen| screen.contains("status: ready"))?;
+    assert!(t.screen().contains("status: ready"));
+
+    t.send(Key::Char('q'))?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #187.

Add an integration test that mirrors the README's first `Terminal` example and runs it against the existing `hello-tui` fixture. The test compile-checks and exercises the documented builder chain (`size`, `env_clear`, `timeout`, `spawn`), `wait_until`, `screen`, `send`, and `wait_exit` without changing the README's `myapp` example.

The test does not attempt to validate the surrounding prose or snapshot macro; it covers the API calls owned by the crate and uses the fixture helper because sibling workspace binaries do not provide `CARGO_BIN_EXE_*` variables.

## Validation

- `cargo test -p termlens --test readme_example -- --nocapture`
- `cargo fmt --all -- --check`
