### PR TITLE
fix(ci): run install check after releases

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -25,6 +25,12 @@ name: install
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to verify (default: the release tag or newest published)"
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -58,7 +64,11 @@ jobs:
         run: |
           api="https://crates.io/api/v1/crates/termlens"
           agent="termlens-install-check (github actions)"
-          version="${WANTED:-${TAG#v}}"
+          # A reusable caller has the release tag available, while a manual
+          # dispatch accepts either a tag or the crate version. Normalize both
+          # before querying crates.io.
+          version="${WANTED#v}"
+          version="${version:-${TAG#v}}"
           if [ -z "$version" ]; then
             version=$(curl -sSf -H "User-Agent: $agent" "$api" | jq -r .crate.max_stable_version)
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,16 @@ jobs:
             --notes-file "$RUNNER_TEMP/notes.md" \
             --verify-tag
 
+
+  # Releases created with GITHUB_TOKEN do not emit a release event that can
+  # start another workflow. Call the consumer check directly after publishing
+  # the GitHub release so every tag verifies what crates.io serves.
+  install:
+    name: verify published crate
+    needs: github-release
+    uses: ./.github/workflows/install.yml
+    with:
+      version: ${{ github.ref_name }}
   # Tell the repository that tests this tool against a real subject that a
   # new version exists, so the deep run happens now rather than at its next
   # scheduled tick.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -48,7 +48,9 @@ Pushing the tag runs `release.yml`, which:
 4. `cargo publish -p termlens` via Trusted Publishing (OIDC) — the
    repository stores no tokens,
 5. creates the GitHub Release with notes extracted from the CHANGELOG
-   section for that version (`.github/scripts/extract-changelog.sh`).
+   section for that version (`.github/scripts/extract-changelog.sh`), and
+6. runs the registry-consumer check against that published version on Linux
+   and macOS.
 
 ## If something fails mid-release
 


### PR DESCRIPTION
## Summary

- make the registry-consumer workflow callable from the release pipeline
- run it after the GitHub Release is created, instead of relying on an event emitted by GITHUB_TOKEN
- normalize a reusable caller's X.Y.Z tag before querying crates.io

Closes #206.

## Verification

- cargo test --workspace --all-features --lib
- cargo fmt --all -- --check
- git diff --check
- .github/scripts/check-dco.sh origin/main..HEAD
- .github/scripts/check-no-ai-attribution.sh origin/main..HEAD

Not run locally: the pinned zizmor audit, because this environment does not provide pipx; CI runs that audit at the repository's configured pedantic level.