### PR TITLE
feat: DEC line drawing, modified wheel, Screen equality, history notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,91 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Added
+
+- **DEC Special Graphics is translated, so an ncurses border reads as
+  `┌───┐` rather than `lqqqk`.** `ESC ( 0` selects the line-drawing set —
+  it is what `smacs`/`rmacs` are on an xterm terminfo, so it is how every
+  ncurses application and plenty that are not draw their frames — and the
+  bytes used to reach the grid untranslated. That put the crate's own
+  promise in the wrong: a user sees a box, and a test asserting a border was
+  right failed against an application that was correct, while a snapshot
+  that had blessed `lqqqk` went on passing after the border broke. The
+  `vt100` backend drops the designation entirely, so termlens tracks the
+  G0/G1 designations (`ESC ( Ps` / `ESC ) Ps`) and the `SO`/`SI` locking
+  shifts itself and hands both parsers the glyph a byte draws. Scope is
+  stated rather than implied: only the DEC Special Graphics set is
+  translated, other designations read as ASCII, G2/G3 and the single shifts
+  are not modelled, and a hard reset (`RIS`) returns both sets to ASCII.
+
+- **`Terminal::scroll_with`, with `Scroll::ctrl()` / `alt()` / `shift()`
+  and a `ScrollChord` type.** `Ctrl`-wheel is zoom and `Shift`-wheel is
+  horizontal scrolling in a large share of terminal applications, and
+  neither could be sent: `scroll` took a bare direction, so the binding most
+  likely to be wired to the wrong handler was the one with no coverage. The
+  modifier bits ride on the wheel's button code exactly as they do on a
+  click, and `scroll` is now the unmodified case of `scroll_with`, as
+  `click` is of `click_with`. The wheel gets a chord type of its own rather
+  than a wider `MouseChord`, so a wheel direction cannot be handed to
+  `click_with`: a notch has no release, and the type keeps that from being a
+  runtime surprise.
+
+- **`Screen` implements `PartialEq` and `Eq`.** It was the only public
+  value type without them, so "did anything change?" was written by
+  comparing `to_string()` renderings — which is text only, and so passes
+  two screens that differ in a highlight, a colour or a concealed field.
+  Equality means *the same observation*: cells, cursor, size, and every
+  piece of out-of-band state including the cumulative `repaints` and
+  `bells` counters, so two visually identical snapshots either side of a
+  bell compare unequal because they are different moments. The doc says
+  which comparison to reach for when "looks the same" is what is meant.
+
+- **A content wait that fails while rows have scrolled off says so.** The
+  most-copied line in these docs, `wait_until(|s| s.contains(..))`, reads
+  the visible grid, so text the application printed and then scrolled away
+  in the same burst can never satisfy it — and the screen embedded in the
+  timeout does not show the text either, so the failure read as "the app
+  never printed it". `Error::Timeout` and `Error::Eof` from `wait_until`
+  and `wait_frame` now say how many rows have scrolled off the top and
+  point at `Screen::full_text`. The note is conditional, because the wait
+  cannot know what an arbitrary closure was looking for; it is silent when
+  nothing has scrolled. `contains` and `find` document where they stop.
+
+### Changed
+
+- **`resize` is refused once the child has released the terminal**, with
+  the same `Error::Write` that `send` returns, naming the child and its exit
+  status. It used to succeed, and the snapshot then reported a geometry no
+  application ever rendered at with the dead child's last frame clipped
+  underneath it — the one operation on a departed child that silently
+  mutated observable state. The final screen stays readable at the size the
+  child exited with. A size that cannot work is still `Error::Size`, checked
+  first.
+
 ### Fixed
+
+- **`Bitmap::colours` is linear in the pixel count, and its order is
+  defined.** It counted distinct colours with a scan of the distinct set per
+  pixel — O(pixels × colours), 9 ms for 96x96 and extrapolating to seconds
+  for a screenshot, in a test suite, where a wait that takes seven seconds
+  looks like a hang. It now counts in one pass. Ties, which the old
+  implementation happened to order by first appearance through a stable
+  sort, are now ordered that way on purpose and the doc says so: a test
+  asserting on `colours()[0]` has one answer.
+
+- **`resize` documents what happens to history.** Rows already in scrollback
+  keep the width they were captured at and rows captured afterwards have the
+  new width, so `full_text()` after a narrowing resize can hold both
+  geometries. That was true before and said nowhere a caller would meet it;
+  it is now a recorded decision on `resize` and `scrollback_text`, with the
+  alternative — discarding history on resize — rejected in writing rather
+  than by omission.
+
+- **Doc comments on `TerminalBuilder::size`, `spawn` and `resize` name
+  `Error::Size`** for a rejected size, not `Error::Input`. The links
+  resolved, to the wrong variant, so following them gave a `match` arm that
+  never fires — and `Error` is `#[non_exhaustive]`, so a wildcard elsewhere
+  would have swallowed the mistake silently.
 
 - **Colon-form SGR colours now reach cell styles.** `38:2::r:g:b`,
   `38:2:r:g:b`, and indexed foreground and background colours are normalized
@@ -23,6 +107,16 @@ listed under a **Changed** or **Removed** heading.
   checks both endpoints only — the interpolated path cannot leave the
   rectangle they span. Separately, the SGR encoder no longer wraps or
   panics at `u16::MAX`: the 1-based `+ 1` is done in `u32`.
+
+### Security
+
+- **`SECURITY.md` no longer claims the crate has no `unsafe`.** It has two
+  blocks, both FFI and both present since the features they serve landed:
+  `dup(2)`, which opens the responder thread's writer on the PTY master, and
+  `kill(2)` behind `Terminal::signal`. Neither touches memory the child can
+  influence and the parsing path has none, which is the claim that matters;
+  the policy now says exactly that rather than something stronger and
+  false.
 
 ## [0.7.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,17 @@ listed under a **Changed** or **Removed** heading.
   sort, are now ordered that way on purpose and the doc says so: a test
   asserting on `colours()[0]` has one answer.
 
+- **`wait_frame` after `resize` could miss the repaint that answered it.**
+  `resize` sent the `SIGWINCH` first and took the frame cursor afterwards, so
+  a fast application's acknowledging repaint could complete in that gap, be
+  counted as a frame from *before* the resize, and never be offered — the
+  wait then timed out reporting that the application had not repainted,
+  while the live screen showed that it had. Found by the stress workflow at
+  16 threads, once in 25 runs. The grid is now resized and the cursor taken
+  before the signal goes out, under one lock, so a frame drawn in answer to
+  the resize is always newer than the cursor and always lands in a grid of
+  the new size.
+
 - **`resize` documents the resize-then-type trap.** A keystroke that reaches
   a crossterm application in the same instant as the `SIGWINCH` can be lost:
   its event reader returns the `Resize` as soon as the poll reports the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,16 @@ listed under a **Changed** or **Removed** heading.
   sort, are now ordered that way on purpose and the doc says so: a test
   asserting on `colours()[0]` has one answer.
 
+- **`resize` documents the resize-then-type trap.** A keystroke that reaches
+  a crossterm application in the same instant as the `SIGWINCH` can be lost:
+  its event reader returns the `Resize` as soon as the poll reports the
+  signal and abandons the input readiness delivered alongside, and the poll
+  is edge-triggered, so the byte is not offered again until more input
+  arrives. The stress workflow caught termlens's own suite doing exactly that
+  — a resize followed at once by `Esc` hung the fixture about one run in
+  forty. The test now waits for the application to acknowledge the resize,
+  which is the advice the doc gives.
+
 - **`resize` documents what happens to history.** Rows already in scrollback
   keep the width they were captured at and rows captured afterwards have the
   new width, so `full_text()` after a narrowing resize can hold both

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,31 @@ change from your editor into `main`.
 ```sh
 git clone https://github.com/vyncint/termlens
 cd termlens
-cargo test --workspace        # full suite: unit + integration + doctests
+cargo test --workspace --all-features   # the whole suite: unit + integration + doctests, `decode` included
 ```
+
+`--all-features` matters: `decode` is off by default, and without it sixteen
+tests never build. That is the `test` job. CI gates on more than the test
+job, and every gate is reproducible locally — run these before pushing and
+nothing in CI should surprise you:
+
+```sh
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+cargo clippy --workspace --all-targets --no-default-features --features decode -- -D warnings
+cargo test --workspace --no-default-features
+cargo test --workspace --no-default-features --features decode
+RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features
+cargo deny check                          # cargo install cargo-deny
+cargo +1.85 check --workspace --locked    # the MSRV: `rust-version` in Cargo.toml
+```
+
+The list is written out here rather than left as a pointer because a first
+PR that fails on `cargo fmt` after following the setup to the letter is an
+avoidable bad first experience. If it ever disagrees with
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml), the workflow is the
+source of truth and this list is the bug.
 
 The integration tests spawn real PTYs and small fixture apps from
 `fixtures/`; there is nothing to install beyond a Rust toolchain

--- a/README.md
+++ b/README.md
@@ -96,8 +96,12 @@ colour, `DECRQM` mode probes, and terminfo capabilities via `XTGETTCAP` —
 so capability-probing apps run instead of hanging, and anything left
 unanswered is named inside the next timeout error. Every answer is
 truthful or absent: nothing is claimed that the emulator cannot render.
+The grid holds what a user would *see*: DEC Special Graphics — the
+`ESC ( 0` line-drawing set every ncurses border is made of — is translated,
+so a frame reads as `┌───┐` rather than `lqqqk`.
 
-Input is **mode-aware**: mouse clicks and scrolls, pastes, modifier
+Input is **mode-aware**: mouse clicks and scrolls (with modifiers —
+`Ctrl`-wheel zoom is `scroll_with(Scroll::Up.ctrl(), ..)`), pastes, modifier
 chords, and cursor keys are encoded exactly as the application
 configured its terminal (SGR mouse, bracketed paste, DECCKM) — because
 the emulator knows which modes the app enabled. A `drag` reports one
@@ -148,7 +152,9 @@ assert_eq!(image.decode()?.pixel(9, 9), Some([0x39, 0xd3, 0x53, 0xff]));
 hands finished output *back* to the terminal — a pager, a log view, a TUI
 that commits completed blocks into native scrollback and keeps a small
 live region — stays testable. `full_text()` spans history and screen, so
-an assertion need not know which region a block currently sits in.
+an assertion need not know which region a block currently sits in — and
+`contains`/`find` read the visible grid alone, so when a wait fails while
+rows have scrolled off, the error says how many and points at `full_text`.
 
 Screens are immutable snapshots taken under the same
 lock the reader writes through, so every assertion sees a consistent
@@ -211,12 +217,19 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.7)
+## Known limitations (v0.8)
 
 - Scrollback is **bounded** (1000 rows by default), **text only** — a
   scrolled-off row has no styles and no cell addressing — and is **not
-  reflowed** by a `resize`. The visible grid stays the fully-featured
-  surface.
+  reflowed** by a `resize`: rows keep the width they were captured at, by
+  decision (`Terminal::resize` says why). The visible grid stays the
+  fully-featured surface.
+- **Character sets: G0 and G1 only, and one set translated.** `ESC ( Ps` /
+  `ESC ) Ps` designations and the `SO`/`SI` locking shifts are modelled, and
+  the DEC Special Graphics set (`0`) is translated; every other designation —
+  the UK set, the alternate ROMs — reads as ASCII, and G2/G3 with their
+  single shifts are not modelled. `DECSC`/`DECRC` do not save or restore the
+  charset state.
 - `wait_frame` needs the application to bracket its repaints in DEC 2026
   synchronized updates, and only the last 8 completed frames are retained;
   everything else waits with `wait_until`, under the three rules in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,13 @@ issues in escape-sequence handling) are treated as security issues.
 
 What the project does continuously, enforced by required CI on every change:
 
-- **No `unsafe` code** in the crate (`unsafe_code` lint, clippy
-  `-D warnings`). Escape sequences from the child are parsed by pure-Rust
-  code; nothing from the terminal stream is ever executed or evaluated.
+- **`unsafe` is confined to two audited FFI calls** — `dup(2)`, to open a
+  second writer on the PTY master for the responder thread, and `kill(2)`
+  behind `Terminal::signal` — each a single line with a `SAFETY` comment and
+  a local `#[allow]`; the `unsafe_code` lint is on, so any third block fails
+  clippy `-D warnings`. Neither touches memory the child can influence.
+  Everything on the parsing path is pure Rust: escape sequences from the
+  child are parsed, never executed or evaluated.
 - **Dependency policy** (`cargo-deny` job): RUSTSEC advisories, yanked
   crates, license allowlist, and crates.io-only sources — on every PR, with
   weekly grouped Dependabot updates and Dependabot alerts enabled.

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -17,6 +17,17 @@
 //! expose: the **window title** (`OSC 0`/`OSC 2`), kept whole in its own
 //! buffer — the diagnostic capture below truncates at 24 bytes, real titles
 //! don't fit.
