### PR TITLE
ci: let Dependabot pass the commit policy

### DIFF
--- a/.github/scripts/check-no-ai-attribution.sh
+++ b/.github/scripts/check-no-ai-attribution.sh
@@ -15,6 +15,17 @@
 #         actions@github.com emails
 #       - names containing claude/copilot/devin/aider/codex/gemini
 #
+# One carve-out, and only from the identity rules: a named dependency bot.
+# The policy exists so that a human is not displaced as the author of record,
+# and a dependency bump has no human author to displace — Dependabot is not an
+# assistant that helped somebody write something, it is the whole author. The
+# message rules still apply to its commits in full, so a bot cannot carry an
+# AI co-author trailer or a "Generated with" watermark in past this.
+#
+# It is a hygiene guard, not a security boundary: anyone can set an author
+# email locally. What stops a forged one is that it still has to survive
+# review and a merge, which is where attribution is actually judged.
+#
 # Usage:
 #   .github/scripts/check-no-ai-attribution.sh <base>..<head>
 #
@@ -24,6 +35,12 @@
 #   git commit --allow-empty -s -m "test: bad commit" \
 #     -m "Co-Authored-By: Example Bot <example[bot]@users.noreply.github.com>"
 #   .github/scripts/check-no-ai-attribution.sh main..HEAD  # must fail once
+#   # and the dependency-bot carve-out, which must pass on identity but still
+#   # fail on a watermark in the message:
+#   git -c user.name='dependabot[bot]' \
+#       -c user.email='49699333+dependabot[bot]@users.noreply.github.com' \
+#       commit --allow-empty -m "build(deps): bump x" -m "Signed-off-by: dependabot[bot] <support@github.com>"
+#   .github/scripts/check-no-ai-attribution.sh main..HEAD  # still just the one failure
 #   git checkout - && git branch -D scratch/attribution
 set -euo pipefail
 
