### PR TITLE
docs: document graphics decode errors

### DIFF
--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -290,6 +290,16 @@ impl GraphicsPayload {
     ///
     /// Decoding is done here, on demand, and never as the bytes arrive: a
     /// test that only counts payloads should not pay for inflating them.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecodeError::NotCaptured`] when the payload exceeded the
+    /// capture bound, [`DecodeError::NoImage`] when the action carries no
+    /// image, and [`DecodeError::Unsupported`] when its format is not
+    /// supported. [`DecodeError::Malformed`] covers contradictory or invalid
+    /// payload data, including data that cannot be decoded within its declared
+    /// size. [`DecodeError::TooLarge`] covers declared dimensions or sixel
+    /// commands beyond the 4096-pixel and related safety limits.
     #[cfg(feature = "decode")]
     pub fn decode(&self) -> Result<Bitmap, DecodeError> {
         let data = self.data.as_deref().ok_or(DecodeError::NotCaptured)?;


### PR DESCRIPTION
## Summary

Fixes #181.

Add an `# Errors` section to `GraphicsPayload::decode` that names all five `DecodeError` variants and their conditions, including the 4096-pixel and related safety limits. The existing explanation of why decoding errors are preferable to `None` is retained.

Documentation only; decoding behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p termlens --no-deps --all-features`
- `cargo clippy -p termlens --all-features -- -D warnings`
