### PR TITLE
docs: clarify send_str newlines

### DIFF
--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -2003,7 +2003,11 @@ impl Terminal {
         self.send(key)
     }
 
-    /// Send a string literally (UTF-8 bytes, no key mapping, no newline).
+    /// Send a string literally as UTF-8 bytes, with no key mapping or appended
+    /// newline. Any `\n` already in `s` is sent as LF (`0x0A`), unlike
+    /// [`crate::Key::Enter`], which sends the CR (`\r`) a terminal produces for Enter.
+    /// Use [`paste`](Self::paste) when you want terminal-style line-break
+    /// handling.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

Fixes #185.

Clarify that `send_str` sends embedded `\n` bytes literally as LF (`0x0A`), while `Key::Enter` sends CR (`\r`). Point readers to `paste` when they want terminal-style line-break handling. The function remains byte-for-byte literal; this is documentation only.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p termlens --all-features -- -W clippy::missing_errors_doc` (the existing `GraphicsPayload::decode` warning is tracked by #181)