@@ -41,6 +58,13 @@ msg_patterns=(
 # Identity patterns (ERE). Emails are lowercased before matching.
 email_pattern='(\[bot\]@users\.noreply\.github\.com$|@noreply\.anthropic\.com$|^actions@github\.com$)'
 name_pattern='\b(claude|copilot|devin|aider|codex|gemini)\b'
+
+# Automation identities exempt from the *identity* rules above (never from the
+# message rules). Anchored at both ends and matched against the whole
+# lowercased address: a substring rule here would be a hole a crafted local
+# part could walk through. Matched by name rather than by GitHub's numeric user
+# id, so the exemption survives an id change; add another bot by naming it.
+trusted_bot_emails='^([0-9]+\+)?(dependabot|dependabot-preview)\[bot\]@users\.noreply\.github\.com$'
 
 fail=0
 count=0
@@ -66,6 +90,11 @@ while IFS= read -r sha; do
     else
       name="$(git log -1 --format='%cn' "$sha")"
       email="$(git log -1 --format='%ce' "$sha")"
+    fi
+    # Skip the identity rules for a named dependency bot in this role. The
+    # message rules ran above and applied to this commit like any other.
+    if printf '%s\n' "$email" | tr '[:upper:]' '[:lower:]' | grep -Eq "$trusted_bot_emails"; then
+      continue
     fi
     if printf '%s\n' "$email" | tr '[:upper:]' '[:lower:]' | grep -Eq "$email_pattern"; then
       echo "::error::Commit ${sha} ${role} email '${email}' is a bot/vendor identity."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ and says so in its CONTRIBUTING. Use whatever helps.
 
 - no `Co-Authored-By:` trailer naming an assistant, a model, or a vendor,
 - no "Generated with …" footer, no robot emoji,
-- no bot account as author or committer.
+- no bot account as author or committer — save a named dependency bot, which
+  is exempt from the identity rule only and still checked on its message.
 
 The human who opens the pull request is the author of record and takes
 responsibility for the change under the DCO. That is what the sign-off

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,9 +131,10 @@ agents on the layout, the commands, and the house style.
 
 **AI attribution is not welcome.** No `Co-Authored-By` trailer naming an
 assistant, model or vendor; no "Generated with …" footer; no robot emoji; no
-bot identity as author or committer. Whoever opens the pull request is the
-author of record, takes responsibility under the DCO, and the history should
-say so — a tool cannot certify the DCO, which is the whole point of it.
+bot identity as author or committer, save the one carve-out below. Whoever
+opens the pull request is the author of record, takes responsibility under the
+DCO, and the history should say so — a tool cannot certify the DCO, which is
+the whole point of it.
 
 This is enforced, not requested: `commit-policy.yml` runs
 [`check-no-ai-attribution.sh`](.github/scripts/check-no-ai-attribution.sh) and
@@ -156,6 +157,15 @@ git push --force-with-lease
 `.claude/settings.json` turns co-author trailers off for agents that read
 repository settings. That is a courtesy; the check in CI is the boundary.
 Contributions authored *by* an autonomous account are not accepted.
+
+**One carve-out: a named dependency bot.** Dependabot is exempt from the
+*identity* half of the check and from nothing else. The rule exists so that a
+human is not displaced as the author of record, and a version bump has no
+human to displace — it is not somebody's work with the credit misassigned. The
+message rules still apply in full, so a bot cannot carry an AI co-author
+trailer, a "Generated with" footer or a robot emoji past the check either.
+Adding another bot means naming it in `check-no-ai-attribution.sh`: the
+allowlist is a list on purpose, so that widening it is a visible decision.
 
 ## 7. PR flow
 


### PR DESCRIPTION
## What & why

Every Dependabot pull request in this ecosystem has failed `commit-policy`.
All four ever opened did; two of them (mossaic#74, reconverge#84) were merged
with the check red.

`check-no-ai-attribution.sh` rejects any author or committer whose email ends
`[bot]@users.noreply.github.com`, and Dependabot authors as
`49699333+dependabot[bot]@users.noreply.github.com`.

That rule exists so a human is not displaced as the author of record. A version
bump has no human to displace — it is not somebody's work with the credit
misassigned — so a named dependency bot is now exempt from the **identity**
half of the check and from nothing else. The message rules still apply to its
commits in full: a bot cannot carry an AI co-author trailer, a "Generated …"
footer or a robot emoji past this.

The allowlist matches Dependabot by name rather than by GitHub's numeric user
id, anchored at both ends of the whole address, so a crafted local part such as
`evil+dependabot[bot]@users.noreply.github.com` is still rejected. It is a
hygiene guard rather than a security boundary — anyone can set an author email
locally — and what actually stops a forged one is review before merge.

### The generated files

`AGENTS.md` and `CONTRIBUTING.md` §6 are **generated** from the private
ecosystem repository and were not edited here by hand — they come from
`tools/gen_agents.py` and `tools/gen_contributing.py`, so the documented
policy matches the enforced one. The ecosystem-side change lands
separately; this pull request carries its output.

### Tested

`tools/test-policy-scripts.sh` in the ecosystem repository is new, and runs
both scripts over commits crafted to sit on each side of every rule. Half the
cases are expected failures, so a rule that stops firing shows up as a case
that unexpectedly passes.

Against the copy in this pull request: **14/14**, including

- dependabot clean commit — passes (this is the fix; it failed before)
- dependabot + "Generated …" / AI co-author / robot emoji — still fails
- an unnamed `[bot]` address — still fails
- `evil+dependabot[bot]@users.noreply.github.com` — still fails
- an AI author name, an `@noreply.anthropic.com` address — still fail

Behaviour was diffed against the previous script over the same cases: the only
two that change are the two Dependabot ones.

### What this does not do

- No `CHANGELOG.md` entry: nothing here is user-facing.
- Dependabot's own `dependabot.yml` schedule is untouched.
- I did not re-run the already-closed Dependabot pull requests; they will need
  a rebase or reopen to pick this up.

## Checklist

- [x] No issue linked — direct maintainer request
- [x] Tested, and the tests can fail — see above
- [x] No Rust changed, so fmt/clippy are unaffected
- [x] **All commits are signed off**
- [x] **No AI attribution trailers**
- [ ] `CHANGELOG.md` — n/a, not user-facing