+//!
+//! And it holds the **character-set state** vt100 ignores: which glyph set
+//! `ESC ( Ps` / `ESC ) Ps` designated into G0 and G1, and which of the two
+//! `SI`/`SO` has invoked. That is what lets the emulator hand the grid the
+//! glyph a byte *draws* — `ESC ( 0 l q q q k` is `┌───┐`, not five letters —
+//! which is how ncurses draws every border (`smacs`/`rmacs` on an xterm
+//! terminfo are exactly `ESC ( 0` / `ESC ( B`). Only the DEC Special
+//! Graphics set is translated; every other designation reads as ASCII, and
+//! G2/G3 with their single shifts are not modelled. The tracker decides, the
+//! emulator rewrites: the bytes the parsers see are then a translated stream
+//! rather than a sub-slice of the read, which `emu/vt100.rs` stages.
 
 use std::sync::Arc;
 
@@ -97,6 +108,58 @@ pub(crate) fn decode_base64(input: &[u8]) -> Option<Vec<u8>> {
         }
     }
     Some(out)
+}
+
+/// Which glyph set a G0/G1 designation currently names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Charset {
+    /// ASCII — and every national replacement set, which differ from it in
+    /// a handful of positions this crate does not model.
+    Ascii,
+    /// DEC Special Graphics (`ESC ( 0`): the line-drawing set.
+    DecSpecialGraphics,
+}
+
+/// The glyph a byte draws in DEC Special Graphics, where it differs from
+/// ASCII: the 32 bytes `0x5f..=0x7e`. Everything below `_` draws as itself.
+/// The mapping is xterm's, which is also what every terminfo `acsc` string
+/// is written against.
+fn dec_special_graphics(b: u8) -> Option<&'static str> {
+    Some(match b {
+        b'_' => " ",        // blank
+        b'`' => "\u{25c6}", // ◆ diamond
+        b'a' => "\u{2592}", // ▒ checkerboard
+        b'b' => "\u{2409}", // ␉ HT
+        b'c' => "\u{240c}", // ␌ FF
+        b'd' => "\u{240d}", // ␍ CR
+        b'e' => "\u{240a}", // ␊ LF
+        b'f' => "\u{b0}",   // ° degree
+        b'g' => "\u{b1}",   // ± plus-minus
+        b'h' => "\u{2424}", // ␤ NL
+        b'i' => "\u{240b}", // ␋ VT
+        b'j' => "\u{2518}", // ┘
+        b'k' => "\u{2510}", // ┐
+        b'l' => "\u{250c}", // ┌
+        b'm' => "\u{2514}", // └
+        b'n' => "\u{253c}", // ┼
+        b'o' => "\u{23ba}", // ⎺ scan line 1
+        b'p' => "\u{23bb}", // ⎻ scan line 3
+        b'q' => "\u{2500}", // ─ scan line 5
+        b'r' => "\u{23bc}", // ⎼ scan line 7
+        b's' => "\u{23bd}", // ⎽ scan line 9
+        b't' => "\u{251c}", // ├
+        b'u' => "\u{2524}", // ┤
+        b'v' => "\u{2534}", // ┴
+        b'w' => "\u{252c}", // ┬
+        b'x' => "\u{2502}", // │
+        b'y' => "\u{2264}", // ≤
+        b'z' => "\u{2265}", // ≥
+        b'{' => "\u{3c0}",  // π
+        b'|' => "\u{2260}", // ≠
+        b'}' => "\u{a3}",   // £
+        b'~' => "\u{b7}",   // · bullet
+        _ => return None,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,6 +373,16 @@ pub(crate) struct SeqTracker {
     /// the accessor on `Screen`, and "never asked" stays distinguishable
     /// from every value it could have asked for.
     cursor_style: Option<u8>,
+    /// The intermediate byte of the current `ESC <intermediate> <final>`
+    /// sequence — `(` or `)` for a G0/G1 designation — so the final byte
+    /// knows which set it designates. Zero once a second intermediate makes
+    /// it something else.
+    esc_intermediate: u8,
+    /// What `ESC ( Ps` and `ESC ) Ps` last designated into G0 and G1.
+    g0: Charset,
+    g1: Charset,
+    /// True after `SO` (`0x0e`) invoked G1; `SI` (`0x0f`) returns to G0.
+    shifted_out: bool,
     /// Which introducer opened the current DCS-class string: `P` (DCS),
     /// `X` (SOS), `^` (PM) or `_` (APC). Sixel and kitty graphics differ
     /// only by this, so consuming all four alike — which is all the tracker
@@ -373,6 +446,10 @@ impl SeqTracker {
             frame_printable: 0,
             focus_events: false,
             cursor_style: None,
+            esc_intermediate: 0,
+            g0: Charset::Ascii,
+            g1: Charset::Ascii,
+            shifted_out: false,
             dcs_introducer: 0,
             dcs_final: 0,
             dcs_intermediate: 0,
@@ -487,6 +564,43 @@ impl SeqTracker {
     /// for the next one.
     pub(crate) fn take_frame_printable(&mut self) -> u32 {
         std::mem::replace(&mut self.frame_printable, 0)
+    }
+
+    /// The glyph `b` draws in the invoked character set, when that set is
+    /// DEC Special Graphics and `b` is one of the bytes it redefines — or
+    /// `None` when the byte draws as itself, or is not a character at all.
+    ///
+    /// Consulted **before** the byte is stepped: whether a byte is a
+    /// character depends on the state the tracker is in before it, and the
+    /// designation's own final byte must not be translated.
+    pub(crate) fn graphics_glyph(&self, b: u8) -> Option<&'static str> {
+        if self.state != State::Ground {
+            return None;
+        }
+        let invoked = if self.shifted_out { self.g1 } else { self.g0 };
+        if invoked != Charset::DecSpecialGraphics {
+            return None;
+        }
+        dec_special_graphics(b)
+    }
+
+    /// Apply the final byte of an `ESC ( Ps` / `ESC ) Ps` designation.
+    ///
+    /// `0` is DEC Special Graphics. Everything else — `B` (ASCII), `A` (UK,
+    /// which differs from ASCII only at `#`), the alternate-ROM sets —
+    /// reads as ASCII: close enough for every one of them that guessing at
+    /// the odd position would be a worse answer than the plain one.
+    fn designate(&mut self, final_byte: u8) {
+        let set = if final_byte == b'0' {
+            Charset::DecSpecialGraphics
+        } else {
+            Charset::Ascii
+        };
+        match self.esc_intermediate {
+            b'(' => self.g0 = set,
+            b')' => self.g1 = set,
+            _ => {}
+        }
     }
 
     fn reset_dcs_scanner(&mut self, introducer: u8) {
@@ -965,6 +1079,8 @@ impl SeqTracker {
         const CAN: u8 = 0x18;
         const SUB: u8 = 0x1a;
         const BEL: u8 = 0x07;
+        const SO: u8 = 0x0e;
+        const SI: u8 = 0x0f;
 
         let mut event = SeqEvent::None;
         self.state = match self.state {
@@ -978,6 +1094,14 @@ impl SeqTracker {
                     // and both of those are other states.
                     if b == BEL && self.utf8_remaining == 0 {
                         self.bells = self.bells.saturating_add(1);
+                    }
+                    // Locking shifts: SO invokes G1, SI returns to G0. vt100
+                    // sees both bytes too and ignores them, so nothing else
+                    // has to be told.
+                    match b {
+                        SO => self.shifted_out = true,
+                        SI => self.shifted_out = false,
+                        _ => {}
                     }
                     // Anything that is not a C0 control or DEL. Named once
                     // because the two readers below want the same test for
@@ -995,11 +1119,20 @@ impl SeqTracker {
                     // label. Bytes rather than characters here, so a
                     // multi-byte grapheme survives the split — its
                     // continuation bytes are all >= 0x80 and printable too.
+                    // A byte the invoked character set redefines is recorded
+                    // as the glyph it draws: the label is what a reader sees
+                    // and clicks, and a reader sees `─`, not `q`.
                     if printable && self.link_open {
-                        if self.link_label.len() < LINK_LABEL_MAX {
-                            self.link_label.push(b);
-                        } else {
-                            self.link_label_truncated = true;
+                        let drawn: &[u8] = match self.graphics_glyph(b) {
+                            Some(glyph) => glyph.as_bytes(),
+                            None => std::slice::from_ref(&b),
+                        };
+                        for &drawn in drawn {
+                            if self.link_label.len() < LINK_LABEL_MAX {
+                                self.link_label.push(drawn);
+                            } else {
+                                self.link_label_truncated = true;
+                            }
                         }
                     }
                     self.track_utf8(b);
@@ -1021,12 +1154,16 @@ impl SeqTracker {
                     self.reset_dcs_scanner(b);
                     State::Dcs
                 }
-                0x20..=0x2f => State::EscIntermediate,
+                0x20..=0x2f => {
+                    self.esc_intermediate = b;
+                    State::EscIntermediate
+                }
                 ESC => State::Esc,
                 CAN | SUB => State::Ground,
                 // RIS (`ESC c`), the hard reset: the terminal returns to its
                 // power-on state, so the cursor is the terminal's default
-                // again and any open hyperlink span cannot survive.
+                // again, both character sets are ASCII with G0 invoked, and
+                // any open hyperlink span cannot survive.
                 //
                 // Reporting the last `DECSCUSR` after a reset would claim a
                 // fact the terminal does not hold — and it would do it in the
@@ -1043,6 +1180,9 @@ impl SeqTracker {
                 // the terminal still holds.
                 b'c' => {
                     self.cursor_style = None;
+                    self.g0 = Charset::Ascii;
+                    self.g1 = Charset::Ascii;
+                    self.shifted_out = false;
                     self.close_link();
                     State::Ground
                 }
@@ -1050,9 +1190,20 @@ impl SeqTracker {
                 _ => State::Ground,
             },
             State::EscIntermediate => match b {
-                0x20..=0x2f => State::EscIntermediate,
+                // A second intermediate makes this something other than a
+                // G0/G1 designation (`ESC % G` selects UTF-8, for one).
+                0x20..=0x2f => {
+                    self.esc_intermediate = 0;
+                    State::EscIntermediate
+                }
                 ESC => State::Esc,
                 CAN | SUB => State::Ground,
+                // The final byte: a designation, if the intermediate was `(`
+                // or `)`, and the end of the sequence either way.
+                0x30..=0x7e => {
+                    self.designate(b);
+                    State::Ground
+                }
                 _ => State::Ground,
             },
             State::Csi => match b {
@@ -1480,6 +1631,14 @@ mod tests {
         assert_eq!(seen[0].2.as_deref(), Some("ab"));
     }
 
+    /// The label is what a reader sees: a link wrapped around line drawing
+    /// records the glyphs, not the bytes that stood for them.
+    #[test]
+    fn a_label_drawn_in_the_graphics_set_records_the_glyphs() {
+        let seen = links(b"\x1b(0\x1b]8;;http://x/\x1b\\lqk\x1b]8;;\x1b\\\x1b(B");
+        assert_eq!(seen[0].2.as_deref(), Some("\u{250c}\u{2500}\u{2510}"));
+    }
+
     #[test]
     fn control_characters_are_not_part_of_a_label() {
         // A newline moves the cursor; it does not spell anything.
@@ -1714,6 +1873,106 @@ mod tests {
         assert!(links.iter().all(|l| l.closed() && l.label().is_some()));
         assert_eq!(links[LINK_HISTORY - 1].uri(), "http://example.invalid/4999");
         assert_eq!(links[LINK_HISTORY - 1].label(), Some("label4999"));
+    }
+
+    /// The glyphs a fed tracker would hand the grid for `text`, byte by
+    /// byte: the translation where one applies, the byte itself otherwise.
+    fn drawn(bytes: &[u8]) -> String {
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
+        let mut out = String::new();
+        for &b in bytes {
+            match t.graphics_glyph(b) {
+                Some(glyph) => out.push_str(glyph),
+                None if t.state == State::Ground && (0x20..0x7f).contains(&b) => {
+                    out.push(b as char);
+                }
+                None => {}
+            }
+            t.step(b);
+        }
+        out
+    }
+
+    /// The reproduction from the issue, and the shape ncurses emits on an
+    /// xterm terminfo: designate into G0, draw, designate ASCII back.
+    #[test]
+    fn dec_special_graphics_in_g0_translates_the_bytes_it_redefines() {
+        assert_eq!(drawn(b"lqqqk"), "lqqqk", "ASCII until designated");
+        assert_eq!(
+            drawn(b"\x1b(0lqqqk\x1b(B"),
+            "\u{250c}\u{2500}\u{2500}\u{2500}\u{2510}"
+        );
+        // Back to ASCII after the redesignation, and the letters are letters.
+        assert_eq!(drawn(b"\x1b(0lq\x1b(Blq"), "\u{250c}\u{2500}lq");
+        // Bytes below `_` are the same in both sets.
+        assert_eq!(drawn(b"\x1b(0A1 +\x1b(B"), "A1 +");
+        // The designation's own final byte is never a glyph.
+        assert_eq!(drawn(b"\x1b(0\x1b(0"), "");
+    }
+
+    /// The vt100-terminfo shape: designate into G1 once, then SO/SI.
+    #[test]
+    fn shift_out_invokes_g1_and_shift_in_returns_to_g0() {
+        assert_eq!(drawn(b"\x1b)0lqk"), "lqk", "G1 designated but not invoked");
+        assert_eq!(
+            drawn(b"\x1b)0\x0elqk\x0flqk"),
+            "\u{250c}\u{2500}\u{2510}lqk"
+        );
+        // SO with an ASCII G1 changes nothing.
+        assert_eq!(drawn(b"\x0elqk"), "lqk");
+        // And G0 can be the graphics set while G1 is ASCII: SO turns it off.
+        assert_eq!(drawn(b"\x1b(0q\x0eq\x0fq"), "\u{2500}q\u{2500}");
+    }
+
+    #[test]
+    fn a_hard_reset_returns_both_sets_to_ascii() {
+        assert_eq!(drawn(b"\x1b(0\x1b)0\x0eq\x1bcq\x0fq"), "\u{2500}qq");
+    }
+
+    /// Only a byte in ground state is a character: the same bytes inside an
+    /// OSC title, a CSI parameter or a DCS payload must pass untouched.
+    #[test]
+    fn bytes_inside_sequences_are_never_translated() {
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
+        for &b in b"\x1b(0" {
+            t.step(b);
+        }
+        assert_eq!(t.graphics_glyph(b'q'), Some("\u{2500}"));
+        for &b in b"\x1b]0;lqqk" {
+            assert_eq!(t.graphics_glyph(b), None, "inside an OSC: {b:?}");
+            t.step(b);
+        }
+        t.step(0x07);
+        assert_eq!(&*t.title(), "lqqk", "the title keeps its letters");
+        for &b in b"\x1b[3" {
+            assert_eq!(t.graphics_glyph(b), None, "inside a CSI: {b:?}");
+            t.step(b);
+        }
+        t.step(b'm');
+        assert_eq!(t.graphics_glyph(b'x'), Some("\u{2502}"), "and ground again");
+    }
+
+    /// Other national sets and the alternate ROMs read as ASCII, and a second
+    /// intermediate is not a designation at all.
+    #[test]
+    fn other_designations_read_as_ascii() {
+        for seq in [&b"\x1b(A"[..], b"\x1b(B", b"\x1b(1", b"\x1b(2", b"\x1b(<"] {
+            let mut bytes = seq.to_vec();
+            bytes.push(b'q');
+            assert_eq!(drawn(&bytes), "q", "{seq:?}");
+        }
+        // `ESC ( 0` then `ESC % G` (select UTF-8): the second sequence has
+        // two intermediates and designates nothing, so G0 stays graphics.
+        assert_eq!(drawn(b"\x1b(0\x1b%Gq"), "\u{2500}");
+    }
+
+    #[test]
+    fn a_designation_split_across_feeds_still_applies() {
+        let mut t = SeqTracker::new(crate::graphics::DEFAULT_CAPTURE);
+        t.feed(b"\x1b(");
+        assert!(t.mid_sequence());
+        t.feed(b"0");
+        assert_eq!(t.graphics_glyph(b'l'), Some("\u{250c}"));
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -42,6 +42,12 @@ pub(crate) struct Vt100Emulator {
     graphics_bytes: usize,
     /// The retention budget, from `TerminalBuilder::capture_graphics`.
     capture: usize,
+    /// Bytes rewritten on their way to the parsers and not yet handed over.
+    /// Empty except while a DEC Special Graphics set is invoked: a byte the
+    /// set redefines reaches the grid as the glyph it draws, so the stream
+    /// the parsers see is then no longer a sub-slice of the read. Kept
+    /// between calls only for its allocation.
+    staged: Vec<u8>,
 }
 
 impl Vt100Emulator {
@@ -72,6 +78,7 @@ impl Vt100Emulator {
             graphics: Arc::new(Vec::new()),
             graphics_bytes: 0,
             capture,
+            staged: Vec::new(),
         }
     }
 
@@ -89,6 +96,23 @@ impl Vt100Emulator {
         self.parser.process(&normalized);
         self.shadow.feed(bytes);
         self.capture_scrolled_rows();
+    }
+
+    /// Hand the grid everything staged so far followed by `tail`, in order.
+    ///
+    /// The common case — nothing was rewritten — feeds `tail` straight
+    /// through, so a stream that never designates a character set pays for
+    /// none of this.
+    fn feed_staged(&mut self, tail: &[u8]) {
+        if self.staged.is_empty() {
+            self.feed(tail);
+            return;
+        }
+        let mut staged = std::mem::take(&mut self.staged);
+        staged.extend_from_slice(tail);
+        self.feed(&staged);
+        staged.clear();
+        self.staged = staged;
     }
 
     /// File a completed payload, stamped with where it landed.
@@ -184,16 +208,26 @@ impl Vt100Emulator {
 
 impl Emulator for Vt100Emulator {
     fn process(&mut self, bytes: &[u8]) -> Processed {
-        // How much of this segment the grid has already been given. Only a
-        // graphics payload moves it mid-segment; everything else is fed in
-        // one go, exactly as before.
+        // How much of this segment the grid has already been given. A
+        // graphics payload moves it mid-segment, and so does a byte the
+        // invoked character set redefines: that byte is staged as the glyph
+        // it draws instead of being sliced through, and everything else is
+        // fed in one go, exactly as before.
         let mut fed = 0;
         for (i, &byte) in bytes.iter().enumerate() {
+            // Asked before the step, because whether this byte is a character
+            // at all depends on the state the tracker is in before it — and
+            // a designation's own final byte must not be drawn.
+            if let Some(glyph) = self.tracker.graphics_glyph(byte) {
+                self.staged.extend_from_slice(&bytes[fed..i]);
+                self.staged.extend_from_slice(glyph.as_bytes());
+                fed = i + 1;
+            }
             let stop = match self.tracker.step(byte) {
                 SeqEvent::SyncEnd => Some(Stop::FrameComplete(self.close_frame())),
                 SeqEvent::Query(query) => Some(Stop::Query(query)),
                 SeqEvent::Graphics(payload) => {
-                    self.feed(&bytes[fed..=i]);
+                    self.feed_staged(&bytes[fed..=i]);
                     fed = i + 1;
                     self.record_graphics(*payload);
                     None
@@ -209,14 +243,14 @@ impl Emulator for Vt100Emulator {
                 }
             };
             if let Some(stop) = stop {
-                self.feed(&bytes[fed..=i]);
+                self.feed_staged(&bytes[fed..=i]);
                 return Processed {
                     consumed: i + 1,
                     stop: Some(stop),
                 };
             }
         }
-        self.feed(&bytes[fed..]);
+        self.feed_staged(&bytes[fed..]);
         Processed {
             consumed: bytes.len(),
             stop: None,
@@ -555,6 +589,55 @@ mod tests {
         assert!(s.cell(0, 0).unwrap().style().strikethrough, "{s}");
     }
 
+    /// `ESC ( 0 l q q q k` is a box. Both parsers receive the translated
+    /// stream — the snapshot's correspondence check would fail otherwise.
+    #[test]
+    fn dec_special_graphics_reaches_the_grid_as_the_glyphs_it_draws() {
+        let emu = emu_with(b"\x1b(0lqqqk\x1b(B\r\nplain");
+        let s = emu.snapshot();
+        assert_eq!(
+            s.text(),
+            "\u{250c}\u{2500}\u{2500}\u{2500}\u{2510}\nplain\n\n"
+        );
+        assert_eq!(s.find("\u{2510}"), Some((0, 4)), "one cell per glyph");
+        assert!(!s.contains("lqqqk"));
+
+        // SO/SI with the set in G1, the vt100-terminfo shape.
+        let emu = emu_with(b"\x1b)0\x0elqk\x0f ok");
+        assert_eq!(
+            emu.snapshot().row_text(0).trim_end(),
+            "\u{250c}\u{2500}\u{2510} ok"
+        );
+    }
+
+    /// A style set inside the graphics set travels with the glyph, and the
+    /// attribute shadow stays in step: the rewrite happens before either
+    /// parser, so the two grids are still the same shape.
+    #[test]
+    fn a_styled_line_drawing_run_keeps_its_style_and_the_shadow_in_step() {
+        let emu = emu_with(b"\x1b(0\x1b[31;9mqq\x1b[0m\x1b(Bq");
+        let s = emu.snapshot();
+        assert_eq!(s.row_text(0).trim_end(), "\u{2500}\u{2500}q");
+        let drawn = *s.cell(0, 0).unwrap().style();
+        assert_eq!(drawn.fg, Color::Indexed(1));
+        assert!(drawn.strikethrough, "the shadow-carried attribute too");
+        assert_eq!(s.cell(0, 2).unwrap().style(), &Style::default());
+    }
+
+    /// A translated byte that also closes a frame, split across feeds: the
+    /// staged glyph must reach the grid before the stop is reported, and a
+    /// designation split across chunks must still apply.
+    #[test]
+    fn translation_survives_chunk_boundaries_and_frame_stops() {
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        feed_all(&mut emu, b"\x1b(");
+        feed_all(&mut emu, b"0\x1b[?2026hl");
+        feed_all(&mut emu, b"q\x1b[?2026lk");
+        let s = emu.snapshot();
+        assert_eq!(s.row_text(0).trim_end(), "\u{250c}\u{2500}\u{2510}");
+        assert!(!emu.in_sync_update());
+    }
+
     #[test]
     fn hidden_cursor_is_reported() {
         let emu = emu_with(b"\x1b[?25l");
@@ -704,7 +787,10 @@ mod tests {
 
     #[test]
     fn history_rows_keep_the_width_they_were_captured_at() {
-        // Documented limit: resize does not reflow.
+        // Documented decision (`Terminal::resize`): history is not reflowed
+        // and not discarded. Rows captured before a narrowing resize keep
+        // their width; rows captured after it have the new one; both sit in
+        // the same history.
         let mut emu = Vt100Emulator::new(2, 10, 100, crate::graphics::DEFAULT_CAPTURE);
         feed_all(&mut emu, b"0123456789\r\nabcdefghij\r\nnext");
         assert_eq!(emu.snapshot().scrollback_text(), "0123456789");
@@ -715,6 +801,17 @@ mod tests {
             "a captured row keeps its width; narrowing the screen must not \
              retroactively rewrite history"
         );
+        // Two more rows at the new width scroll off; the old row is still
+        // there, still ten wide, above the four-wide ones.
+        feed_all(&mut emu, b"\r\nwxyz\r\nlast");
+        let history = emu.snapshot().scrollback_text();
+        let rows: Vec<&str> = history.lines().collect();
+        assert_eq!(rows[0], "0123456789", "captured at 10 columns: {history}");
+        assert!(
+            rows[1..].iter().all(|row| row.chars().count() <= 4),
+            "captured at 4 columns: {history}"
+        );
+        assert!(rows.len() >= 3, "{history}");
     }
 
     #[test]

--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -436,17 +436,36 @@ impl Bitmap {
     ///
     /// The shape of most assertions about a chart: how many greens, and is
     /// the brightest one the one the palette names.
+    ///
+    /// **Ties are broken by first appearance**, in raster order (left to
+    /// right, top to bottom), so the result is fully determined by the image
+    /// and `colours()[0]` has one answer — a test harness must not hand back
+    /// a different order on a different run. Linear in the pixel count: a
+    /// 512x512 screenshot costs milliseconds, not the seconds a per-pixel
+    /// scan of the distinct set used to.
     #[must_use]
     pub fn colours(&self) -> Vec<([u8; 4], u32)> {
-        let mut seen: Vec<([u8; 4], u32)> = Vec::new();
-        for pixel in &self.pixels {
-            match seen.iter_mut().find(|(colour, _)| colour == pixel) {
-                Some((_, count)) => *count += 1,
-                None => seen.push((*pixel, 1)),
-            }
+        use std::collections::HashMap;
+
+        // One pass, remembering where each colour first appeared so that
+        // equal counts have an order the caller can rely on.
+        let mut counts: HashMap<[u8; 4], (u32, usize)> = HashMap::new();
+        for (index, pixel) in self.pixels.iter().enumerate() {
+            counts
+                .entry(*pixel)
+                .and_modify(|(count, _)| *count += 1)
+                .or_insert((1, index));
         }
-        seen.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
-        seen
+        let mut seen: Vec<([u8; 4], u32, usize)> = counts
+            .into_iter()
+            .map(|(colour, (count, first))| (colour, count, first))
+            .collect();
+        // Count descending, then first appearance: a total order, so the
+        // sort's own stability is not what the determinism rests on.
+        seen.sort_unstable_by_key(|&(_, count, first)| (std::cmp::Reverse(count), first));
+        seen.into_iter()
+            .map(|(colour, count, _)| (colour, count))
+            .collect()
     }
 }
 
@@ -1361,6 +1380,64 @@ mod tests {
         let colours = payload.decode().expect("decodes").colours();
         assert_eq!(colours[0], ([1, 2, 3, 255], 3));
         assert_eq!(colours[1], ([9, 9, 9, 255], 1));
+    }
+
+    /// Equal counts come out in the order the colours first appear, so the
+    /// answer is a property of the image rather than of a hash seed. Both
+    /// orders, so a test that happened to agree by luck is ruled out.
+    #[cfg(feature = "decode")]
+    #[test]
+    fn colours_break_ties_by_first_appearance() {
+        let a = [1, 1, 1, 255];
+        let b = [2, 2, 2, 255];
+        let c = [3, 3, 3, 255];
+        let image = |pixels: &[[u8; 4]]| {
+            let raw: Vec<u8> = pixels.iter().flatten().copied().collect();
+            let data = base64(&raw);
+            kitty_payload(
+                format!("a=T,f=32,s={},v=1", pixels.len()).as_bytes(),
+                data.as_bytes(),
+            )
+            .decode()
+            .expect("decodes")
+            .colours()
+        };
+        assert_eq!(image(&[a, b, b, a, c]), vec![(a, 2), (b, 2), (c, 1)]);
+        assert_eq!(image(&[b, a, a, b, c]), vec![(b, 2), (a, 2), (c, 1)]);
+        // And the count still wins over appearance.
+        assert_eq!(image(&[a, b, b]), vec![(b, 2), (a, 1)]);
+    }
+
+    /// A 512x512 image with every pixel a distinct colour — the shape of a
+    /// photograph or a screenshot, and the one the issue extrapolated to
+    /// seven seconds under the old per-pixel scan. The time is not asserted
+    /// (a timing assertion is a flake waiting to happen); what is asserted
+    /// is that the answer is complete and in raster order, which the
+    /// quadratic version also got right, only slowly.
+    #[cfg(feature = "decode")]
+    #[test]
+    fn colours_on_a_photograph_sized_image_completes() {
+        let side = 512u32;
+        let pixels = (side * side) as usize;
+        let mut raw = Vec::with_capacity(pixels * 4);
+        for i in 0..pixels {
+            // i < 2^24, so the RGB triple is unique per pixel.
+            raw.extend_from_slice(&[(i >> 16) as u8, (i >> 8) as u8, i as u8, 0xff]);
+        }
+        let data = base64(&raw);
+        let bitmap = kitty_payload(
+            format!("a=T,f=32,s={side},v={side}").as_bytes(),
+            data.as_bytes(),
+        )
+        .decode()
+        .expect("decodes");
+        let colours = bitmap.colours();
+        assert_eq!(colours.len(), pixels, "every pixel is its own colour");
+        assert!(colours.iter().all(|&(_, count)| count == 1));
+        // All tied at one, so the order is raster order.
+        assert_eq!(colours[0].0, [0, 0, 0, 0xff]);
+        assert_eq!(colours[1].0, [0, 0, 1, 0xff]);
+        assert_eq!(colours[pixels - 1].0, [3, 0xff, 0xff, 0xff]);
     }
 
     #[cfg(feature = "decode")]

--- a/crates/termlens/src/keys.rs
+++ b/crates/termlens/src/keys.rs
@@ -498,6 +498,11 @@ mod tests {
         assert_eq!(mouse_sgr(64, 0, 0, true), b"\x1b[<64;1;1M");
         assert_eq!(mouse_legacy(0, 0, 0), b"\x1b[M\x20\x21\x21");
         assert_eq!(mouse_legacy(3, 9, 6,), b"\x1b[M\x23\x2a\x27");
+        // Modifiers ride on the wheel's code exactly as on a button: +4
+        // shift, +8 alt, +16 ctrl. Ctrl-wheel-up is 64 + 16, in both forms.
+        assert_eq!(mouse_sgr(80, 0, 0, true), b"\x1b[<80;1;1M");
+        assert_eq!(mouse_sgr(69, 2, 3, true), b"\x1b[<69;3;4M"); // shift + wheel down
+        assert_eq!(mouse_legacy(80, 0, 0), b"\x1b[M\x70\x21\x21"); // 32 + 80
     }
 
     /// `u16::MAX + 1` used to wrap to 0 in release and panic in debug.

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -119,7 +119,8 @@ pub use screen::{Cell, Clipboard, Color, CursorShape, Link, MouseMode, Screen, S
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{
-    ExitStatus, FrameTiming, Graphics, MouseButton, MouseChord, Scroll, Terminal, TerminalBuilder,
+    ExitStatus, FrameTiming, Graphics, MouseButton, MouseChord, Scroll, ScrollChord, Terminal,
+    TerminalBuilder,
 };
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -263,7 +263,7 @@ impl Link {
 /// what clippy's `result_large_err` will accept. And a `Screen` clone then
 /// bumps one refcount instead of copying every field, which matters because
 /// a clone happens on each wait evaluation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TermState {
     pub(crate) title: Arc<str>,
     pub(crate) alternate_screen: bool,
@@ -379,7 +379,23 @@ impl Cell {
 /// whitespace stripped per line. Trailing blanks are *preserved* inside the
 /// grid itself, so coordinate queries like [`Screen::cell`] and
 /// [`Screen::find`] are unaffected by the trimming.
-#[derive(Clone)]
+///
+/// # Equality
+///
+/// `==` means **the same observation**: every cell, the cursor, the size,
+/// and all the out-of-band state — title, modes, clipboard, links,
+/// graphics, retained history, and the cumulative
+/// [`repaints`](Self::repaints) and [`bells`](Self::bells) counters — agree.
+/// That is deliberately stricter than "looks the same": two visually
+/// identical snapshots taken either side of a bell compare unequal, because
+/// they *are* different moments, and a test asking "did anything change?"
+/// usually wants to hear about the bell. For "looks the same", compare
+/// [`with_styles`](Self::with_styles) renderings, which cover text and
+/// style and nothing invisible. Comparing plain `to_string()` output is the
+/// trap to avoid: [`Display`](fmt::Display) is text only, so two screens
+/// that differ only in a highlight, a colour or a concealed field compare
+/// equal that way.
+#[derive(Clone, PartialEq, Eq)]
 pub struct Screen {
     cols: u16,
     rows: u16,
@@ -756,6 +772,12 @@ impl Screen {
     /// Empty when nothing has scrolled. History is text only — a scrolled
     /// row has no [`Style`] and no [`cell`](Self::cell) addressing, which
     /// is what keeps a snapshot cheap enough to take on every wait.
+    ///
+    /// Each row keeps the width it was captured at. A
+    /// [`resize`](crate::Terminal::resize) does not reflow history, so
+    /// after a narrowing resize the rows captured before it are wider than
+    /// the rows captured after — see there for why that is the chosen
+    /// behaviour.
     #[must_use]
     pub fn scrollback_text(&self) -> String {
         let mut out = String::new();
@@ -794,7 +816,14 @@ impl Screen {
     ///
     /// The **visible screen only** — like every other query on this type.
     /// For content that may already have scrolled off, use
-    /// [`full_text`](Self::full_text).
+    /// [`full_text`](Self::full_text) (history and screen) or
+    /// [`scrollback_text`](Self::scrollback_text) (history alone). This is
+    /// the trap in the most-copied line in these docs: a
+    /// `wait_until(|s| s.contains("done"))` on text the application printed
+    /// and then scrolled away in the same burst can never succeed, and the
+    /// screen embedded in the timeout will not show the text either. The
+    /// timeout therefore says how many rows have scrolled off whenever any
+    /// have.
     ///
     /// # Normalization
     ///
@@ -831,6 +860,11 @@ impl Screen {
 
     /// Locate the first occurrence of `needle` scanning rows top to bottom;
     /// returns the `(row, col)` of its first character.
+    ///
+    /// The **visible screen only**, like [`contains`](Self::contains): a
+    /// needle that has scrolled into history is not found here, however
+    /// recently it left. [`full_text`](Self::full_text) spans history and
+    /// screen, [`scrollback_text`](Self::scrollback_text) the history alone.
     ///
     /// Needles containing `\n` match across consecutive rows with exactly
     /// the semantics of [`Screen::contains`] (trailing whitespace stripped
@@ -1540,6 +1574,53 @@ mod tests {
         assert!(
             rendered.ends_with("styles:\n0: 0-2 bg=#1e1e2e"),
             "{rendered}"
+        );
+    }
+
+    /// `==` is the same observation, counters included — stricter than the
+    /// text rendering, which is the trap the doc names.
+    #[test]
+    fn equality_is_the_same_observation_not_the_same_rendering() {
+        let a = screen(10, 2, &["hello"]);
+        assert_eq!(a, a.clone(), "a clone observes the same instant");
+        assert_eq!(a, screen(10, 2, &["hello"]), "built alike, equal");
+        assert_ne!(a, screen(10, 2, &["hullo"]));
+
+        // A bell changes no cell: the renderings agree, the screens do not.
+        let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
+        let quiet = Screen::from_parts(1, 1, 0, 0, true, cells.clone(), TermState::default());
+        let rung = Screen::from_parts(
+            1,
+            1,
+            0,
+            0,
+            true,
+            cells,
+            TermState {
+                bells: 1,
+                ..TermState::default()
+            },
+        );
+        assert_eq!(quiet.to_string(), rung.to_string());
+        assert_ne!(quiet, rung);
+
+        // A style is invisible to `to_string()` and visible to `==` — and to
+        // the styled rendering, which is the comparison the doc points at.
+        let bold = vec![Cell::new(
+            "x".into(),
+            Style {
+                bold: true,
+                ..Style::default()
+            },
+            false,
+            false,
+        )];
+        let styled = Screen::from_parts(1, 1, 0, 0, true, bold, TermState::default());
+        assert_eq!(quiet.to_string(), styled.to_string());
+        assert_ne!(quiet, styled);
+        assert_ne!(
+            quiet.with_styles().to_string(),
+            styled.with_styles().to_string()
         );
     }
 

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -301,9 +301,15 @@ pub enum Graphics {
     Kitty,
 }
 
-/// Scroll-wheel direction for [`Terminal::scroll`].
+/// Scroll-wheel direction for [`Terminal::scroll`] and
+/// [`Terminal::scroll_with`].
+///
+/// Add modifiers the same way [`MouseButton`] does — `Scroll::Up.ctrl()`
+/// for the zoom idiom, `Scroll::Down.shift()` where an application maps
+/// Shift-wheel to horizontal scrolling — and send the result with
+/// [`Terminal::scroll_with`].
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Scroll {
     /// Wheel up (away from the user).
     Up,
@@ -313,6 +319,97 @@ pub enum Scroll {
     Left,
     /// Horizontal wheel right.
     Right,
+}
+
+impl Scroll {
+    /// The xterm button code: the wheel is buttons 64–67.
+    fn code(self) -> u8 {
+        match self {
+            Scroll::Up => 64,
+            Scroll::Down => 65,
+            Scroll::Left => 66,
+            Scroll::Right => 67,
+        }
+    }
+
+    /// This wheel direction with `Ctrl` held — zoom, in most applications
+    /// that bind it.
+    #[must_use]
+    pub fn ctrl(self) -> ScrollChord {
+        ScrollChord::from(self).ctrl()
+    }
+
+    /// This wheel direction with `Alt` held.
+    #[must_use]
+    pub fn alt(self) -> ScrollChord {
+        ScrollChord::from(self).alt()
+    }
+
+    /// This wheel direction with `Shift` held — horizontal scrolling, in
+    /// most applications that bind it.
+    #[must_use]
+    pub fn shift(self) -> ScrollChord {
+        ScrollChord::from(self).shift()
+    }
+}
+
+/// A wheel direction plus modifier keys — `Scroll::Up.ctrl()`.
+///
+/// Mirrors [`MouseChord`] for the wheel; anything taking
+/// `impl Into<ScrollChord>` accepts a bare [`Scroll`] too. A type of its own
+/// rather than a wider `MouseChord`, so that `click_with` cannot be handed a
+/// wheel direction and `scroll_with` cannot be handed a button: the two are
+/// different gestures on the wire (a wheel notch has no release), and the
+/// type keeps that from being a runtime surprise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ScrollChord {
+    direction: Scroll,
+    ctrl: bool,
+    alt: bool,
+    shift: bool,
+}
+
+impl From<Scroll> for ScrollChord {
+    fn from(direction: Scroll) -> Self {
+        Self {
+            direction,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        }
+    }
+}
+
+impl ScrollChord {
+    /// Add `Ctrl`.
+    #[must_use]
+    pub fn ctrl(mut self) -> Self {
+        self.ctrl = true;
+        self
+    }
+
+    /// Add `Alt`.
+    #[must_use]
+    pub fn alt(mut self) -> Self {
+        self.alt = true;
+        self
+    }
+
+    /// Add `Shift`.
+    #[must_use]
+    pub fn shift(mut self) -> Self {
+        self.shift = true;
+        self
+    }
+
+    /// The xterm button code: the wheel direction, plus 4 for shift, 8 for
+    /// alt and 16 for control — the same arithmetic a click uses.
+    fn code(self) -> u8 {
+        self.direction.code()
+            + 4 * u8::from(self.shift)
+            + 8 * u8::from(self.alt)
+            + 16 * u8::from(self.ctrl)
+    }
 }
 
 /// A mouse button, for [`Terminal::click_with`] and [`Terminal::drag`].
@@ -984,7 +1081,7 @@ impl TerminalBuilder {
     /// Terminal size as columns × rows. Defaults to 80×24.
     ///
     /// Both dimensions must be non-zero and at most **1000**;
-    /// [`spawn`](Self::spawn) rejects anything else with [`Error::Input`]
+    /// [`spawn`](Self::spawn) rejects anything else with [`Error::Size`]
     /// rather than letting the emulator meet a size no terminal can have,
     /// or one it can only serve slowly enough to look broken.
     ///
@@ -1282,9 +1379,9 @@ impl TerminalBuilder {
     /// [`Error::Spawn`] when the configuration cannot produce a runnable
     /// command (empty program name, missing
     /// [`current_dir`](Self::current_dir)) or the program cannot be
-    /// executed; [`Error::Input`] when the configured
-    /// [`size`](Self::size) has a zero dimension; [`Error::Pty`] when the
-    /// PTY cannot be opened.
+    /// executed; [`Error::Size`] when the configured
+    /// [`size`](Self::size) has a zero dimension or one past the
+    /// 1000-per-axis limit; [`Error::Pty`] when the PTY cannot be opened.
     pub fn spawn(self, program: impl AsRef<OsStr>) -> Result<Terminal> {
         let program = program.as_ref();
         let command_desc = std::iter::once(program)
@@ -1592,9 +1689,14 @@ fn encode_hex(bytes: &[u8]) -> String {
 /// visits every intervening column (or row, whichever spans further) exactly
 /// once — which is the property an application acting on the path depends on.
 /// `from` itself is excluded, because the press already reported it.
+///
+/// The arithmetic is `i64`. Every caller has already checked both endpoints
+/// against the grid, and the grid is capped at 1000 per axis, but
+/// `d * steps` at `u16::MAX` overflows an `i32` — and a helper should not
+/// depend on its callers for a bound it can hold itself.
 fn cells_between(from: (u16, u16), to: (u16, u16)) -> Vec<(u16, u16)> {
-    let (from_col, from_row) = (i32::from(from.0), i32::from(from.1));
-    let (to_col, to_row) = (i32::from(to.0), i32::from(to.1));
+    let (from_col, from_row) = (i64::from(from.0), i64::from(from.1));
+    let (to_col, to_row) = (i64::from(to.0), i64::from(to.1));
     let d_col = to_col - from_col;
     let d_row = to_row - from_row;
     let steps = d_col.abs().max(d_row.abs());
@@ -1667,6 +1769,31 @@ fn frames_phrase(n: u64) -> String {
         "1 complete frame".to_owned()
     } else {
         format!("{n} complete frames")
+    }
+}
+
+/// One-line note for a content wait that failed while history exists.
+///
+/// A predicate reads the visible grid, and so does the screen embedded in
+/// the error, so text the application printed and then scrolled away in the
+/// same burst reads as text it never printed — the most-copied line in the
+/// docs, `wait_until(|s| s.contains(..))`, has that failure mode built in.
+/// The note cannot know what the predicate was looking for, since it is an
+/// arbitrary closure, so it says only what is true — rows are off the top,
+/// and where they can be seen — and leaves the inference to the reader.
+/// Silent when nothing has scrolled, so an application that owns its
+/// viewport is never told about history it does not have.
+fn history_note(screen: &Screen) -> String {
+    match screen.scrollback_rows() {
+        0 => String::new(),
+        1 => " — note: 1 row has scrolled off the top and is not on this screen; if \
+              the text you are waiting for is in it, Screen::full_text() spans history"
+            .to_owned(),
+        rows => format!(
+            " — note: {rows} rows have scrolled off the top and are not on this \
+             screen; if the text you are waiting for is among them, \
+             Screen::full_text() spans history"
+        ),
     }
 }
 
@@ -2250,25 +2377,59 @@ impl Terminal {
 
     /// Scroll the wheel one notch at `(col, row)` (0-based).
     ///
+    /// The unmodified case of [`scroll_with`](Self::scroll_with), exactly as
+    /// [`click`](Self::click) is of [`click_with`](Self::click_with).
+    ///
     /// # Errors
     ///
     /// Same conditions as [`click`](Self::click).
     pub fn scroll(&mut self, col: u16, row: u16, direction: Scroll) -> Result<()> {
+        self.scroll_with(direction, col, row)
+    }
+
+    /// Scroll the wheel one notch at `(col, row)`, optionally with
+    /// modifiers.
+    ///
+    /// Takes a [`Scroll`] or a [`ScrollChord`], the same way
+    /// [`click_with`](Self::click_with) takes a [`MouseButton`] or a
+    /// [`MouseChord`] — and in the same argument order, gesture first:
+    ///
+    /// ```no_run
+    /// # use termlens::Scroll;
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// t.scroll_with(Scroll::Up.ctrl(), 10, 4)?;      // zoom in
+    /// t.scroll_with(Scroll::Down.shift(), 10, 4)?;   // horizontal scroll
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// `Ctrl`-wheel is zoom and `Shift`-wheel is horizontal scrolling in a
+    /// large share of terminal applications, and before this neither could
+    /// be sent at all — so the binding most likely to be wired to the wrong
+    /// handler was the one with no coverage. On the wire the modifiers ride
+    /// on the wheel's button code exactly as they do on a click: `+4`
+    /// shift, `+8` alt, `+16` ctrl.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`click`](Self::click).
+    pub fn scroll_with(
+        &mut self,
+        direction: impl Into<ScrollChord>,
+        col: u16,
+        row: u16,
+    ) -> Result<()> {
         self.ensure_deliverable("a mouse scroll")?;
+        let chord = direction.into();
         let modes = self.input_modes();
         if modes.mouse == MouseMode::None {
             return Err(no_mouse_tracking());
         }
         let (cols, rows) = self.screen().size();
         check_mouse_in_grid(col, row, cols, rows)?;
-        let button = match direction {
-            Scroll::Up => 64,
-            Scroll::Down => 65,
-            Scroll::Left => 66,
-            Scroll::Right => 67,
-        };
         // Wheel events are presses only; there is no release.
-        let bytes = self.mouse_report(&modes, button, col, row, true)?;
+        let bytes = self.mouse_report(&modes, chord.code(), col, row, true)?;
         self.write_input(&bytes, "a mouse scroll")
     }
 
@@ -2485,7 +2646,7 @@ impl Terminal {
             }
             if state.eof {
                 return Some(Err(Error::Eof {
-                    waiting_for: format!("{WHAT}{}", state.query_note()),
+                    waiting_for: format!("{WHAT}{}{}", state.query_note(), history_note(&screen)),
                     screen,
                 }));
             }
@@ -2493,11 +2654,15 @@ impl Terminal {
         });
         match outcome {
             Ok(inner) => inner,
-            Err(Expired) => Err(Error::Timeout {
-                waiting_for: format!("{WHAT}{}", self.shared.lock().query_note()),
-                timeout,
-                screen: self.screen(),
-            }),
+            Err(Expired) => {
+                let screen = self.screen();
+                let note = self.shared.lock().query_note();
+                Err(Error::Timeout {
+                    waiting_for: format!("{WHAT}{note}{}", history_note(&screen)),
+                    timeout,
+                    screen,
+                })
+            }
         }
     }
 
@@ -2619,9 +2784,10 @@ impl Terminal {
                 }
             }
             if state.eof {
+                let screen = state.peek_snapshot();
                 return Some(Err(Error::Eof {
-                    waiting_for: format!("{WHAT}{}", state.query_note()),
-                    screen: state.peek_snapshot(),
+                    waiting_for: format!("{WHAT}{}{}", state.query_note(), history_note(&screen)),
+                    screen,
                 }));
             }
             None
@@ -2642,7 +2808,7 @@ impl Terminal {
                 let (frames, screen, note) = {
                     let mut guard = self.shared.lock();
                     let screen = guard.snapshot();
-                    let note = guard.query_note();
+                    let note = format!("{}{}", guard.query_note(), history_note(&screen));
                     (guard.frames_seen, screen, note)
                 };
                 let waiting_for = if frames > 0 && frames == cursor {
@@ -2941,13 +3107,38 @@ impl Terminal {
     /// advances the frame cursor, so only a frame completed *after* it can
     /// satisfy the wait. `docs/DESIGN.md` §2 shows the trap in full.
     ///
+    /// # History is not reflowed
+    ///
+    /// Rows already in scrollback keep the width they were captured at, and
+    /// rows that scroll off after the resize are captured at the new width,
+    /// so [`full_text`](Screen::full_text) after a narrowing resize can hold
+    /// both geometries. That is a decision rather than an omission. History
+    /// is text, with no record of which rows were soft-wrapped, so there is
+    /// nothing to reflow *from*; and discarding it on resize — the other
+    /// honest option — would make a suite that exercises a responsive layout
+    /// lose everything it had already asserted on. The visible grid is not
+    /// reflowed either: the backend clips or pads each row to the new width,
+    /// which is the stale-frame trap above.
+    ///
+    /// # After the child exits
+    ///
+    /// Refused, the same way [`send`](Self::send) is. Once the child has
+    /// released the terminal there is no process left to receive `SIGWINCH`
+    /// and nothing that could repaint, so a size the snapshot then reported
+    /// would be one no application ever rendered at, over the dead child's
+    /// last frame. The final screen stays readable at the size it exited
+    /// with.
+    ///
     /// # Errors
     ///
-    /// [`Error::Input`] if either dimension is zero (a terminal has at
-    /// least one row and one column), before the PTY or the grid is
-    /// touched; [`Error::Pty`] if the ioctl fails.
+    /// [`Error::Size`] if either dimension is zero (a terminal has at least
+    /// one row and one column) or past the 1000-per-axis limit, before the
+    /// PTY or the grid is touched; [`Error::Write`] when the child has
+    /// released the terminal, carrying the final screen; [`Error::Pty`] if
+    /// the ioctl fails.
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<()> {
         check_size(cols, rows)?;
+        self.ensure_deliverable("a resize")?;
         self.master
             .as_ref()
             .expect("master lives until drop")
@@ -3030,8 +3221,44 @@ impl Drop for Terminal {
 
 #[cfg(test)]
 mod tests {
-    use super::{cells_between, check_mouse_in_grid};
-    use crate::Error;
+    use std::sync::Arc;
+
+    use super::{cells_between, check_mouse_in_grid, history_note, Scroll, ScrollChord};
+    use crate::screen::{Cell, Style, TermState};
+    use crate::{Error, Screen};
+
+    /// The modifier bits ride on the wheel code exactly as on a button.
+    #[test]
+    fn wheel_chords_add_the_xterm_modifier_bits() {
+        assert_eq!(ScrollChord::from(Scroll::Up).code(), 64);
+        assert_eq!(Scroll::Down.shift().code(), 65 + 4);
+        assert_eq!(Scroll::Left.alt().code(), 66 + 8);
+        assert_eq!(Scroll::Up.ctrl().code(), 64 + 16);
+        assert_eq!(Scroll::Right.ctrl().alt().shift().code(), 67 + 28);
+    }
+
+    fn with_history(rows: usize) -> Screen {
+        let state = TermState {
+            scrollback: (0..rows)
+                .map(|n| Arc::from(format!("row {n}")))
+                .collect::<Vec<Arc<str>>>()
+                .into(),
+            ..TermState::default()
+        };
+        let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
+        Screen::from_parts(1, 1, 0, 0, true, cells, state)
+    }
+
+    /// Silent without history, grammatical with it, and it names the remedy.
+    #[test]
+    fn the_history_note_speaks_only_when_rows_have_scrolled() {
+        assert_eq!(history_note(&with_history(0)), "");
+        let one = history_note(&with_history(1));
+        assert!(one.contains("1 row has scrolled off"), "{one}");
+        let many = history_note(&with_history(12));
+        assert!(many.contains("12 rows have scrolled off"), "{many}");
+        assert!(many.contains("Screen::full_text()"), "{many}");
+    }
 
     #[test]
     fn mouse_in_grid_accepts_the_bottom_right_cell() {

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -3156,25 +3156,42 @@ impl Terminal {
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<()> {
         check_size(cols, rows)?;
         self.ensure_deliverable("a resize")?;
-        self.master
-            .as_ref()
-            .expect("master lives until drop")
-            .resize(PtySize {
-                rows,
-                cols,
-                pixel_width: pixel_span(cols, self.cell_size.map(|(w, _)| w)),
-                pixel_height: pixel_span(rows, self.cell_size.map(|(_, h)| h)),
-            })
-            .map_err(|e| Error::Pty(format!("resize failed: {e}")))?;
-        // A frame drawn at the old size cannot be the repaint that answers
-        // this resize, so it stops being offered — which is what makes the
-        // advice in the stale-frame trap above actually hold for
-        // `wait_frame`.
-        self.frame_cursor = self.shared.mutate(|state| {
+        let size = PtySize {
+            rows,
+            cols,
+            pixel_width: pixel_span(cols, self.cell_size.map(|(w, _)| w)),
+            pixel_height: pixel_span(rows, self.cell_size.map(|(_, h)| h)),
+        };
+        let master = self.master.as_ref().expect("master lives until drop");
+        // Grid first, then the kernel, and both under the state lock. The
+        // order carries two guarantees. A frame the application draws in
+        // answer to the SIGWINCH must land in a grid that already has the
+        // new size — otherwise it is rendered into the old geometry, clipped
+        // afterwards, and offered as the repaint that answered the resize.
+        // And the frame cursor must be taken before the signal can reach the
+        // application: with the ioctl first, a fast application's
+        // acknowledging repaint could complete, and be counted, in the gap
+        // before the cursor was read — so the one frame `wait_frame` had been
+        // promised sat behind the cursor and the wait timed out, while the
+        // live screen showed the repaint. The stress workflow found exactly
+        // that at 16 threads, once in 25 runs. Holding the lock across the
+        // ioctl closes the gap: no byte is processed between the two steps.
+        //
+        // The cursor is what makes the advice in the stale-frame trap above
+        // hold for `wait_frame`: a frame drawn at the old size cannot be the
+        // repaint that answers this resize, so it stops being offered.
+        let cursor = self.shared.mutate(|state| {
+            let (old_cols, old_rows) = state.peek_snapshot().size();
             state.emu.set_size(rows, cols);
+            if let Err(e) = master.resize(size) {
+                // The grid and the kernel must not disagree: undo the grid.
+                state.emu.set_size(old_rows, old_cols);
+                return Err(Error::Pty(format!("resize failed: {e}")));
+            }
             state.touch();
-            state.frames_seen
-        });
+            Ok(state.frames_seen)
+        })?;
+        self.frame_cursor = cursor;
         Ok(())
     }
 }

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -3107,6 +3107,23 @@ impl Terminal {
     /// advances the frame cursor, so only a frame completed *after* it can
     /// satisfy the wait. `docs/DESIGN.md` §2 shows the trap in full.
     ///
+    /// # Wait before typing
+    ///
+    /// Let the application acknowledge the resize before sending it anything.
+    /// A keystroke that reaches the application in the same instant as the
+    /// `SIGWINCH` can be **lost**: crossterm's event reader (0.29) returns
+    /// the `Resize` event as soon as its poll reports the signal, abandoning
+    /// the input readiness it was handed in the same poll — and that poll is
+    /// edge-triggered (mio registers with `EPOLLET` and `EV_CLEAR`), so a
+    /// byte already sitting in the queue is not offered again until *more*
+    /// input arrives. The application then blocks in `read()` with your
+    /// keystroke behind it. termlens found this in its own suite, where a
+    /// resize followed at once by `Esc` hung the fixture about one run in
+    /// forty. Wait for something the application draws in response to the
+    /// resize — [`wait_frame`](Self::wait_frame) where it emits synchronized
+    /// updates — and only then send. A real terminal has the same race; a
+    /// human's hands are simply slower than a test.
+    ///
     /// # History is not reflowed
     ///
     /// Rows already in scrollback keep the width they were captured at, and

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -111,6 +111,43 @@ fn resize_to_zero_is_refused_without_touching_the_pty_or_the_grid() -> termlens:
     Ok(())
 }
 
+/// `send` and `signal` refuse once the child is gone; `resize` used to
+/// succeed and report a geometry no application ever rendered at, with the
+/// dead child's last frame underneath it. Refused now, on the same evidence
+/// `send` uses — EOF, so nothing is left to receive the SIGWINCH.
+#[test]
+fn resize_after_the_child_exits_is_refused_like_send() -> termlens::Result<()> {
+    let mut t = Terminal::builder()
+        .size(20, 4)
+        .timeout(Duration::from_secs(10))
+        .args(["-c", "printf ready; read _"])
+        .spawn("/bin/sh")?;
+    t.wait_until(|s| s.contains("ready"))?;
+    t.send(termlens::Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    let before = t.screen();
+    assert_eq!(before.size(), (20, 4));
+
+    let err = t
+        .resize(60, 10)
+        .expect_err("nothing is left to receive a SIGWINCH");
+    assert!(matches!(err, Error::Write { .. }), "got: {err}");
+    let msg = err.to_string();
+    assert!(msg.contains("resize"), "{msg}");
+    assert!(msg.contains("the child is gone"), "{msg}");
+    // The final screen is untouched: still the size the child exited with,
+    // and the very same observation.
+    assert_eq!(t.screen().size(), (20, 4));
+    assert_eq!(
+        t.screen(),
+        before,
+        "a refused resize must not move the snapshot"
+    );
+    // A size that cannot work is still the size error, and is checked first.
+    assert!(matches!(t.resize(0, 10), Err(Error::Size(_))));
+    Ok(())
+}
+
 #[test]
 fn a_missing_program_still_reports_the_underlying_search_failure() {
     let err = Terminal::builder()

--- a/crates/termlens/tests/charset.rs
+++ b/crates/termlens/tests/charset.rs
@@ -1,0 +1,97 @@
+//! DEC Special Graphics: the line-drawing character set ncurses borders are
+//! made of. On an xterm terminfo `smacs`/`rmacs` are `ESC ( 0` / `ESC ( B`;
+//! on a vt100 one the set is designated into G1 once and invoked with
+//! `SO`/`SI`. Either way a user sees `┌───┐`, and so must the grid — before
+//! this, a snapshot blessed `lqqqk` and went on passing while the border was
+//! broken, because the letters were what it had recorded.
+
+use std::time::Duration;
+
+use termlens::{Color, Key, Terminal};
+
+fn sh(script: &str) -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .size(40, 6)
+        .timeout(Duration::from_secs(10))
+        .args(["-c", script])
+        .spawn("/bin/sh")
+}
+
+/// The reproduction from the issue, as a whole frame.
+#[test]
+fn an_ncurses_style_border_reads_as_box_drawing() -> termlens::Result<()> {
+    let mut t = sh(concat!(
+        r"printf '\033(0lqqqk\033(B\n'; ",
+        r"printf '\033(0x\033(B in \033(0x\033(B\n'; ",
+        r"printf '\033(0mqqqj\033(B\n'; ",
+        "printf DONE; read _"
+    ))?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "┌───┐", "{s}");
+    assert_eq!(s.row_text(1).trim_end(), "│ in │", "{s}");
+    assert_eq!(s.row_text(2).trim_end(), "└───┘", "{s}");
+    // One cell per glyph, so coordinates are the user's.
+    assert_eq!(s.find("┐"), Some((0, 4)));
+    assert!(
+        !s.contains("lqqqk"),
+        "the letters must not reach the grid:\n{s}"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The vt100-terminfo shape: `enacs` designates the set into G1 once, then
+/// `smacs`/`rmacs` are the locking shifts SO and SI.
+#[test]
+fn shift_out_and_shift_in_select_the_designated_set() -> termlens::Result<()> {
+    let mut t = sh(r"printf '\033)0\016lqk\017 lqk \016x\017'; printf DONE; read _")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "┌─┐ lqk │DONE", "{s}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// A colour set inside the graphics set travels with the glyph. The
+/// attribute shadow follows the same translated stream, so its
+/// correspondence check — run on every snapshot — is what proves the two
+/// grids stayed the same shape through the rewrite.
+#[test]
+fn a_styled_border_keeps_its_style() -> termlens::Result<()> {
+    let mut t = sh(r"printf '\033(0\033[31mqqq\033[0m\033(B end'; printf DONE; read _")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "─── endDONE", "{s}");
+    for col in 0..3 {
+        let cell = s.cell(0, col).expect("on screen");
+        assert_eq!(cell.contents(), "─");
+        assert_eq!(cell.style().fg, Color::Indexed(1), "col {col}: {s}");
+    }
+    assert_eq!(s.cell(0, 4).unwrap().style().fg, Color::Default);
+    assert!(
+        s.with_styles().to_string().contains("0: 0-2 fg=1"),
+        "{}",
+        s.with_styles()
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// A hard reset returns both sets to ASCII — and clears the screen, as RIS
+/// does, so the glyph drawn before it is gone and the byte after it is a
+/// letter again.
+#[test]
+fn a_hard_reset_returns_to_ascii() -> termlens::Result<()> {
+    let mut t = sh(r"printf '\033(0q\033cq'; printf DONE; read _")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "qDONE", "{s}");
+    assert!(!s.contains("─"), "{s}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -447,6 +447,28 @@ fn a_resize_stops_offering_frames_drawn_at_the_old_size() -> termlens::Result<()
     Ok(())
 }
 
+/// The repaint that answers a resize is offered to `wait_frame`, however fast
+/// the application is, and it is drawn into the resized grid. The frame
+/// cursor used to be taken *after* the SIGWINCH went out, so an acknowledging
+/// repaint that completed in that gap was counted as a pre-resize frame and
+/// never offered — found by the stress workflow at 16 threads, once in 25
+/// runs. The grid is now resized and the cursor taken before the signal,
+/// under one lock, so there is no gap for a frame to fall into.
+#[test]
+fn the_repaint_answering_a_resize_is_offered_to_wait_frame() -> termlens::Result<()> {
+    let mut t = spawn_form_echo()?;
+    t.wait_frame(|s| s.contains("form-echo ready"))?;
+    for (cols, rows) in [(60u16, 12u16), (40, 8), (100, 30)] {
+        t.resize(cols, rows)?;
+        let frame = t.wait_frame(|s| s.contains(&format!("last: resize:{cols}x{rows}")))?;
+        // Drawn into the resized grid, not clipped out of the old one.
+        assert_eq!(frame.size(), (cols, rows), "{frame}");
+    }
+    t.send(Key::Esc)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
 /// `screen()` is the live grid even for an application that brackets
 /// every repaint — the tear is real, documented, and wanted for
 /// diagnosis. `wait_frame`'s return value is the frame-consistent read.

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -435,13 +435,23 @@ fn mouse_events_outside_the_grid_are_refused() -> termlens::Result<()> {
     assert!(err.to_string().contains("20x5"), "{err}");
 
     // After a shrink, a coordinate that was valid earlier must name the
-    // *new* size — otherwise the error reads as a mystery.
-    t.resize(10, 3)?;
+    // *new* size — otherwise the error reads as a mystery. Wide enough for
+    // the fixture's acknowledgement to fit on its row, and still excluding
+    // (19, 4) on both axes.
+    t.resize(18, 4)?;
+    // Wait for the application to have handled the SIGWINCH before sending
+    // it anything: a keystroke arriving in the same instant as the resize
+    // can be lost by crossterm's event reader — see `Terminal::resize`. The
+    // stress workflow found this at 8 threads on its first iteration, and it
+    // reproduced locally about one run in forty. `wait_frame` is the right
+    // wait: a resize advances the frame cursor, so only a frame drawn after
+    // it can satisfy this.
+    t.wait_frame(|s| s.contains("last: resize:18x4"))?;
     let err = t.click(19, 4).expect_err("pre-resize coordinate");
     assert!(matches!(err, Error::Input(_)), "got: {err}");
     let msg = err.to_string();
     assert!(msg.contains("(19, 4)"), "{msg}");
-    assert!(msg.contains("10x3"), "post-resize size: {msg}");
+    assert!(msg.contains("18x4"), "post-resize size: {msg}");
     assert!(!msg.contains("20x5"), "must not report the old size: {msg}");
 
     t.send(Key::Esc)?;

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -31,6 +31,15 @@ fn clicks_round_trip_through_the_apps_tracking_mode() -> termlens::Result<()> {
     t.scroll(3, 2, Scroll::Down)?;
     t.wait_frame(|s| s.contains("last: mouse:scrolldown:3,2"))?;
 
+    // Modified wheel notches, decoded by crossterm's own parser: the zoom
+    // and horizontal-scroll idioms, which had no way onto the wire before.
+    t.scroll_with(Scroll::Up.ctrl(), 3, 2)?;
+    t.wait_frame(|s| s.contains("last: mouse:ctrl+scrollup:3,2"))?;
+    t.scroll_with(Scroll::Down.shift(), 4, 1)?;
+    t.wait_frame(|s| s.contains("last: mouse:shift+scrolldown:4,1"))?;
+    t.scroll_with(Scroll::Up.ctrl().alt(), 3, 2)?;
+    t.wait_frame(|s| s.contains("last: mouse:ctrl+alt+scrollup:3,2"))?;
+
     t.send(Key::Esc)?;
     assert!(t.wait_exit()?.success());
     Ok(())
@@ -220,6 +229,10 @@ fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Res
     t.click_with(termlens::MouseButton::Right, 10, 4)?;
     t.click_with(termlens::MouseButton::Left.ctrl(), 3, 1)?;
     t.scroll(5, 5, termlens::Scroll::Left)?;
+    // Ctrl-wheel-up (64 + 16) and Shift-wheel-down (65 + 4): the modifiers
+    // ride on the wheel's button code exactly as they do on a click.
+    t.scroll_with(termlens::Scroll::Up.ctrl(), 5, 5)?;
+    t.scroll_with(termlens::Scroll::Down.shift(), 5, 5)?;
     // Drag left button from (2,2) to (6,3): press, motion (0+32), release.
     t.drag(termlens::MouseButton::Left, (2, 2), (6, 3))?;
 
@@ -231,6 +244,8 @@ fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Res
         "[<16;4;2M",
         "[<16;4;2m", // ctrl + left
         "[<66;6;6M", // horizontal wheel
+        "[<80;6;6M", // ctrl + wheel up
+        "[<69;6;6M", // shift + wheel down
         // Drag (2,2) -> (6,3): press, one motion per crossed cell, release.
         "[<0;3;3M",
         "[<32;4;3M",

--- a/crates/termlens/tests/readme_example.rs
+++ b/crates/termlens/tests/readme_example.rs
@@ -16,8 +16,17 @@ fn readme_example_compiles_and_runs() -> termlens::Result<()> {
         .timeout(Duration::from_secs(5))
         .spawn(util::fixture_bin("hello-tui"))?;
 
-    t.wait_until(|screen| screen.contains("status: ready"))?;
-    assert!(t.screen().contains("status: ready"));
+    // The README waits on "Ready" and snapshots. The fixture's last byte is
+    // the bottom-right corner, so the corner is waited on as well — rule 2
+    // of `docs/DESIGN.md` §2: a whole-screen snapshot must wait on the last
+    // thing the application paints, or it races the rest of the frame at a
+    // chunk boundary.
+    t.wait_until(|screen| screen.contains("status: ready") && screen.contains("╯"))?;
+    // The README's most distinctive line, compiled against the `insta` the
+    // crate itself dev-depends on. A dev-dependency is present in every
+    // feature configuration, so this needs no `cfg(feature = "insta")`: the
+    // `--no-default-features` CI job builds and runs it too.
+    insta::assert_snapshot!(t.screen());
 
     t.send(Key::Char('q'))?;
     assert!(t.wait_exit()?.success());

--- a/crates/termlens/tests/scrollback.rs
+++ b/crates/termlens/tests/scrollback.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use termlens::{Key, Terminal};
+use termlens::{Error, Key, Terminal};
 
 /// `sh` printing `count` numbered lines on a `rows`-row screen, then
 /// parking so the terminal stays alive.
@@ -133,6 +133,57 @@ fn history_is_observable_from_a_predicate() -> termlens::Result<()> {
     t.wait_until(|s| s.scrollback_text().contains("committed-block"))?;
     assert!(!t.screen().contains("committed-block"));
 
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The most-copied line in the docs, on text that scrolled away in the same
+/// burst: the wait can never succeed, and the screen in the error does not
+/// show the text either — so it used to read as "the app never printed it".
+/// The error now says that rows are off the top, and where they can be seen.
+#[test]
+fn a_wait_on_scrolled_off_text_names_the_history_in_its_error() -> termlens::Result<()> {
+    let mut t = numbered(3, 10, 100)?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let scrolled = t.screen().scrollback_rows();
+    assert!(scrolled > 1, "the setup must have scrolled: {}", t.screen());
+
+    // "line-1" is in history; `contains` reads the grid alone.
+    let err = t
+        .wait_until_for(|s| s.contains("line-1\n"), Duration::from_millis(300))
+        .expect_err("the text is in history, not on the grid");
+    assert!(matches!(err, Error::Timeout { .. }), "got: {err}");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&format!("{scrolled} rows have scrolled off the top")),
+        "{msg}"
+    );
+    assert!(msg.contains("full_text"), "the remedy is named: {msg}");
+    // And the claim checks out against the very screen the error carries.
+    assert!(err.screen().unwrap().full_text().contains("line-1\n"));
+
+    // The EOF path carries the same note.
+    t.send(Key::Enter)?;
+    let err = t
+        .wait_until(|s| s.contains("line-1\n"))
+        .expect_err("the child has exited");
+    assert!(matches!(err, Error::Eof { .. }), "got: {err}");
+    assert!(err.to_string().contains("scrolled off the top"), "{err}");
+    Ok(())
+}
+
+/// No history, no note: an application that owns its viewport is never told
+/// about rows it does not have.
+#[test]
+fn a_wait_with_nothing_scrolled_carries_no_history_note() -> termlens::Result<()> {
+    let mut t = numbered(12, 3, 100)?;
+    t.wait_until(|s| s.contains("READY"))?;
+    assert_eq!(t.screen().scrollback_rows(), 0);
+    let err = t
+        .wait_until_for(|s| s.contains("absent"), Duration::from_millis(200))
+        .expect_err("never printed");
+    assert!(!err.to_string().contains("scrolled off"), "{err}");
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())

--- a/crates/termlens/tests/snapshots/readme_example__readme_example_compiles_and_runs.snap
+++ b/crates/termlens/tests/snapshots/readme_example__readme_example_compiles_and_runs.snap
@@ -1,0 +1,11 @@
+---
+source: crates/termlens/tests/readme_example.rs
+expression: t.screen()
+---
+size: 80x24  cursor: hidden
+╭──────────────────────────────╮
+│ hello-tui                    │
+│                              │
+│ status: ready                │
+│ press q to quit              │
+╰──────────────────────────────╯

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -202,7 +202,13 @@ screen dump** — a CI log alone answers "what was the app showing?".
 - `wait_until(pred)` — re-evaluates `pred` on a fresh snapshot whenever the
   reader delivers bytes (condvar notification), with a 50ms poll cap as a
   missed-wakeup backstop. Fails fast with `Error::Eof` the moment the PTY
-  closes while `pred` is false: more waiting can never succeed.
+  closes while `pred` is false: more waiting can never succeed. When rows
+  have scrolled into history, both errors say how many and point at
+  `full_text` — a content predicate cannot see them and neither can the
+  embedded screen, so text printed and then scrolled away in one burst
+  otherwise reads as text the application never printed. The note is
+  conditional on purpose: the predicate is an arbitrary closure, so the
+  wait cannot know what it was looking for, only what is true.
 - `wait_frame(pred)` — evaluates `pred` **only on complete frames**. The
   sequence tracker recognizes DEC private mode 2026 (`CSI ?2026 h/l`,
   including multi-mode lists); the reader splits each chunk at every
@@ -329,8 +335,8 @@ complete frames.
 
 Rule 1 has one non-obvious failure mode after `resize`. The emulated
 grid resizes immediately — but its *content* is still the old frame,
-merely clipped (or reflowed) to the new geometry, until the application
-handles SIGWINCH and repaints. Both halves of this predicate are true of
+merely clipped or padded to the new geometry (the backend reflows
+nothing), until the application handles SIGWINCH and repaints. Both halves of this predicate are true of
 the **stale** frame:
 
 ```rust
@@ -405,9 +411,15 @@ bound (free, within noise), 639ms on the re-read path.
 
 Two limits are documented rather than papered over: history is bounded, so
 a longer run drops its oldest rows; and resize does not reflow, so rows
-keep the width they were captured at. The alternate screen accumulates no
-history at all (vt100 gives the alternate grid none), which is what makes
-retention safe to default on for full-screen TUIs.
+keep the width they were captured at — a decision, recorded on
+`Terminal::resize`, not an omission. History is text with no record of
+which rows were soft-wrapped, so there is nothing to reflow from, and the
+other honest option, discarding history on resize, would cost a suite that
+exercises a responsive layout everything it had asserted on. Rows captured
+after a resize have the new width, so `full_text()` can hold both
+geometries, and says so where a caller meets it. The alternate screen
+accumulates no history at all (vt100 gives the alternate grid none), which
+is what makes retention safe to default on for full-screen TUIs.
 
 ## 3. Snapshot text format (spec)
 
@@ -458,6 +470,14 @@ Rules:
    `(none)`, so the snapshot itself records that styles were asserted.
    Wide-character continuation cells participate in spans like any other
    cell.
+
+   `Screen` itself compares as **the same observation** (`PartialEq`/`Eq`):
+   cells, cursor, size, and every piece of out-of-band state including the
+   cumulative counters. Two visually identical snapshots either side of a
+   bell are unequal, because they are different moments. The text format is
+   deliberately blind to all of that — so comparing `to_string()` output is
+   style-blind, and `with_styles()` is the rendering to compare for "looks
+   the same".
 
 6. **Out-of-band terminal state is not part of the text format.** The
    window title (tracked by termlens itself from `OSC 0`/`OSC 2` — the
@@ -601,6 +621,16 @@ But it is an implementation detail:
 - Known vt100 limits: no reflow of scrollback on resize, and cluster
   handling for exotic emoji is whatever vt100 does (pinned by the
   unicode-torture snapshot rather than promised).
+- vt100 has no character-set handling at all — `ESC ( 0` reaches
+  `unhandled_escape` and is dropped — so **DEC Special Graphics is
+  translated by termlens itself**. The sequence tracker holds the G0/G1
+  designations and the `SI`/`SO` shift, and the emulator asks it, byte by
+  byte and *before* stepping, whether the byte draws as a glyph; if so the
+  glyph is staged in place of the byte and the staged stream is what both
+  parsers receive. Rewriting before either parser is what keeps the primary
+  and the attribute shadow the same shape, exactly as the SGR rewrite does.
+  Scope is deliberately narrow and stated in the README: G0/G1 and the
+  locking shifts, one set translated, everything else read as ASCII.
 
 ### The attribute shadow
 
@@ -664,7 +694,12 @@ call order is a trap.
 Mouse input is **mode-aware**: the emulator knows which tracking mode and
 encoding the application enabled (`?9/?1000/?1002/?1003`, SGR `?1006`),
 `click`/`scroll` encode to match, and no tracking enabled is a typed
-error — never bytes the application would misparse as keys.
+error — never bytes the application would misparse as keys. Modifiers ride
+on the button code the same way for a button and a wheel notch (`+4` shift,
+`+8` alt, `+16` ctrl), so `MouseButton::Left.ctrl()` and `Scroll::Up.ctrl()`
+are one idiom; the wheel gets a chord type of its own (`ScrollChord`) so
+that a wheel direction cannot be handed to `click_with`, since a notch has
+no release and the two are different gestures on the wire.
 
 A **drag reports one motion per cell crossed**, interpolated on a straight
 line and on both axes for a diagonal. A single report at the destination is

--- a/docs/announce-r-rust.md
+++ b/docs/announce-r-rust.md
@@ -75,7 +75,7 @@ pty* because device numbers recycle instantly — termlens serializes pty
 lifecycle edges behind a process-wide lock so your parallel tests don't
 hit it.
 
-Honest limitations (v0.7): Unix only for now (portable-pty supports
+Honest limitations (v0.8): Unix only for now (portable-pty supports
 ConPTY, so Windows is planned); scrollback is retained but bounded, text
 only, and not reflowed on resize; `wait_frame` needs the app to opt into
 DEC 2026; inline graphics are captured and decodable but still never

--- a/fixtures/form-echo/src/main.rs
+++ b/fixtures/form-echo/src/main.rs
@@ -49,8 +49,9 @@ impl Default for App {
     }
 }
 
-/// Stable, greppable one-token description of a key event.
-/// Stable one-token description of a mouse event.
+/// Stable one-token description of a mouse event, with the same
+/// `ctrl+alt+shift+` prefix order keys use — so a modified wheel notch reads
+/// `mouse:ctrl+scrollup:3,2` and an unmodified one exactly as before.
 fn describe_mouse(mouse: &MouseEvent) -> Option<String> {
     let kind = match mouse.kind {
         MouseEventKind::Down(_) => "down",
@@ -59,9 +60,29 @@ fn describe_mouse(mouse: &MouseEvent) -> Option<String> {
         MouseEventKind::ScrollDown => "scrolldown",
         _ => return None,
     };
-    Some(format!("mouse:{kind}:{},{}", mouse.column, mouse.row))
+    let prefix = modifier_prefix(mouse.modifiers);
+    Some(format!(
+        "mouse:{prefix}{kind}:{},{}",
+        mouse.column, mouse.row
+    ))
 }
 
+/// `ctrl+alt+shift+`, for whichever of the three are held.
+fn modifier_prefix(modifiers: KeyModifiers) -> String {
+    let mut prefix = String::new();
+    for (on, name) in [
+        (modifiers.contains(KeyModifiers::CONTROL), "ctrl+"),
+        (modifiers.contains(KeyModifiers::ALT), "alt+"),
+        (modifiers.contains(KeyModifiers::SHIFT), "shift+"),
+    ] {
+        if on {
+            prefix.push_str(name);
+        }
+    }
+    prefix
+}
+
+/// Stable, greppable one-token description of a key event.
 fn describe(key: &KeyEvent) -> String {
     if let KeyCode::Char(c) = key.code {
         if key.modifiers.contains(KeyModifiers::CONTROL) {
@@ -74,18 +95,11 @@ fn describe(key: &KeyEvent) -> String {
     }
     // Special keys: stable "ctrl+alt+shift+name" prefix order. BackTab
     // inherently carries SHIFT; keep its historical bare name.
-    let mut prefix = String::new();
-    if key.code != KeyCode::BackTab {
-        for (on, name) in [
-            (key.modifiers.contains(KeyModifiers::CONTROL), "ctrl+"),
-            (key.modifiers.contains(KeyModifiers::ALT), "alt+"),
-            (key.modifiers.contains(KeyModifiers::SHIFT), "shift+"),
-        ] {
-            if on {
-                prefix.push_str(name);
-            }
-        }
-    }
+    let prefix = if key.code == KeyCode::BackTab {
+        String::new()
+    } else {
+        modifier_prefix(key.modifiers)
+    };
     let name: String = match key.code {
         KeyCode::Enter => "enter".into(),
         KeyCode::Esc => "esc".into(),

--- a/fixtures/form-echo/src/main.rs
+++ b/fixtures/form-echo/src/main.rs
@@ -221,7 +221,17 @@ fn main() -> io::Result<()> {
                 draw(&mut out, &app)?;
                 continue;
             }
-            _ => continue,
+            // Acknowledge a resize on the `last:` line, so a test that resizes
+            // can wait for the application to have handled the SIGWINCH before
+            // sending it anything else. Not decoration: a keystroke arriving
+            // in the same instant as the SIGWINCH can be lost by crossterm's
+            // event reader (see `Terminal::resize`), so a test with nothing
+            // to wait for between the two is a race.
+            Event::Resize(cols, rows) => {
+                app.last = format!("resize:{cols}x{rows}");
+                draw(&mut out, &app)?;
+                continue;
+            }
         };
         if key.kind != KeyEventKind::Press {
             continue;


### PR DESCRIPTION
Closes ten of the twelve open items of the **v0.8** milestone. The two that
are not code changes here — #146 (styled history) and #147 (addressing
history) — are design questions, and each gets a written decision in its
issue once this lands rather than a half-built feature in a release.

## DEC Special Graphics is translated (#179)

`ESC ( 0 l q q q k` is `┌───┐`, and the grid used to say `lqqqk`. That is how
every ncurses application draws its borders (`smacs`/`rmacs` on an xterm
terminfo are exactly `ESC ( 0` / `ESC ( B`), so the crate's own promise —
assert on what a user would *see* — was wrong for a large class of programs,
and wrong in the worse direction too: a snapshot that had blessed `lqqqk` kept
passing after the border broke.

`vt100` drops the designation entirely (`ESC ( 0` reaches `unhandled_escape`),
so the sequence tracker now holds the G0/G1 designations and the `SO`/`SI`
locking shift, and the emulator asks it, byte by byte and **before** stepping,
whether a byte draws as a glyph. If so the glyph is staged in place of the byte
and both parsers receive the staged stream — rewriting before either parser is
what keeps the primary and the attribute shadow the same shape, exactly as the
SGR rewrite does, and the shadow's correspondence check runs on every snapshot.
A stream that never designates a set takes the old slice-through path and pays
nothing.

Scope is stated rather than implied, in the README, `DESIGN.md` and the
CHANGELOG: G0/G1 and the locking shifts only; one set translated; other
designations read as ASCII; G2/G3 and single shifts not modelled; `RIS` returns
both sets to ASCII; `DECSC`/`DECRC` do not save charset state. An `OSC 8` label
written in the graphics set records the glyphs, since the label is what a
reader sees.

## `Terminal::scroll_with` (#174)

`Scroll::{ctrl, alt, shift}` and a `ScrollChord` type, mirroring
`MouseButton`/`MouseChord`; `scroll` is now the unmodified case of it, as
`click` is of `click_with`. The wheel gets a chord type of its own rather than a
wider `MouseChord` so a wheel direction cannot be handed to `click_with` — a
notch has no release, and the type keeps that from being a runtime surprise.
The `form-echo` fixture now names mouse modifiers, so `Ctrl`-wheel is proved
through crossterm's parser and not only through our own table.

## `Screen: PartialEq + Eq` (#183)

Equality is **the same observation**, counters included, and the doc says so —
along with the trap it replaces: comparing `to_string()` is style-blind.

## Waits name scrolled-off history (#203, the diagnostic half of #147)

`wait_until` and `wait_frame` errors, on both the timeout and EOF paths, say
how many rows have scrolled off the top and point at `Screen::full_text`. The
note is conditional on purpose: the predicate is an arbitrary closure, so the
wait cannot know what it was looking for — only what is true. Silent when
nothing has scrolled. `contains` and `find` say where they stop.

## `resize` after exit is refused (#202) — behaviour change

The same `Error::Write` as `send`, on the same evidence (EOF). It used to
succeed and the snapshot then reported a size no application ever rendered at.
Listed under **Changed**. No existing test resized after `wait_exit`.

## The rest

- **#201** `Bitmap::colours` is linear (`HashMap`), ties ordered by first
  appearance on purpose and documented. The timing is not asserted — the issue
  is right that it would flake — but the 512x512 all-distinct case is in the
  suite, and it ran in about 8 s quadratic against milliseconds now.
- **#148** documented as a decision on `resize` and `scrollback_text`, with the
  alternative (discard history on resize) rejected in writing; the two-width
  case is pinned in a test.
- **#198** three doc links, not two: `spawn`'s `# Errors` had the same wrong
  variant.
- **#200** the README mirror snapshots with `insta::assert_snapshot!`; the
  blessed file was read against the `hello-tui` snapshot before acceptance
  (identical grid). It needs no `cfg(feature = "insta")`: `insta` is a
  dev-dependency and is present in every feature configuration, which the
  `--no-default-features` job now proves.
- **#199** CONTRIBUTING's first command is the real full suite, and every CI
  gate is listed inline with `ci.yml` named as the source of truth.
- **`SECURITY.md` claimed the crate has no `unsafe`.** It has two blocks —
  `dup(2)` and `kill(2)` — both audited FFI. The policy now says that.
- `cells_between` uses `i64`: bounded by its callers today, but `d * steps` at
  `u16::MAX` overflows an `i32`, and a helper should hold its own bound.

## Verification

fmt · clippy `-D warnings` in all three feature configurations · **360 tests**
all-features, **340** no-default-features, **358** decode-only (337 on `main`)
· docs `-D warnings`, default and all-features · `cargo deny` · MSRV 1.85 with
`--locked --all-features` · `cargo-semver-checks` against the published 0.7.0:
**no semver update required** (every API change is additive).

Every new guard was mutation-checked — removed in turn, its test went red,
file restored from the commit: charset translation off, `SO` ignored, `RIS`
keeping the graphics set, the history note silenced, `resize` accepting a
departed child, wheel modifiers dropped, and the colours tie order reversed.

## What the stress workflow found

The first stress run on this branch — 100 iterations, ten shards — went **9 of
10 green**. The ubuntu/8-thread shard failed on its first iteration in
`mouse_events_outside_the_grid_are_refused`: a `resize` followed at once by
`Esc`, and the fixture never exited. That test landed in #177 after the last
stress run, so it had never been stressed. It reproduced locally at about one
run in forty.

The cause is in crossterm's event reader, and a real terminal has the same
race. When its poll reports the tty and the `SIGWINCH` fd in the same call,
the signal arm `return`s the `Resize` event at once, abandoning the tty
readiness it was handed — and mio registers edge-triggered (`EPOLLET`,
`EV_CLEAR`), so the `Esc` already in the queue is never offered again until
*more* input arrives. The application blocks in `read()` with the keystroke
behind it.

Fixed in the second commit: `form-echo` acknowledges a resize on its `last:`
line, the test waits for that frame before sending `Esc`, and
`Terminal::resize` documents the trap so a user's own test does not walk into
it.

## …and then a real bug in `resize`

The second stress run went 9 of 10 again, now failing at 16 threads on
iteration 21 — at the new `wait_frame` for the acknowledgement. The error was
telling: the live screen showed `last: resize:18x4`, so the fixture *had*
repainted, yet the wait reported no repaint since the cursor. `resize` sent the
`SIGWINCH` first and took the frame cursor **afterwards**; a fast application's
acknowledging repaint could complete, and be counted, in that gap — so the one
frame the wait had been promised sat behind the cursor. The doc's guarantee
("only a frame completed after the resize can satisfy the wait") was inverted
by the ordering. Worse, such a frame was rendered into the *old* grid and then
clipped.

Fixed in the third commit: the grid is resized and the cursor taken **before**
the ioctl, all under one state lock, so no byte is processed between the two
steps; if the ioctl fails the grid is restored so kernel and grid never
disagree. A new test in `frames.rs` resizes three times and requires each
acknowledging frame to be offered *and* to carry the new size. Listed under
**Fixed** in the CHANGELOG — this one affected users, not just our suite.

Verified with 40 iterations each of the input and frames suites and 12 of the
whole workspace, all at 16 threads, no failure — and the stress workflow is
running again on the final commit; the release PR will cite that run.
