### PR TITLE
ci: let a squashed Dependabot merge pass on main

### DIFF
--- a/.github/scripts/check-no-ai-attribution.sh
+++ b/.github/scripts/check-no-ai-attribution.sh
@@ -15,7 +15,8 @@
 #         actions@github.com emails
 #       - names containing claude/copilot/devin/aider/codex/gemini
 #
-# One carve-out, and only from the identity rules: a named dependency bot.
+# One carve-out: a named dependency bot, from the identity rules and from a
+# co-author trailer naming itself (which GitHub writes into a squash message).
 # The policy exists so that a human is not displaced as the author of record,
 # and a dependency bump has no human author to displace — Dependabot is not an
 # assistant that helped somebody write something, it is the whole author. The
@@ -66,19 +67,31 @@ name_pattern='\b(claude|copilot|devin|aider|codex|gemini)\b'
 # id, so the exemption survives an id change; add another bot by naming it.
 trusted_bot_emails='^([0-9]+\+)?(dependabot|dependabot-preview)\[bot\]@users\.noreply\.github\.com$'
 
+# The same addresses as they appear inside a trailer. GitHub composes a
+# squash-merge message itself and appends a Co-authored-by naming the pull
+# request's author — so a Dependabot pull request that passed this check
+# lands on main carrying `Co-authored-by: dependabot[bot] <...>`, and `bot`
+# is in the vendor list above. The very commit the carve-out exists to permit
+# would fail, on main, after passing on the branch, and main cannot be
+# repaired. Such a trailer is dropped before the message rules are matched;
+# every other co-author trailer is matched exactly as before.
+trusted_bot_coauthor='^co-authored-by:[[:space:]]*[^<]*<([0-9]+\+)?(dependabot|dependabot-preview)\[bot\]@users\.noreply\.github\.com>[[:space:]]*$'
+
 fail=0
 count=0
 while IFS= read -r sha; do
   count=$((count + 1))
   msg="$(git log -1 --format='%B' "$sha")"
+  # Everything except a co-author trailer naming an allowlisted bot.
+  msg_scan="$(printf '%s\n' "$msg" | grep -viE "$trusted_bot_coauthor" || true)"
 
   for pat in "${msg_patterns[@]}"; do
-    if printf '%s\n' "$msg" | grep -Eiq "$pat"; then
+    if printf '%s\n' "$msg_scan" | grep -Eiq "$pat"; then
       echo "::error::Commit ${sha} message matches banned pattern: ${pat}"
       fail=1
     fi
   done
-  if printf '%s\n' "$msg" | grep -Fq '🤖'; then
+  if printf '%s\n' "$msg_scan" | grep -Fq '🤖'; then
     echo "::error::Commit ${sha} message contains a robot-emoji watermark."
     fail=1
   fi


### PR DESCRIPTION
## What & why

Merging a Dependabot pull request turns `main` red, even though the pull
request itself is green. simt-diff hit this at
[`52cc142`](https://github.com/vyncint/simt-diff/commit/52cc1428425d87dcc6ac5fbf64bcdbb8cb83225c)
minutes after the carve-out landed.

GitHub composes the squash-merge message itself and appends a co-author
trailer naming the pull request's author. For a Dependabot pull request that
trailer names `dependabot[bot]`, at
`49699333+dependabot[bot]@users.noreply.github.com` — and `bot` is in the
vendor list the message rules match against, so the rule fires.

The identity carve-out did not help: this is the *message* half, which was left
strict on purpose. The result is the worst shape available — the commit passes
on the branch, fails on `main`, and `main` is linear and non-fast-forward, so
it cannot be repaired. Exactly the failure `check-dco.sh` already carries a
composed-squash exemption for.

A co-author trailer naming an allowlisted dependency bot is now dropped before
the message rules are matched. Every other such trailer is matched exactly as
before, and the rest of the message — watermarks, robot emoji, any other
vendor — is still matched in full, including on the bot's own commits.

### Tested

`tools/test-policy-scripts.sh` gains three cases. Run against the **current**
script they reproduce the bug; against this one, 17/17:

- a GitHub-composed squash naming dependabot as co-author — passes (the fix)
- the same shape naming an AI vendor — still fails
- the same shape naming an unallowlisted `other[bot]` — still fails

Also run against the real commit that turned simt-diff's `main` red: rejected
by the current script, accepted by this one.

### What this does not do

- No `CHANGELOG.md` entry: not user-facing.
- Does not repair simt-diff's existing red commit on `main`; that run stays
  red in history and goes green on the next push.

## Checklist

- [x] No issue linked — follow-up to the Dependabot carve-out
- [x] Tested, and the tests can fail — they fail against the current script
- [x] No Rust changed
- [x] **All commits are signed off**
- [x] **No AI attribution trailers**
