### PR TITLE
ci: cover decode-only configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --no-default-features --features decode -- -D warnings
 
   # CI runners have no TTY; termlens creates its own PTYs. This suite passing
   # headless is the proof of the crate's core value claim.
@@ -73,6 +75,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --no-default-features
+      - run: cargo test --workspace --no-default-features --features decode
 
   msrv:
     name: msrv


### PR DESCRIPTION
Fixes #161. Extends the existing no-default-features job to test the decode-only build, and extends the existing clippy job to lint both no-default configurations. Keeping the checks in their current jobs preserves the required-green wiring and avoids extra runners. Verification: cargo test -p termlens --lib --no-default-features --features decode; cargo clippy -p termlens --lib --no-default-features -- -D warnings; cargo clippy -p termlens --lib --no-default-features --features decode -- -D warnings; git diff --check; DCO and attribution checks. I did not run the full all-targets command locally because this Windows host cannot compile the repository's Unix-only integration test target; the PR CI runs it on Linux.