### PR TITLE
fix: normalize colon-form SGR colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ listed under a **Changed** or **Removed** heading.
 
 ### Fixed
 
+- **Colon-form SGR colours now reach cell styles.** `38:2::r:g:b`,
+  `38:2:r:g:b`, and indexed foreground and background colours are normalized
+  before the backend parses them, matching their semicolon-form equivalents.
+
 - **Mouse `click` / `click_with` / `drag` / `scroll` refuse coordinates
   outside the current grid.** A real terminal cannot produce an off-window
   mouse event; sending one was the same class of mistake as clicking with

--- a/crates/termlens/src/emu/shadow.rs
+++ b/crates/termlens/src/emu/shadow.rs
@@ -338,6 +338,16 @@ mod tests {
         String::from_utf8_lossy(&out).replace('\x1b', "E")
     }
 
+    /// The primary rewriter's output, as a readable string.
+    fn normalized(bytes: &[u8]) -> String {
+        let mut state = State::Ground;
+        let mut pending = Vec::new();
+        let mut out = rewrite_stream(&mut state, &mut pending, bytes, normalize_colon_colours);
+        // Anything still held at the end of the stream is not a complete SGR.
+        out.append(&mut pending);
+        String::from_utf8_lossy(&out).replace('\x1b', "E")
+    }
+
     #[test]
     fn the_three_dropped_attributes_get_carriers() {
         assert_eq!(shadowed(b"\x1b[5mX"), "E[1mX"); // blink -> bold
@@ -404,6 +414,28 @@ mod tests {
         ] {
             assert_eq!(
                 shadowed(seq),
+                String::from_utf8_lossy(seq).replace('\x1b', "E"),
+                "sequence {:?} must pass through untouched",
+                String::from_utf8_lossy(seq)
+            );
+        }
+    }
+
+    #[test]
+    fn colon_colour_normalization_preserves_unrecognized_bytes() {
+        assert_eq!(normalized(b"\x1b[38:2::10:20:30m"), "E[38;2;10;20;30m");
+        assert_eq!(normalized(b"\x1b[38:5:196m"), "E[38;5;196m");
+        assert_eq!(normalized(b"\x1b[1;38:2::4:5:6;3m"), "E[1;38;2;4;5;6;3m");
+
+        for seq in [
+            &b"\x1b[4:3m"[..],
+            &b"\x1b[38:2::9m"[..],
+            &b"\x1b[38:2:1:10:20:30m"[..],
+            &b"\x1b[?25l"[..],
+            &b"\x1b]8;;http://x/\x1b\\"[..],
+        ] {
+            assert_eq!(
+                normalized(seq),
                 String::from_utf8_lossy(seq).replace('\x1b', "E"),
                 "sequence {:?} must pass through untouched",
                 String::from_utf8_lossy(seq)

--- a/crates/termlens/src/emu/shadow.rs
+++ b/crates/termlens/src/emu/shadow.rs
@@ -57,6 +57,32 @@ enum State {
     Csi,
 }
 
+/// Rewrites colon-form extended colours into the semicolon form understood by
+/// `vt100`. Like [`AttrShadow`], it only holds a complete plain SGR and emits
+/// every other sequence unchanged.
+pub(super) struct ColorNormalizer {
+    state: State,
+    pending: Vec<u8>,
+}
+
+impl ColorNormalizer {
+    pub(super) fn new() -> Self {
+        Self {
+            state: State::Ground,
+            pending: Vec::new(),
+        }
+    }
+
+    pub(super) fn feed(&mut self, bytes: &[u8]) -> Vec<u8> {
+        rewrite_stream(
+            &mut self.state,
+            &mut self.pending,
+            bytes,
+            normalize_colon_colours,
+        )
+    }
+}
+
 /// A parallel `vt100::Parser` carrying blink, conceal and strikethrough.
 pub(super) struct AttrShadow {
     parser: ::vt100::Parser,
@@ -106,56 +132,111 @@ impl AttrShadow {
     /// over to the next call, so a sequence split across chunks is neither
     /// lost nor half-applied.
     fn rewrite_stream(&mut self, bytes: &[u8]) -> Vec<u8> {
-        let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-        for &b in bytes {
-            // An ESC anywhere abandons whatever was being collected and
-            // starts a new sequence, so the held bytes were not an SGR.
-            if b == 0x1b {
-                out.append(&mut self.pending);
-                self.pending.push(b);
-                self.state = State::Esc;
-                continue;
-            }
-            match self.state {
-                State::Ground => out.push(b),
-                State::Esc => {
-                    self.pending.push(b);
-                    if b == b'[' {
-                        self.state = State::Csi;
-                    } else {
-                        out.append(&mut self.pending);
-                        self.state = State::Ground;
-                    }
+        rewrite_stream(&mut self.state, &mut self.pending, bytes, rewrite_sgr)
+    }
+}
+
+fn rewrite_stream(
+    state: &mut State,
+    pending: &mut Vec<u8>,
+    bytes: &[u8],
+    rewrite: fn(&[u8]) -> Option<Vec<u8>>,
+) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    for &b in bytes {
+        // An ESC anywhere abandons whatever was being collected and starts a
+        // new sequence, so the held bytes were not an SGR.
+        if b == 0x1b {
+            out.append(pending);
+            pending.push(b);
+            *state = State::Esc;
+            continue;
+        }
+        match state {
+            State::Ground => out.push(b),
+            State::Esc => {
+                pending.push(b);
+                if b == b'[' {
+                    *state = State::Csi;
+                } else {
+                    out.append(pending);
+                    *state = State::Ground;
                 }
-                State::Csi => {
-                    self.pending.push(b);
-                    match b {
-                        // Parameter and intermediate bytes: keep collecting.
-                        0x20..=0x3f => {}
-                        // Final byte: an SGR is rewritten, anything else
-                        // passes through.
-                        0x40..=0x7e => {
-                            let seq = std::mem::take(&mut self.pending);
-                            self.state = State::Ground;
-                            match (b == b'm').then(|| rewrite_sgr(&seq)).flatten() {
-                                Some(rewritten) => out.extend_from_slice(&rewritten),
-                                None => out.extend_from_slice(&seq),
-                            }
+            }
+            State::Csi => {
+                pending.push(b);
+                match b {
+                    // Parameter and intermediate bytes: keep collecting.
+                    0x20..=0x3f => {}
+                    // Final byte: an SGR is rewritten, anything else passes
+                    // through.
+                    0x40..=0x7e => {
+                        let seq = std::mem::take(pending);
+                        *state = State::Ground;
+                        match (b == b'm').then(|| rewrite(&seq)).flatten() {
+                            Some(rewritten) => out.extend_from_slice(&rewritten),
+                            None => out.extend_from_slice(&seq),
                         }
-                        // A control byte inside a CSI (CAN, SUB, …). vte
-                        // decides what that means; passing the bytes through
-                        // unchanged means the shadow cannot diverge, at the
-                        // cost of not rewriting this one sequence.
-                        _ => {
-                            out.append(&mut self.pending);
-                            self.state = State::Ground;
-                        }
+                    }
+                    // A control byte inside a CSI (CAN, SUB, …). vte decides
+                    // what that means; preserve it rather than guessing.
+                    _ => {
+                        out.append(pending);
+                        *state = State::Ground;
                     }
                 }
             }
         }
-        out
     }
+    out
+}
+
+fn normalize_colon_colours(seq: &[u8]) -> Option<Vec<u8>> {
+    let params = seq.get(2..seq.len().checked_sub(1)?)?;
+    if params
+        .iter()
+        .any(|b| !matches!(b, b'0'..=b'9' | b';' | b':'))
+    {
+        return None;
+    }
+    if !params.contains(&b':') {
+        return None;
+    }
+
+    let groups: Vec<&[u8]> = params.split(|&b| b == b';').collect();
+    let mut normalized = Vec::with_capacity(groups.len());
+    let mut changed = false;
+    for group in groups {
+        let parts: Vec<&[u8]> = group.split(|&b| b == b':').collect();
+        let replacement = match parts.as_slice() {
+            [first @ (b"38" | b"48"), b"2", b"", red, green, blue]
+            | [first @ (b"38" | b"48"), b"2", red, green, blue] => {
+                Some(vec![*first, b"2", *red, *green, *blue])
+            }
+            [first @ (b"38" | b"48"), b"5", index] => Some(vec![*first, b"5", *index]),
+            _ => None,
+        };
+        if let Some(replacement) = replacement {
+            normalized.extend(replacement.into_iter().map(<[u8]>::to_vec));
+            changed = true;
+        } else {
+            normalized.push(group.to_vec());
+        }
+    }
+    if !changed {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(seq.len());
+    out.extend_from_slice(b"\x1b[");
+    for (index, group) in normalized.iter().enumerate() {
+        if index > 0 {
+            out.push(b';');
+        }
+        out.extend_from_slice(group);
+    }
+    out.push(b'm');
+    Some(out)
 }
 
 /// Rewrite one complete `ESC [ … m` into the carrier form.

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use super::seq::{SeqEvent, SeqTracker};
-use super::shadow::AttrShadow;
+use super::shadow::{AttrShadow, ColorNormalizer};
 use super::{Emulator, FrameSpan, InputModes, ModeState, MouseEncoding, Processed, Stop};
 use crate::graphics::{GraphicsPayload, GraphicsSeen, HISTORY};
 use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
@@ -18,6 +18,7 @@ pub(crate) struct Vt100Emulator {
     /// `emu/shadow.rs` for why this is a second parser rather than
     /// hand-rolled attribute tracking.
     shadow: AttrShadow,
+    colors: ColorNormalizer,
     /// How many rows of history to retain (0 disables it entirely).
     scrollback_len: usize,
     /// When the current synchronized update began, stamped at the byte that
@@ -63,6 +64,7 @@ impl Vt100Emulator {
             parser: ::vt100::Parser::new(rows, cols, scrollback_len),
             tracker: SeqTracker::new(capture),
             shadow: AttrShadow::new(rows, cols),
+            colors: ColorNormalizer::new(),
             scrollback_len,
             frame_started: None,
             history: VecDeque::new(),
@@ -83,7 +85,8 @@ impl Vt100Emulator {
         if bytes.is_empty() {
             return;
         }
-        self.parser.process(bytes);
+        let normalized = self.colors.feed(bytes);
+        self.parser.process(&normalized);
         self.shadow.feed(bytes);
         self.capture_scrolled_rows();
     }
@@ -509,6 +512,30 @@ mod tests {
         let y = *s.cell(0, 1).unwrap().style();
         assert_eq!(y.fg, Color::Rgb(0, 8, 9));
         assert!(!y.conceal && !y.strikethrough);
+    }
+
+    #[test]
+    fn colon_form_rgb_colours_match_semicolon_form() {
+        let emu = emu_with(b"\x1b[38;2;10;20;30mA\x1b[0m\x1b[38:2::10:20:30mB");
+        let s = emu.snapshot();
+        assert_eq!(s.cell(0, 0).unwrap().style().fg, Color::Rgb(10, 20, 30));
+        assert_eq!(s.cell(0, 1).unwrap().style().fg, Color::Rgb(10, 20, 30));
+    }
+
+    #[test]
+    fn colon_form_colours_support_optional_colour_space_and_chunking() {
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        emu.feed(b"\x1b[38:2:10:");
+        emu.feed(b"20:30mA\x1b[48:5:196mB");
+        let s = emu.snapshot();
+
+        let foreground = s.cell(0, 0).unwrap().style();
+        assert_eq!(foreground.fg, Color::Rgb(10, 20, 30));
+        assert_eq!(foreground.bg, Color::Default);
+
+        let background = s.cell(0, 1).unwrap().style();
+        assert_eq!(background.fg, Color::Rgb(10, 20, 30));
+        assert_eq!(background.bg, Color::Indexed(196));
     }
 
     #[test]

--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -149,8 +149,8 @@ fn strikethrough_and_blink_appear_in_the_styled_rendering() -> termlens::Result<
 #[test]
 fn colon_form_rgb_colours_match_semicolon_form() -> termlens::Result<()> {
     let mut t = sh(concat!(
-        r"printf '\033[38;2;10;20;30mA\033[0m' ",
-        r"'\033[38:2::10:20:30mB\033[0m'; read guard"
+        r"printf '\033[38;2;10;20;30mA\033[0m\033[38:2::10:20:30mB\033[0m'; ",
+        "read guard"
     ))?;
     t.wait_until(|s| s.contains("AB"))?;
     let s = t.screen();

--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -147,6 +147,31 @@ fn strikethrough_and_blink_appear_in_the_styled_rendering() -> termlens::Result<
 }
 
 #[test]
+fn colon_form_rgb_colours_match_semicolon_form() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf '\033[38;2;10;20;30mA\033[0m' ",
+        r"'\033[38:2::10:20:30mB\033[0m'; read guard"
+    ))?;
+    t.wait_until(|s| s.contains("AB"))?;
+    let s = t.screen();
+
+    let semicolon = s.find("A").expect("semicolon-form colour");
+    let colon = s.find("B").expect("colon-form colour");
+    assert_eq!(
+        s.cell(semicolon.0, semicolon.1).unwrap().style().fg,
+        termlens::Color::Rgb(10, 20, 30)
+    );
+    assert_eq!(
+        s.cell(colon.0, colon.1).unwrap().style().fg,
+        termlens::Color::Rgb(10, 20, 30)
+    );
+
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
 fn dim_and_italic_appear_without_shadow_collisions() -> termlens::Result<()> {
     let mut t = sh(concat!(
         r"printf '\033[2mfaint\033[0m ",


### PR DESCRIPTION
## Summary

- normalize supported colon-form SGR colours before primary-grid parsing
- retain non-empty colour-space forms and unrecognised control sequences unchanged
- add direct byte-level coverage for both conversion and preservation behaviour

Closes #180.

## Testing

- cargo test -p termlens --lib
- .github/scripts/check-dco.sh main..HEAD
- .github/scripts/check-no-ai-attribution.sh main..HEAD

The full package test target includes Unix-only process integration tests and does not compile on Windows; the portable library suite passed.