### PR TITLE
release: v0.8.0 — line drawing, the wheel's modifiers, and honest history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-29
+
 ### Added
 
 - **DEC Special Graphics is translated, so an ncurses border reads as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "crossterm",
 ]
@@ -181,14 +181,14 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "crossterm",
 ]
 
 [[package]]
 name = "image-echo"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "miniz_oxide",
 ]
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "crossterm",
 ]
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -611,7 +611,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.


### PR DESCRIPTION
Version bump and CHANGELOG move for **v0.8.0**. No code changes — everything
below landed in #204.

## What ships

| | |
|---|---|
| **Added** | DEC Special Graphics translated (`ESC ( 0`, `SO`/`SI`) — ncurses borders read as `┌───┐`; `Terminal::scroll_with` with `Scroll::{ctrl,alt,shift}` and `ScrollChord`; `Screen: PartialEq + Eq`; waits name scrolled-off history and point at `full_text` |
| **Changed** | `resize` is refused once the child has released the terminal, like `send` |
| **Fixed** | `wait_frame` after `resize` no longer misses the repaint that answered it; `Bitmap::colours` linear with a defined tie order; `resize` documents the resize-then-type trap and that history keeps its captured width; doc links name `Error::Size` |
| **Security** | `SECURITY.md` names the two `unsafe` FFI calls instead of claiming there are none |

## Step 0 of docs/RELEASING.md

The stress workflow ran on the final code commit `103c413`: **100 iterations
across ten shards, Linux and macOS, all green** ([run](https://github.com/vyncint/termlens/actions/runs/33226286392)). It earned
its keep on this branch: the first run found the resize-then-type race in
crossterm's edge-triggered reader (a test fix plus documentation), and the
second found that `resize` took the frame cursor after sending the `SIGWINCH`,
so a fast application's acknowledging repaint could be counted as pre-resize
and never offered to `wait_frame` — a real bug, fixed in #204. Locally on the
final code: 40 iterations each of the input and frames suites and 12 of the
whole workspace at 16 threads, no failure.

## Gates on this commit

fmt · clippy `-D warnings` in all three feature configurations · **361 tests**
all-features · **342** no-default-features · **360** decode-only · docs
`-D warnings` · MSRV 1.85 `--locked --all-features` · `cargo deny` ·
`cargo-semver-checks` against the published 0.7.0: **no semver update
required** — every API change is additive, and the behaviour change on
`resize` is listed under Changed.

## Dogfood

mossaic, the most demanding consumer, against this tree through a temporary
`[patch.crates-io]` (never committed): **213 tests, all green**, with
`cargo tree` confirming the path dependency resolved.

## Checked by hand

Every constant the docs quote was verified against the code: scrollback,
frames, timings, the reply cap, OSC capture, DCS header, link log and label
bounds, graphics capture, the decode ceiling, the MSRV, and the new charset
scope statement. `extract-changelog.sh 0.8.0` on the moved section finds
**13 entries**, which is what the GitHub Release notes will carry.
