### PR TITLE
ci: disable scheduled workflow runs

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -36,8 +36,9 @@ on:
       version:
         description: "Version to verify (default: the newest published)"
         required: false
-  schedule:
-    - cron: "37 7 * * 1" # Mondays, after the stress run
+  # Scheduled runs are disabled. Uncomment the block below to restore them.
+  # schedule:
+  #   - cron: "37 7 * * 1" # Mondays, after the stress run
 
 permissions:
   contents: read

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -45,8 +45,9 @@ on:
         description: Full-suite iterations per OS, split across the shards
         required: false
         default: "100"
-  schedule:
-    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  # Scheduled runs are disabled. Uncomment the block below to restore them.
+  # schedule:
+  #   - cron: "17 6 * * 1" # Mondays 06:17 UTC
 
 permissions:
   contents: read


### PR DESCRIPTION
## What & why

Nothing in this repository runs on a cron any more. The `schedule:` block is
commented out in every workflow that had one:

- `install.yml` (`37 7 * * 1`)
- `stress.yml` (`17 6 * * 1`)

Every other trigger is untouched — `push`, `pull_request`, `release`,
`workflow_dispatch` and `repository_dispatch` all behave exactly as before.
The cron expressions are kept as comments rather than deleted, so restoring a
schedule is uncommenting one block, and the reasoning behind each chosen time
stays next to it.

Comments and prose that stated a cadence as *current behaviour* are corrected
in the same commit. Prose explaining *why a cadence was chosen* is left alone —
it still explains the block sitting right there, commented out.

### What this does not do

- No `CHANGELOG.md` entry: nothing here is user-facing.
- No tests: this is workflow configuration, and its only real check is that
  the YAML still parses and every workflow keeps at least one trigger. Both
  were verified before pushing.
- Dependabot's weekly schedule is left alone — it is dependency management,
  not CI.

## Checklist

- [x] No issue linked — this is a direct maintainer request, not a tracked bug
- [ ] Tests added/updated — n/a, workflow configuration only
- [x] No Rust changed, so fmt/clippy are unaffected
- [x] **All commits are signed off**
- [x] **No AI attribution trailers**
- [ ] `CHANGELOG.md` — n/a, not user-facing
- [x] No snapshots touched
