### PR TITLE
fix: the 0.8.0 audit — seventeen issues from milestone v0.9

### DIFF
--- a/.github/scripts/check-ci-gates-listed.sh
+++ b/.github/scripts/check-ci-gates-listed.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Every gate CI runs must appear in CONTRIBUTING.md §1's "run these before
+# pushing" block. The paragraph under that block promises the workflow is
+# the source of truth when the two disagree; this is what makes the promise
+# hold. Usage: check-ci-gates-listed.sh [ci.yml] [CONTRIBUTING.md]
+set -euo pipefail
+
+ci="${1:-.github/workflows/ci.yml}"
+doc="${2:-CONTRIBUTING.md}"
+
+# Single-line `- run: cargo …` steps are the reproducible gates. Multi-line
+# `run: |` blocks are job plumbing (the msrv assertion, the zizmor retry,
+# required-green's jq) and are not something a contributor types.
+ci_cmds="$(sed -n 's/^[[:space:]]*- run: \(cargo .*\)$/\1/p' "$ci" | sed -E 's/[[:space:]]+/ /g')"
+
+# CONTRIBUTING §1: every ```sh block between "## 1." and "## 2.", comments
+# stripped, the RUSTDOCFLAGS prefix and a `+toolchain` selector removed —
+# `cargo +1.85 check` in the doc is `cargo check` under RUSTUP_TOOLCHAIN
+# in the workflow. Extended regex throughout: BSD sed has no \\+ in basic.
+doc_cmds="$(awk '/^## 1\./{s=1} /^## 2\./{s=0} s' "$doc" \
+  | awk '/^```/{f=!f; next} f' \
+  | sed -E -e 's/#.*$//' \
+           -e "s/^RUSTDOCFLAGS='-D warnings' //" \
+           -e 's/^cargo \+[^ ]+ /cargo /' \
+           -e 's/[[:space:]]+/ /g' -e 's/^ //' -e 's/ $//' \
+  | grep -v '^$')"
+
+status=0
+while IFS= read -r cmd; do
+  [ -z "$cmd" ] && continue
+  if ! grep -Fxq -- "$cmd" <<<"$doc_cmds"; then
+    echo "::error::CI runs \`$cmd\` but CONTRIBUTING.md §1 does not list it"
+    status=1
+  fi
+done <<<"$ci_cmds"
+
+# zizmor is pinned in the workflow; the doc must name the same pin.
+pin="$(grep -o 'zizmor==[0-9.]*' "$ci" | head -1)"
+if [ -n "$pin" ] && ! grep -Fq -- "$pin" "$doc"; then
+  echo "::error::CI pins \`$pin\` but CONTRIBUTING.md names a different zizmor, or none"
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "every CI gate is listed in CONTRIBUTING.md §1 ($(grep -c . <<<"$ci_cmds") commands, $pin)"
+fi
+exit "$status"

--- a/.github/scripts/check-dco.sh
+++ b/.github/scripts/check-dco.sh
@@ -24,6 +24,9 @@
 #       -m "test: composed (#1)"
 #   .github/scripts/check-dco.sh main..HEAD            # must fail
 #   .github/scripts/check-dco.sh main..HEAD "$(git rev-parse HEAD)"  # passes
+#   # and a range git cannot read must FAIL, never report OK on nothing:
+#   .github/scripts/check-dco.sh main..deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+#   .github/scripts/check-dco.sh HEAD..HEAD
 #   git checkout - && git branch -D scratch/dco
 set -euo pipefail
 
@@ -34,6 +37,21 @@ composed="${2:-}"
 # which exempts nothing.
 if [ -n "$composed" ]; then
   composed="$(git rev-parse --verify --quiet "${composed}^{commit}" || true)"
+fi
+
+# Read the range before walking it. A process substitution hides git's exit
+# status, so a range git could not resolve — a shallow clone with no base, an
+# event whose sha is gone, a typo — used to run the loop over nothing and
+# report OK on commits that were never read (termlens#214). Both halves are
+# errors: an unresolvable range, and a range with no commits in it.
+if ! shas="$(git rev-list --no-merges "$range")"; then
+  echo "::error::check-dco: could not resolve the commit range '${range}' —" \
+       "refusing to report a pass on commits that were never read"
+  exit 1
+fi
+if [ -z "$shas" ]; then
+  echo "::error::check-dco: the range '${range}' resolved to no commits"
+  exit 1
 fi
 
 fail=0
@@ -97,7 +115,7 @@ while IFS= read -r sha; do
          "'git rebase --signoff' for a branch, then force-push."
     fail=1
   fi
-done < <(git rev-list --no-merges "$range")
+done <<<"$shas"
 
 echo "check-dco: inspected ${count} commit(s) in ${range}"
 if [ "$fail" -ne 0 ]; then

--- a/.github/scripts/check-no-ai-attribution.sh
+++ b/.github/scripts/check-no-ai-attribution.sh
@@ -43,6 +43,9 @@
 #       commit --allow-empty -m "build(deps): bump x" -m "Signed-off-by: dependabot[bot] <support@github.com>"
 #   .github/scripts/check-no-ai-attribution.sh main..HEAD  # still just the one failure
 #   git checkout - && git branch -D scratch/attribution
+#   # and a range git cannot read must FAIL, never report OK on nothing:
+#   .github/scripts/check-no-ai-attribution.sh main..deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+#   .github/scripts/check-no-ai-attribution.sh HEAD..HEAD
 set -euo pipefail
 
 range="${1:?usage: check-no-ai-attribution.sh <range>}"
@@ -76,6 +79,21 @@ trusted_bot_emails='^([0-9]+\+)?(dependabot|dependabot-preview)\[bot\]@users\.no
 # repaired. Such a trailer is dropped before the message rules are matched;
 # every other co-author trailer is matched exactly as before.
 trusted_bot_coauthor='^co-authored-by:[[:space:]]*[^<]*<([0-9]+\+)?(dependabot|dependabot-preview)\[bot\]@users\.noreply\.github\.com>[[:space:]]*$'
+
+# Read the range before walking it. A process substitution hides git's exit
+# status, so a range git could not resolve — a shallow clone with no base, an
+# event whose sha is gone, a typo — used to run the loop over nothing and
+# report OK on commits that were never read (termlens#214). Both halves are
+# errors: an unresolvable range, and a range with no commits in it.
+if ! shas="$(git rev-list "$range")"; then
+  echo "::error::check-no-ai-attribution: could not resolve the commit range '${range}' —" \
+       "refusing to report a pass on commits that were never read"
+  exit 1
+fi
+if [ -z "$shas" ]; then
+  echo "::error::check-no-ai-attribution: the range '${range}' resolved to no commits"
+  exit 1
+fi
 
 fail=0
 count=0
@@ -118,7 +136,7 @@ while IFS= read -r sha; do
       fail=1
     fi
   done
-done < <(git rev-list "$range")
+done <<<"$shas"
 
 echo "check-no-ai-attribution: inspected ${count} commit(s) in ${range}"
 if [ "$fail" -ne 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,19 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --all-features
 
-  no-default-features:
-    name: no-default-features
+  # Every feature configuration a consumer can ask for. The default set is
+  # what `cargo add termlens --dev` produces, and until #226 no job ran it:
+  # `test` runs --all-features and this job ran only the two reduced sets.
+  # Additivity makes a gap there unlikely, not impossible, and the cell
+  # costs about ninety seconds.
+  #
+  # Priced and deferred, deliberately (#226): the default set on the macOS
+  # leg — a second full suite per PR for a fault class the stress workflow
+  # is better placed to find — and a --no-default-features consumer in
+  # install.yml, which would need the registry step there to stop assuming
+  # `decode`.
+  features:
+    name: features
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -73,9 +84,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
+          components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --no-default-features
       - run: cargo test --workspace --no-default-features --features decode
+      - run: cargo test --workspace
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  # CONTRIBUTING §1 promises that every gate above is reproducible locally
+  # and that the workflow is the source of truth when the two disagree. It
+  # disagreed twice before anyone noticed (#227); this is the check that
+  # makes the promise hold.
+  gates-listed:
+    name: gates-listed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - run: .github/scripts/check-ci-gates-listed.sh
 
   msrv:
     name: msrv
@@ -170,7 +197,7 @@ jobs:
   required-green:
     name: required-green
     if: always()
-    needs: [fmt, clippy, test, no-default-features, msrv, docs, deny, zizmor]
+    needs: [fmt, clippy, test, features, msrv, docs, deny, zizmor, gates-listed]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every needed job succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,24 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: cargo check --workspace --locked
+      # rust-toolchain.toml pins stable so that fmt and clippy output is
+      # reproducible, and rustup honours that file over the `rustup default`
+      # the action above sets — so this job installed 1.85 and then ran
+      # stable (#213). RUSTUP_TOOLCHAIN outranks the file, and the assertion
+      # makes the no-op impossible to bring back quietly.
+      - name: Assert the MSRV toolchain is the one in use
+        env:
+          MSRV: ${{ steps.msrv.outputs.msrv }}
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.msrv }}
+        run: |
+          rustc -vV
+          rustc -vV | grep -q "^release: ${MSRV}" \
+            || { echo "::error::the msrv job is not running rustc ${MSRV}"; exit 1; }
+      # --all-targets: tests and examples compile against the same floor,
+      # so they are part of the claim. Passes at 1.85 today without a bump.
+      - run: cargo check --workspace --locked --all-targets
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.msrv }}
 
   docs:
     name: docs

--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -47,6 +47,14 @@ jobs:
           AFTER: ${{ github.event.after }}
         run: |
           if [ "$EVENT" = "pull_request" ]; then
+            # Both ends must be readable here, or the range is not a range:
+            # a sha this checkout does not have made the scripts walk nothing
+            # and report OK on commits they never read (#214). The scripts
+            # now refuse that too; this names the missing commit first.
+            for sha in "$BASE" "$HEAD"; do
+              git cat-file -e "$sha" 2>/dev/null \
+                || { echo "::error::commit $sha is not in this checkout, so the range cannot be checked"; exit 1; }
+            done
             range="${BASE}..${HEAD}"
           elif [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
                || ! git cat-file -e "$BEFORE" 2>/dev/null; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,32 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Added
+
+- **`Error::Emulator`: an emulator panic is a diagnosis, not a timeout.** The
+  emulation runs on the reader thread, so a panic there propagated nowhere —
+  the drain died, the screen froze, and every wait burned its full deadline
+  reporting a predicate that could never come true. The reader now catches it,
+  records it, and keeps draining (a stalled drain blocks the child writing
+  into a full buffer); `wait_until`, `wait_frame` and `wait_idle` fail at once
+  with the emulator's own message and the last screen taken before the
+  failure. The emulator is never asked for a screen again — after a panic its
+  state means nothing. `wait_exit` is deliberately unaffected: the child's
+  exit status is still true. (#211)
+
 ### Changed
+
+- **The smallest terminal is 2x2, not 1x1.** One column panics the emulator on
+  a double-width character, and one row panics it on a line that *wraps* — on
+  the reader thread, in both profiles, where the panic propagates nowhere: the
+  grid froze, every later wait ran to its deadline against a plausible-looking
+  screen, and `cargo test` printed `test result: ok` over a suite that had
+  stopped testing anything. `80x1` is an ordinary shape, not an exotic one.
+  `spawn` and `resize` now refuse a dimension below 2 with `Error::Size`, the
+  way they already refused 0 — #49's "no path can reach the emulator with a
+  zero" was satisfied exactly one value too low. `2x8` and `2x2` render both
+  trigger shapes correctly, so the floor is the smallest guard that closes
+  them. (#211)
 
 - **A child starts in the test process's working directory, not `$HOME`.**
   Without `current_dir` the PTY layer fell back to the home directory, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ listed under a **Changed** or **Removed** heading.
   different shells. `SHELL=/bin/sh` is now pinned under `env_clear` the way
   `TERM` is, an explicit `.env("SHELL", …)` still wins, and a test asserts
   the whole environment rather than probing one name. (#221)
+- **A bare program name under `env_clear()` is refused with the remedies.**
+  Clearing the environment removes `PATH`, so `spawn("sh")` could not
+  resolve and failed with the PTY layer's "Unable to resolve the PATH",
+  which named neither the cause nor a way out. `spawn` now refuses it up
+  front with an `Error::Spawn` that says `env_clear` removed `PATH` and
+  offers both fixes: an absolute path, or `.env("PATH", …)`. (#222)
 - **A highlight over CJK or emoji is one span again.** A wide character's
   continuation column carried no style, so `with_styles()` rendered a bar
   over `ab汉cd` as two spans with a hole and `cell(row, col).style()` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`find` no longer matches the blank padding past the end of a row.** Its
+  single-row path searched the row padded out to the terminal width while
+  `contains` searched the trimmed text, so `find("Total: ")` was `Some` on
+  a screen whose row read `Total:` — against the invariant both rustdocs
+  state, that a needle is found precisely when `contains` is true. Both now
+  trim trailing whitespace per row first; the trim treats a drawn trailing
+  U+00A0/U+3000 as padding too, and both rustdocs say so. (#212)
+
 ## [0.8.0] - 2026-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Changed
+
+- **A child starts in the test process's working directory, not `$HOME`.**
+  Without `current_dir` the PTY layer fell back to the home directory, so a
+  relative `spawn()` path and a directory-sensitive program behaved unlike
+  every other Rust process API — while `current_dir`'s rustdoc promised the
+  test runner's directory all along. The default is now what
+  `std::process::Command` does; `current_dir` still overrides it. A test that
+  relied on the old fallback should say `.current_dir(std::env::home_dir())`
+  explicitly. (#215)
+
 ### Fixed
 
 - **`find` no longer matches the blank padding past the end of a row.** Its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ listed under a **Changed** or **Removed** heading.
   state, that a needle is found precisely when `contains` is true. Both now
   trim trailing whitespace per row first; the trim treats a drawn trailing
   U+00A0/U+3000 as padding too, and both rustdocs say so. (#212)
+- **A highlight over CJK or emoji is one span again.** A wide character's
+  continuation column carried no style, so `with_styles()` rendered a bar
+  over `ab汉cd` as two spans with a hole and `cell(row, col).style()` on
+  the second column reported `Default` — DESIGN §3 rule 5 and `find_by`'s
+  rustdoc both promised the opposite. The snapshot now gives the
+  continuation the leading cell's style, as a terminal paints it. (#218)
 
 ## [0.8.0] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ listed under a **Changed** or **Removed** heading.
   which named neither the cause nor a way out. `spawn` now refuses it up
   front with an `Error::Spawn` that says `env_clear` removed `PATH` and
   offers both fixes: an absolute path, or `.env("PATH", …)`. (#222)
+- **A byte that is not UTF-8 shows as U+FFFD instead of vanishing.** The
+  backend drops both a byte it cannot decode and the U+FFFD its own parser
+  substitutes for one, so a Latin-1 `é` in a file name left no trace on the
+  grid and every column after it shifted left — a test asserting on the
+  column of what followed passed against the wrong screen. Bytes are now
+  decoded once on the reader thread: an invalid sequence becomes the
+  replacement character a terminal shows (carried through the backend as a
+  noncharacter it will draw, and restored in the snapshot), and a character
+  split across two reads is carried rather than replaced. `wait_idle` treats
+  a stream that stopped mid-character as not yet idle. (#217)
 - **A highlight over CJK or emoji is one span again.** A wide character's
   continuation column carried no style, so `with_styles()` rendered a bar
   over `ab汉cd` as two spans with a hole and `cell(row, col).style()` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ listed under a **Changed** or **Removed** heading.
   state, that a needle is found precisely when `contains` is true. Both now
   trim trailing whitespace per row first; the trim treats a drawn trailing
   U+00A0/U+3000 as padding too, and both rustdocs say so. (#212)
+- **`env_clear()` no longer leaks the machine's login shell.** The PTY layer
+  fills `SHELL` from the host when the variable is absent, so a child's
+  supposedly hermetic environment differed between two machines with
+  different shells. `SHELL=/bin/sh` is now pinned under `env_clear` the way
+  `TERM` is, an explicit `.env("SHELL", …)` still wins, and a test asserts
+  the whole environment rather than probing one name. (#221)
 - **A highlight over CJK or emoji is one span again.** A wide character's
   continuation column carried no style, so `with_styles()` rendered a bar
   over `ab汉cd` as two spans with a hole and `cell(row, col).style()` on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,14 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo clippy --workspace --all-targets --no-default-features -- -D warnings
 cargo clippy --workspace --all-targets --no-default-features --features decode -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings    # default features: what `cargo add termlens --dev` gives you
 cargo test --workspace --no-default-features
 cargo test --workspace --no-default-features --features decode
+cargo test --workspace                                   # default features
+RUSTDOCFLAGS='-D warnings' cargo doc --no-deps
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features
 cargo deny check                          # cargo install cargo-deny
+pipx run zizmor==1.29.0 --persona=pedantic .github/workflows/   # workflow audit; needs GH_TOKEN for the online checks
 cargo +1.85 check --workspace --locked --all-targets    # the MSRV: `rust-version` in Cargo.toml
 ```
 
@@ -39,7 +43,9 @@ The list is written out here rather than left as a pointer because a first
 PR that fails on `cargo fmt` after following the setup to the letter is an
 avoidable bad first experience. If it ever disagrees with
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml), the workflow is the
-source of truth and this list is the bug.
+source of truth and this list is the bug — and the `gates-listed` CI job
+(`.github/scripts/check-ci-gates-listed.sh`) fails when the two disagree,
+so the bug cannot sit here unnoticed again.
 
 The integration tests spawn real PTYs and small fixture apps from
 `fixtures/`; there is nothing to install beyond a Rust toolchain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ cargo test --workspace --no-default-features
 cargo test --workspace --no-default-features --features decode
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features
 cargo deny check                          # cargo install cargo-deny
-cargo +1.85 check --workspace --locked    # the MSRV: `rust-version` in Cargo.toml
+cargo +1.85 check --workspace --locked --all-targets    # the MSRV: `rust-version` in Cargo.toml
 ```
 
 The list is written out here rather than left as a pointer because a first

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ fn quits_from_the_main_screen() -> termlens::Result<()> {
         .timeout(Duration::from_secs(5))   // every wait_* has this deadline
         .spawn(env!("CARGO_BIN_EXE_myapp"))?;
 
-    t.wait_until(|screen| screen.contains("Ready"))?;
+    // Wait on the LAST thing the app paints before snapshotting the whole
+    // screen; an early marker races the rest of the frame (DESIGN.md §2, rule 2).
+    t.wait_until(|screen| screen.contains("Ready") && screen.contains("╯"))?;
     insta::assert_snapshot!(t.screen());   // snapshot the rendered grid
     // …or t.screen().with_styles() to catch style-only regressions too
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ design. termlens's position:
 - **Two SGR style attributes are not modeled.** Overline (`SGR 53`) and double
   underline (`SGR 21`) do not reach [`Style`](https://docs.rs/termlens/latest/termlens/struct.Style.html),
   so `with_styles()` cannot distinguish those attributes from a plain cell.
+  And bold and dim are **one intensity state**, not two: the last of
+  `SGR 1`/`SGR 2` written wins, so a cell never reports both.
 - **A reply the terminal's own input queue cannot hold may not arrive.**
   termlens no longer drops answers of its own accord, but the tty input
   queue is small (~1 KB on macOS, ~4 KB on Linux), so an application that

--- a/crates/termlens/examples/inspect.rs
+++ b/crates/termlens/examples/inspect.rs
@@ -8,7 +8,15 @@
 //!
 //! Waits for the program to exit (up to the timeout) or, if it keeps
 //! running, for 300ms of output silence — then prints the screen.
+//!
+//! Exit code 0 means inspect ran and printed a screen; the trailer under
+//! the screen says what the program did — its exit status, or that it was
+//! still running at the deadline. Exit code 1 means inspect itself could
+//! not run: bad arguments, or a program that could not be spawned. A
+//! viewer, not a gate: the program's own status is reported, not
+//! propagated.
 
+use std::io::{self, Write};
 use std::process::ExitCode;
 use std::time::Duration;
 
@@ -57,17 +65,37 @@ fn main() -> ExitCode {
         }
     };
 
+    let mut out = String::new();
     match t.wait_exit() {
         Ok(status) => {
-            println!("{}", t.screen());
-            println!("--- exited: {status} ---");
+            out.push_str(&t.screen().to_string());
+            out.push_str(&format!("\n--- exited: {status} ---\n"));
         }
-        Err(_) => {
-            // Still running: settle on a quiet screen instead.
+        Err(termlens::Error::Timeout { .. }) => {
+            // Still running at the deadline: settle on a quiet screen instead.
             let _ = t.wait_idle(Duration::from_millis(300));
-            println!("{}", t.screen());
-            println!("--- still running (killed on exit) ---");
+            out.push_str(&t.screen().to_string());
+            out.push_str("\n--- still running at the deadline (killed on exit) ---\n");
         }
+        Err(e) => {
+            // Not "still running": the OS wait itself failed, and saying so
+            // is the difference between a slow program and a broken harness.
+            out.push_str(&t.screen().to_string());
+            out.push_str(&format!("\n--- waiting for the program failed: {e} ---\n"));
+        }
+    }
+    // One write, and a reader that closed early (`inspect … | head`) is a
+    // clean exit rather than a panic on a broken pipe (#223).
+    let mut stdout = io::stdout().lock();
+    if let Err(e) = stdout
+        .write_all(out.as_bytes())
+        .and_then(|()| stdout.flush())
+    {
+        if e.kind() == io::ErrorKind::BrokenPipe {
+            return ExitCode::SUCCESS;
+        }
+        eprintln!("inspect: writing the screen failed: {e}");
+        return ExitCode::FAILURE;
     }
     ExitCode::SUCCESS
 }

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -486,6 +486,22 @@ mod tests {
     }
 
     #[test]
+    fn bold_and_dim_are_one_intensity_state_and_the_last_write_wins() {
+        // Documented on `Style::bold` and `Style::dim` (#225): the backend
+        // keeps one intensity, so a cell never reports both, and SGR 22
+        // clears whichever is set.
+        let screen = emu_with(b"\x1b[1;2mA\x1b[0m\x1b[2;1mB\x1b[0m\x1b[1m\x1b[22mC").snapshot();
+        let style = |col| *screen.cell(0, col).unwrap().style();
+        assert!(!style(0).bold && style(0).dim, "ESC[1;2m: {:?}", style(0));
+        assert!(style(1).bold && !style(1).dim, "ESC[2;1m: {:?}", style(1));
+        assert!(
+            !style(2).bold && !style(2).dim,
+            "ESC[1m ESC[22m: {:?}",
+            style(2)
+        );
+    }
+
+    #[test]
     fn blink_conceal_and_strikethrough_reach_the_cells() {
         // The three attributes vt100 drops. Recovered via the shadow parser
         // (see `emu/shadow.rs`).

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -260,7 +260,7 @@ impl Emulator for Vt100Emulator {
     fn snapshot(&self) -> Screen {
         let screen = self.parser.screen();
         let (rows, cols) = screen.size();
-        let mut cells = Vec::with_capacity(usize::from(rows) * usize::from(cols));
+        let mut cells: Vec<Cell> = Vec::with_capacity(usize::from(rows) * usize::from(cols));
         // The shadow grid is the same shape as the primary — vt100's
         // attributes never influence geometry, and the two streams differ
         // only by rewritten SGR — so cell (row, col) means the same in both.
@@ -273,10 +273,22 @@ impl Emulator for Vt100Emulator {
             for col in 0..cols {
                 // In-range lookups on vt100 are always Some; blank fallback
                 // keeps this total rather than panicking inside a snapshot.
-                cells.push(screen.cell(row, col).map_or_else(
+                let mut converted = screen.cell(row, col).map_or_else(
                     || Cell::new(String::new(), Style::default(), false, false),
                     |cell| convert_cell(cell, self.shadow.cell(row, col)),
-                ));
+                );
+                // A wide character's second column is painted in the leading
+                // cell's colours, so it carries the leading cell's style.
+                // vt100 leaves the placeholder unstyled, which split every
+                // highlight over CJK or emoji into two spans with a hole
+                // (#218) — the same shape as the shadow recovery: upstream
+                // drops it, the snapshot restores it.
+                if col > 0 && converted.is_wide_continuation() {
+                    if let Some(lead) = cells.last() {
+                        converted = Cell::new(String::new(), *lead.style(), false, true);
+                    }
+                }
+                cells.push(converted);
             }
         }
         let (cursor_row, cursor_col) = screen.cursor_position();
@@ -473,6 +485,21 @@ mod tests {
         assert_eq!(wide.contents(), "汉");
         assert!(screen.cell(0, 1).unwrap().is_wide_continuation());
         assert_eq!(screen.find("x"), Some((0, 2)));
+    }
+
+    #[test]
+    fn a_wide_characters_continuation_carries_the_leading_cells_style() {
+        // `ab汉cd` on one background: six columns, one span, no hole at the
+        // continuation column (#218).
+        let screen = emu_with(b"\x1b[48;2;30;30;46mab\xe6\xb1\x89cd\x1b[0m").snapshot();
+        let bg = Color::Rgb(30, 30, 46);
+        assert!(screen.cell(0, 3).unwrap().is_wide_continuation());
+        for col in 0..6 {
+            assert_eq!(screen.cell(0, col).unwrap().style().bg, bg, "col {col}");
+        }
+        let styled = screen.with_styles().to_string();
+        assert!(styled.contains("0: 0-5 bg=#1e1e2e"), "{styled}");
+        assert_eq!(screen.cell(0, 6).unwrap().style(), &Style::default());
     }
 
     #[test]

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -1,6 +1,7 @@
 //! The `vt100`-crate backend. Public types never leak from here: every
 //! snapshot converts vt100's grid into termlens's own [`Screen`].
 
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -92,9 +93,11 @@ impl Vt100Emulator {
         if bytes.is_empty() {
             return;
         }
-        let normalized = self.colors.feed(bytes);
+        // U+FFFD would be dropped on the way in — see `stand_in_for_replacement`.
+        let bytes = stand_in_for_replacement(bytes);
+        let normalized = self.colors.feed(&bytes);
         self.parser.process(&normalized);
-        self.shadow.feed(bytes);
+        self.shadow.feed(&bytes);
         self.capture_scrolled_rows();
     }
 
@@ -194,7 +197,8 @@ impl Vt100Emulator {
             screen.set_scrollback(len - i);
             let take = (len - i).min(usize::from(rows));
             for line in screen.rows(0, cols).take(take) {
-                self.history.push_back(Arc::from(line.trim_end()));
+                self.history
+                    .push_back(Arc::from(restore_replacement(line.trim_end()).as_ref()));
             }
             i += take;
         }
@@ -434,11 +438,53 @@ fn convert_cell(cell: &::vt100::Cell, shadow: Option<&::vt100::Cell>) -> Cell {
         strikethrough: shadow.is_some_and(::vt100::Cell::underline),
     };
     Cell::new(
-        cell.contents().to_owned(),
+        restore_replacement(cell.contents()).into_owned(),
         style,
         cell.is_wide(),
         cell.is_wide_continuation(),
     )
+}
+
+/// What the reader substitutes for a byte it could not decode (`utf8.rs`).
+const REPLACEMENT: &str = "\u{FFFD}";
+/// What the grid is fed in its place. vt100's `print` drops U+FFFD outright
+/// (0.16, `perform.rs`), so the replacement would vanish exactly as the
+/// invalid byte did (#217). U+FDD0 is a Unicode noncharacter — reserved for
+/// internal use like this, never for interchange, so no application has any
+/// business emitting one — and vt100 draws it as an ordinary width-1 cell.
+/// The snapshot puts U+FFFD back wherever it appears.
+const STAND_IN: &str = "\u{FDD0}";
+
+/// `bytes` with every encoded U+FFFD swapped for the stand-in, allocating
+/// only when there is one to swap. A stop never falls inside a character,
+/// so the three bytes always arrive in one feed.
+fn stand_in_for_replacement(bytes: &[u8]) -> Cow<'_, [u8]> {
+    let from = REPLACEMENT.as_bytes();
+    if !bytes.windows(from.len()).any(|window| window == from) {
+        return Cow::Borrowed(bytes);
+    }
+    let to = STAND_IN.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i..].starts_with(from) {
+            out.extend_from_slice(to);
+            i += from.len();
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    Cow::Owned(out)
+}
+
+/// Grid text as the snapshot reports it: the stand-in reads as U+FFFD again.
+fn restore_replacement(text: &str) -> Cow<'_, str> {
+    if text.contains(STAND_IN) {
+        Cow::Owned(text.replace(STAND_IN, REPLACEMENT))
+    } else {
+        Cow::Borrowed(text)
+    }
 }
 
 fn convert_color(color: ::vt100::Color) -> Color {
@@ -500,6 +546,31 @@ mod tests {
         let styled = screen.with_styles().to_string();
         assert!(styled.contains("0: 0-5 bg=#1e1e2e"), "{styled}");
         assert_eq!(screen.cell(0, 6).unwrap().style(), &Style::default());
+    }
+
+    #[test]
+    fn a_replacement_character_is_drawn_like_any_other() {
+        // The reader turns invalid UTF-8 into U+FFFD (#217); the grid has to
+        // show it, or the byte is as invisible as before.
+        let screen = emu_with("caf\u{FFFD} done".as_bytes()).snapshot();
+        assert_eq!(screen.row_text(0).trim_end(), "caf\u{FFFD} done");
+        assert_eq!(screen.cell(0, 3).unwrap().contents(), "\u{FFFD}");
+        assert_eq!(screen.find("done"), Some((0, 5)));
+
+        // Scrolled into history, it is still U+FFFD — never the stand-in.
+        let mut emu = Vt100Emulator::new(4, 10, 100, crate::graphics::DEFAULT_CAPTURE);
+        feed_all(
+            &mut emu,
+            "caf\u{FFFD} done\r\n1\r\n2\r\n3\r\n4\r\n5".as_bytes(),
+        );
+        let screen = emu.snapshot();
+        let history = screen.scrollback_text();
+        assert!(history.contains("caf\u{FFFD} done"), "{history:?}");
+        assert!(
+            !screen.full_text().contains(STAND_IN),
+            "{}",
+            screen.full_text()
+        );
     }
 
     #[test]

--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -66,6 +66,27 @@ pub enum Error {
     #[error("invalid terminal size: {0}")]
     Size(String),
 
+    /// The VT emulator panicked while processing the child's output, so the
+    /// grid stopped advancing at the screen embedded here.
+    ///
+    /// The emulation runs on the reader thread, where a panic propagates
+    /// nowhere: before this existed the drain simply died, every later
+    /// snapshot returned the same frozen screen, and each wait ran to its
+    /// deadline reporting a predicate that was never going to become true.
+    /// A wait now fails immediately and says why. The screen is the last one
+    /// taken before the failure — the emulator is not asked again, because
+    /// its state after a panic means nothing.
+    #[error(
+        "the terminal emulator failed and the screen stopped advancing: {detail}\n\
+         --- last screen before the failure ---\n{screen}"
+    )]
+    Emulator {
+        /// The panic message from the emulator.
+        detail: String,
+        /// The last screen taken before the emulator failed.
+        screen: Screen,
+    },
+
     /// Typed input or control the child cannot receive — e.g. a mouse
     /// click while the application never enabled mouse tracking (sending
     /// it anyway would feed the app bytes it would misparse as garbage
@@ -95,13 +116,14 @@ pub enum Error {
 }
 
 impl Error {
-    /// The screen embedded in [`Error::Timeout`], [`Error::Eof`] or
-    /// [`Error::Write`], if any.
+    /// The screen embedded in [`Error::Timeout`], [`Error::Eof`],
+    /// [`Error::Emulator`] or [`Error::Write`], if any.
     #[must_use]
     pub fn screen(&self) -> Option<&Screen> {
         match self {
             Error::Timeout { screen, .. }
             | Error::Eof { screen, .. }
+            | Error::Emulator { screen, .. }
             | Error::Write { screen, .. } => Some(screen),
             _ => None,
         }

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -106,6 +106,7 @@ mod graphics;
 mod keys;
 mod screen;
 mod terminal;
+mod utf8;
 mod wait;
 
 pub use error::{Error, Result};

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -1345,7 +1345,9 @@ mod tests {
                     };
                     row_cells.push(Cell::new(ch.to_string(), style, wide, false));
                     if wide {
-                        row_cells.push(Cell::new(String::new(), Style::default(), false, true));
+                        // As the emulator builds it: the continuation carries
+                        // the leading cell's style (#218).
+                        row_cells.push(Cell::new(String::new(), style, false, true));
                     }
                 }
             }

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -651,6 +651,11 @@ impl Screen {
     ///
     /// Zero for an application that never emits synchronized updates; there
     /// is nothing to count, not even its redraws.
+    ///
+    /// On a frame that [`wait_frame`](crate::Terminal::wait_frame) handed
+    /// back, this is also the staleness check: the frame's count against
+    /// `screen().repaints()` says how many repaints the live screen is
+    /// ahead of the one you are asserting on.
     #[must_use]
     pub fn repaints(&self) -> u64 {
         self.state.repaints
@@ -958,10 +963,17 @@ impl Screen {
     /// # Panics
     ///
     /// If either range runs backwards (`3..0`). Note the argument order:
-    /// this is the one API in the crate that takes **columns first**, to
-    /// match [`TerminalBuilder::size`](crate::TerminalBuilder::size), while
-    /// every cell address elsewhere is `(row, col)`. Swapping the two is
-    /// therefore the mistake to expect, and a swap can invert a range.
+    /// **columns first**, like every API here that speaks of terminal
+    /// geometry or a mouse position —
+    /// [`TerminalBuilder::size`](crate::TerminalBuilder::size),
+    /// [`Terminal::resize`](crate::Terminal::resize),
+    /// [`Terminal::click`](crate::Terminal::click) and its `click_with`,
+    /// `drag`, `scroll` and `scroll_with` siblings, and [`size`](Self::size).
+    /// Everything that addresses a cell in the grid is row-first:
+    /// [`cell`](Self::cell), [`row_text`](Self::row_text), and the
+    /// `(row, col)` that [`find`](Self::find), [`find_by`](Self::find_by)
+    /// and [`cursor`](Self::cursor) return. Swapping the two is therefore
+    /// the mistake to expect, and a swap can invert a range.
     ///
     /// A panic rather than an error, deliberately, and for the same reason
     /// `&slice[3..0]` panics: a backwards range is not a fact about the

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -43,9 +43,15 @@ pub struct Style {
     pub fg: Color,
     /// Background color.
     pub bg: Color,
-    /// Bold / increased intensity.
+    /// Bold / increased intensity (`SGR 1`).
+    ///
+    /// `bold` and `dim` are two fields over **one** intensity state: the
+    /// last of `SGR 1` and `SGR 2` written wins, so a cell never reports
+    /// both, and `ESC[1;2m` reads as dim only. `SGR 22` clears whichever
+    /// is set.
     pub bold: bool,
-    /// Dim / decreased intensity.
+    /// Dim / decreased intensity (`SGR 2`). Shares one intensity state with
+    /// [`bold`](Self::bold): last write wins, never both.
     pub dim: bool,
     /// Italic.
     pub italic: bool,

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -861,6 +861,12 @@ impl Screen {
     /// Text pulled out as a `String` and matched with `str` methods —
     /// `full_text().contains(..)` — is byte-exact, since the comparison is
     /// then `std`'s and not ours.
+    ///
+    /// Trailing whitespace is trimmed per row first, so the blank padding
+    /// past a row's last glyph is never matched — and neither is a trailing
+    /// U+00A0 or U+3000 the application drew, which the trim cannot tell
+    /// from padding. [`find`](Self::find) trims identically, so the two
+    /// never disagree; [`cell`](Self::cell) still reports the character.
     #[must_use]
     pub fn contains(&self, needle: &str) -> bool {
         if self.is_ascii() && needle.is_ascii() {
@@ -891,6 +897,13 @@ impl Screen {
     /// is found here precisely when `contains` is true. The reported column
     /// is the real one: folding happens per cell, so the byte-to-column map
     /// stays exact even where a composition shortened the text.
+    ///
+    /// Trailing whitespace is trimmed per row before either searches, so
+    /// the blank padding past a row's last glyph is never matched: on a
+    /// row reading `Total:`, `find("Total: ")` is `None`, as `contains`
+    /// says. The same trim treats a trailing U+00A0 or U+3000 the
+    /// application genuinely drew as padding — a decision, so that the two
+    /// searches agree; [`cell`](Self::cell) still reports the character.
     #[must_use]
     pub fn find(&self, needle: &str) -> Option<(u16, u16)> {
         if needle.is_empty() {
@@ -900,7 +913,11 @@ impl Screen {
         if !needle.contains('\n') {
             for row in 0..self.rows {
                 let (text, cols) = self.searchable_row(row);
-                if let Some(byte_off) = text.find(needle.as_str()) {
+                // Search the row as `contains` sees it — trailing whitespace
+                // trimmed — not the grid padded out to `cols`. The trimmed
+                // string is a prefix, so the byte-to-column map is unchanged
+                // and an interior space still matches (#212).
+                if let Some(byte_off) = text.trim_end().find(needle.as_str()) {
                     return Some((row, cols.get(byte_off).copied()?));
                 }
             }
@@ -1442,6 +1459,23 @@ mod tests {
         for needle in ["hello\nworld", "llo\nwor", "x\nworld", "\nagain"] {
             assert_eq!(s.find(needle).is_some(), s.contains(needle), "{needle:?}");
         }
+    }
+
+    #[test]
+    fn single_row_find_agrees_with_contains_about_trailing_padding() {
+        // `find` searched the row padded to the terminal width while
+        // `contains` searched the trimmed text (#212), so a needle ending in
+        // a space was found on a row where nothing followed the word.
+        let s = screen(10, 2, &["Total:", "a b"]);
+        for needle in [
+            "Total:", "Total: ", "Total:  ", " ", "   ", "otal: ", "a b", "a b ", "b ",
+        ] {
+            assert_eq!(s.find(needle).is_some(), s.contains(needle), "{needle:?}");
+        }
+        assert_eq!(s.find("Total:"), Some((0, 0)));
+        assert_eq!(s.find("Total: "), None);
+        assert_eq!(s.find("a b"), Some((1, 0))); // an interior space still matches
+        assert_eq!(s.find(" "), Some((1, 1))); // …and is the only space that does
     }
 
     #[test]

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1195,6 +1195,12 @@ impl TerminalBuilder {
     /// child still starts in the test process's directory unless
     /// [`current_dir`](Self::current_dir) says otherwise.
     ///
+    /// Clearing the environment removes `PATH` with everything else, so a
+    /// bare program name has nothing to resolve against. [`spawn`](Self::spawn)
+    /// refuses one with an [`Error::Spawn`] that names the two ways out — an
+    /// absolute path, or a `PATH` of your own via [`env`](Self::env) — rather
+    /// than letting the PTY layer report "Unable to resolve the PATH".
+    ///
     /// Note this differs from `std::process::Command::env_clear`, which also
     /// discards explicitly set variables; here `env()` and `envs()` entries
     /// survive.
@@ -1376,6 +1382,19 @@ impl TerminalBuilder {
         if program.is_empty() {
             return spawn_err("no program name given (the program argument was empty)".into());
         }
+        // env_clear removes PATH with everything else, and a bare name then
+        // has nothing to resolve against; the PTY layer's "Unable to resolve
+        // the PATH" named neither the cause nor a remedy (#222).
+        if self.env_clear
+            && !self.envs.iter().any(|(k, _)| k == "PATH")
+            && !program.to_string_lossy().contains('/')
+        {
+            return spawn_err(format!(
+                "`{}` is a bare program name and env_clear() removed PATH, so nothing can \
+                 resolve it — give an absolute path, or set a PATH with .env(\"PATH\", …)",
+                program.to_string_lossy()
+            ));
+        }
         check_size(self.cols, self.rows)?;
         // portable-pty filters the cwd through is_dir() and silently falls
         // back to the home directory. Sensible for a terminal emulator,
@@ -1408,8 +1427,9 @@ impl TerminalBuilder {
     ///
     /// [`Error::Spawn`] when the configuration cannot produce a runnable
     /// command (empty program name, missing
-    /// [`current_dir`](Self::current_dir)) or the program cannot be
-    /// executed; [`Error::Size`] when the configured
+    /// [`current_dir`](Self::current_dir), a bare program name under
+    /// [`env_clear`](Self::env_clear) with no `PATH` to resolve it) or the
+    /// program cannot be executed; [`Error::Size`] when the configured
     /// [`size`](Self::size) has a zero dimension or one past the
     /// 1000-per-axis limit; [`Error::Pty`] when the PTY cannot be opened.
     pub fn spawn(self, program: impl AsRef<OsStr>) -> Result<Terminal> {

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1185,11 +1185,15 @@ impl TerminalBuilder {
         self
     }
 
-    /// Don't inherit the parent process environment: the child sees only
-    /// variables set via [`env`](Self::env) or [`envs`](Self::envs) (plus the
-    /// default `TERM`, see [`spawn`](Self::spawn)). Strict control keeps tests
-    /// hermetic — a developer's exotic `LS_COLORS` should never change a
-    /// snapshot.
+    /// Don't inherit the parent process environment: the child sees exactly
+    /// the variables set via [`env`](Self::env) or [`envs`](Self::envs), plus
+    /// the two the harness pins itself unless you set them —
+    /// `TERM=xterm-256color` and `SHELL=/bin/sh` (see [`spawn`](Self::spawn)).
+    /// Nothing else, on any machine: a developer's exotic `LS_COLORS` should
+    /// never change a snapshot, and neither should their login shell. A
+    /// hermetic environment is not a hermetic working directory, though: the
+    /// child still starts in the test process's directory unless
+    /// [`current_dir`](Self::current_dir) says otherwise.
     ///
     /// Note this differs from `std::process::Command::env_clear`, which also
     /// discards explicitly set variables; here `env()` and `envs()` entries
@@ -1395,7 +1399,10 @@ impl TerminalBuilder {
     /// speaks, and deterministic regardless of the host environment.
     ///
     /// The child starts in the test process's working directory unless
-    /// [`current_dir`](Self::current_dir) names another.
+    /// [`current_dir`](Self::current_dir) names another. Under
+    /// [`env_clear`](Self::env_clear) it also gets `SHELL=/bin/sh` unless
+    /// `SHELL` was set explicitly, so its environment is a function of the
+    /// builder alone rather than of the machine's login shell.
     ///
     /// # Errors
     ///
@@ -1458,6 +1465,13 @@ impl TerminalBuilder {
         );
         if !self.envs.iter().any(|(k, _)| k == "TERM") {
             cmd.env("TERM", "xterm-256color");
+        }
+        // The PTY layer fills SHELL from the host's login shell when the
+        // variable is absent, which put one machine-shaped value inside an
+        // environment env_clear promises is hermetic (#221). Pinned the way
+        // TERM is; an explicit `.env("SHELL", …)` still wins.
+        if self.env_clear && !self.envs.iter().any(|(k, _)| k == "SHELL") {
+            cmd.env("SHELL", "/bin/sh");
         }
         for (key, value) in &self.envs {
             cmd.env(key, value);

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -23,6 +23,7 @@ use crate::error::{Error, Result};
 use crate::keys::Input;
 use crate::keys::{mouse_legacy, mouse_sgr, mouse_utf8};
 use crate::screen::{MouseMode, Screen};
+use crate::utf8::Utf8Sanitizer;
 use crate::wait::{next_backoff, Expired, Monitor, INITIAL_BACKOFF, POLL_CAP};
 
 /// How long `wait_exit` keeps draining PTY output after the child has been
@@ -712,6 +713,11 @@ struct EmuState {
     last_activity: Instant,
     /// Set once the PTY read side reaches EOF; nothing more can arrive.
     eof: bool,
+    /// The reader is holding the incomplete tail of a multi-byte character
+    /// for the next read. The emulator never sees a partial character now
+    /// that decoding happens before it (#217), so this is what keeps
+    /// `wait_idle` from calling a stream that stopped mid-character silence.
+    utf8_pending: bool,
     /// Bumped on every state change (bytes, EOF, resize). Lets waiters skip
     /// re-evaluation on spurious wakes, and keys the snapshot cache.
     generation: u64,
@@ -791,6 +797,7 @@ impl EmuState {
             emu,
             last_activity: Instant::now(),
             eof: false,
+            utf8_pending: false,
             generation: 0,
             snapshot_cache: None,
             frames_seen: 0,
@@ -1892,124 +1899,143 @@ fn reader_loop(
     queued_bytes: &AtomicUsize,
 ) {
     let mut buf = [0u8; 8192];
+    // Invalid UTF-8 becomes U+FFFD here, once, so both parsers see the same
+    // valid stream and a stray byte holds its column instead of vanishing
+    // (#217). A character split across two reads is carried, not replaced.
+    let mut sanitizer = Utf8Sanitizer::default();
+    let mut at_eof = false;
     loop {
-        match reader.read(&mut buf) {
-            Ok(0) => break,
-            Ok(n) => {
-                // The emulator stops at each DEC 2026 frame end and at
-                // each query, so state read there (screen, cursor) is
-                // exact — even when the same chunk already carries the
-                // following bytes. Replies are BUILT under the state
-                // lock but WRITTEN after it is released; the state lock
-                // and the writer lock are never held together.
-                let replies = shared.mutate(|state| {
-                    // Counted before the chunk is processed, so a query
-                    // inside it is recorded against *this* read: output
-                    // batched into the same write as the probe must not
-                    // read as the application having moved past it.
-                    state.reads += 1;
-                    let mut replies: Vec<Vec<u8>> = Vec::new();
-                    let mut offset = 0;
-                    while offset < n {
-                        let processed = state.emu.process(&buf[offset..n]);
-                        offset += processed.consumed;
-                        match processed.stop {
-                            Some(Stop::FrameComplete(span)) => {
-                                state.frames_seen += 1;
-                                // Through `build_snapshot`, so a retained
-                                // frame carries the repaint count like every
-                                // other snapshot. Taking it straight from the
-                                // emulator left `Screen::repaints()` at zero
-                                // on exactly the screens `wait_frame` hands
-                                // back — the ones most likely to be asked.
-                                let frame = state.build_snapshot();
-                                if state.frames.len() == FRAME_HISTORY {
-                                    state.frames.pop_front();
-                                }
-                                state.frames.push_back((state.frames_seen, frame));
-                                // Timings outlive the frame ring: a
-                                // performance line is held over a run, not
-                                // over the last eight repaints.
-                                if state.timings.len() == FRAME_TIMING_HISTORY {
-                                    state.timings.pop_front();
-                                }
-                                state.timings.push_back(FrameTiming {
-                                    index: state.frames_seen,
-                                    duration: span.duration,
-                                    printable: span.printable,
-                                });
+        let chunk: Vec<u8> = match reader.read(&mut buf) {
+            Ok(0) => {
+                // Whatever the sanitizer still holds was never completed.
+                at_eof = true;
+                let tail = sanitizer.finish();
+                if tail.is_empty() {
+                    break;
+                }
+                tail
+            }
+            Ok(n) => sanitizer.feed(&buf[..n]),
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            // Linux reports EIO on the master once the child side is gone;
+            // treat any hard error as end-of-stream.
+            Err(_) => break,
+        };
+        let utf8_pending = sanitizer.pending();
+        {
+            // The emulator stops at each DEC 2026 frame end and at
+            // each query, so state read there (screen, cursor) is
+            // exact — even when the same chunk already carries the
+            // following bytes. Replies are BUILT under the state
+            // lock but WRITTEN after it is released; the state lock
+            // and the writer lock are never held together.
+            let replies = shared.mutate(|state| {
+                // Counted before the chunk is processed, so a query
+                // inside it is recorded against *this* read: output
+                // batched into the same write as the probe must not
+                // read as the application having moved past it.
+                state.reads += 1;
+                let mut replies: Vec<Vec<u8>> = Vec::new();
+                let mut offset = 0;
+                while offset < chunk.len() {
+                    let processed = state.emu.process(&chunk[offset..]);
+                    offset += processed.consumed;
+                    match processed.stop {
+                        Some(Stop::FrameComplete(span)) => {
+                            state.frames_seen += 1;
+                            // Through `build_snapshot`, so a retained
+                            // frame carries the repaint count like every
+                            // other snapshot. Taking it straight from the
+                            // emulator left `Screen::repaints()` at zero
+                            // on exactly the screens `wait_frame` hands
+                            // back — the ones most likely to be asked.
+                            let frame = state.build_snapshot();
+                            if state.frames.len() == FRAME_HISTORY {
+                                state.frames.pop_front();
                             }
-                            Some(Stop::Query(query)) => {
-                                if let Some(reply) = state.answer(&query) {
-                                    replies.push(reply);
-                                }
+                            state.frames.push_back((state.frames_seen, frame));
+                            // Timings outlive the frame ring: a
+                            // performance line is held over a run, not
+                            // over the last eight repaints.
+                            if state.timings.len() == FRAME_TIMING_HISTORY {
+                                state.timings.pop_front();
                             }
-                            None => {}
+                            state.timings.push_back(FrameTiming {
+                                index: state.frames_seen,
+                                duration: span.duration,
+                                printable: span.printable,
+                            });
+                        }
+                        Some(Stop::Query(query)) => {
+                            if let Some(reply) = state.answer(&query) {
+                                replies.push(reply);
+                            }
+                        }
+                        None => {}
+                    }
+                }
+                state.utf8_pending = utf8_pending;
+                state.touch();
+                replies
+            });
+            // One queue entry per *read*, not per reply. A single read
+            // can carry dozens of queries — a startup batch is a
+            // legitimate pattern — and enqueueing each answer separately
+            // made the reader outrun the writer, which issues one
+            // `write(2)` per entry. The queue then filled and answers
+            // were discarded although nothing was blocked: measured at
+            // 173 of 200 delivered back-to-back, and 200 of 200 with a
+            // millisecond between the queries. Batching is what removes
+            // that mismatch; ordering is unchanged, since the bytes are
+            // concatenated in the order they were built.
+            if !replies.is_empty() {
+                let batch: Vec<u8> = replies.concat();
+                let count = replies.len();
+                match replies_to {
+                    // Still without waiting. Now that a full queue means
+                    // 64 reads' worth of answers are already pending, it
+                    // really does mean the application has stopped
+                    // reading — and the drain must keep running
+                    // regardless, or the child blocks writing into a full
+                    // output buffer and the harness deadlocks itself.
+                    Some(tx) => {
+                        // Refuse only on the memory bound. The queue is
+                        // unbounded, so this hand-off cannot block and the
+                        // drain cannot stall — which is the constraint
+                        // that rules out backpressuring the reader.
+                        let size = batch.len();
+                        if queued_bytes.load(Ordering::Relaxed) + size > REPLY_QUEUE_BYTES {
+                            shared.mutate(|state| state.replies_dropped += count);
+                        } else {
+                            // Counted as pending *before* the hand-off, so
+                            // a wait that fails while the write is blocked
+                            // can say how many answers are stuck.
+                            pending.fetch_add(count, Ordering::Relaxed);
+                            queued_bytes.fetch_add(size, Ordering::Relaxed);
+                            let request = WriteRequest {
+                                bytes: batch,
+                                ack: None, // fire and forget: never wait
+                                replies: count,
+                            };
+                            if tx.send(request).is_err() {
+                                pending.fetch_sub(count, Ordering::Relaxed);
+                                queued_bytes.fetch_sub(size, Ordering::Relaxed);
+                            }
                         }
                     }
-                    state.touch();
-                    replies
-                });
-                // One queue entry per *read*, not per reply. A single read
-                // can carry dozens of queries — a startup batch is a
-                // legitimate pattern — and enqueueing each answer separately
-                // made the reader outrun the writer, which issues one
-                // `write(2)` per entry. The queue then filled and answers
-                // were discarded although nothing was blocked: measured at
-                // 173 of 200 delivered back-to-back, and 200 of 200 with a
-                // millisecond between the queries. Batching is what removes
-                // that mismatch; ordering is unchanged, since the bytes are
-                // concatenated in the order they were built.
-                if !replies.is_empty() {
-                    let batch: Vec<u8> = replies.concat();
-                    let count = replies.len();
-                    match replies_to {
-                        // Still without waiting. Now that a full queue means
-                        // 64 reads' worth of answers are already pending, it
-                        // really does mean the application has stopped
-                        // reading — and the drain must keep running
-                        // regardless, or the child blocks writing into a full
-                        // output buffer and the harness deadlocks itself.
-                        Some(tx) => {
-                            // Refuse only on the memory bound. The queue is
-                            // unbounded, so this hand-off cannot block and the
-                            // drain cannot stall — which is the constraint
-                            // that rules out backpressuring the reader.
-                            let size = batch.len();
-                            if queued_bytes.load(Ordering::Relaxed) + size > REPLY_QUEUE_BYTES {
-                                shared.mutate(|state| state.replies_dropped += count);
-                            } else {
-                                // Counted as pending *before* the hand-off, so
-                                // a wait that fails while the write is blocked
-                                // can say how many answers are stuck.
-                                pending.fetch_add(count, Ordering::Relaxed);
-                                queued_bytes.fetch_add(size, Ordering::Relaxed);
-                                let request = WriteRequest {
-                                    bytes: batch,
-                                    ack: None, // fire and forget: never wait
-                                    replies: count,
-                                };
-                                if tx.send(request).is_err() {
-                                    pending.fetch_sub(count, Ordering::Relaxed);
-                                    queued_bytes.fetch_sub(size, Ordering::Relaxed);
-                                }
-                            }
-                        }
-                        // No responder thread (no descriptor to duplicate):
-                        // write inline, as before.
-                        None => {
-                            let mut writer = writer.lock().unwrap_or_else(PoisonError::into_inner);
-                            if let Some(writer) = writer.as_mut() {
-                                let _ = writer.write_all(&batch).and_then(|()| writer.flush());
-                            }
+                    // No responder thread (no descriptor to duplicate):
+                    // write inline, as before.
+                    None => {
+                        let mut writer = writer.lock().unwrap_or_else(PoisonError::into_inner);
+                        if let Some(writer) = writer.as_mut() {
+                            let _ = writer.write_all(&batch).and_then(|()| writer.flush());
                         }
                     }
                 }
             }
-            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
-            // Linux reports EIO on the master once the child side is gone;
-            // treat any hard error as end-of-stream.
-            Err(_) => break,
+        }
+        if at_eof {
+            break;
         }
     }
     shared.mutate(|state| {
@@ -3017,7 +3043,11 @@ impl Terminal {
                 return Ok(());
             }
             let elapsed = guard.last_activity.elapsed();
-            if elapsed >= quiet && !guard.emu.mid_sequence() && !guard.emu.in_sync_update() {
+            if elapsed >= quiet
+                && !guard.emu.mid_sequence()
+                && !guard.utf8_pending
+                && !guard.emu.in_sync_update()
+            {
                 return Ok(());
             }
 

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1200,9 +1200,12 @@ impl TerminalBuilder {
         self
     }
 
-    /// Run the program with `dir` as its working directory instead of
-    /// inheriting the test runner's. Directory-sensitive programs no
-    /// longer need a `cd … && …` through a shell.
+    /// Run the program with `dir` as its working directory. The default is
+    /// the test process's own — what `std::process::Command` does — so a
+    /// relative program path or a directory-sensitive program behaves as it
+    /// would under any other Rust process API, and no `cd … && …` through a
+    /// shell is needed. (Before 0.9 the default was the PTY layer's
+    /// fallback, `$HOME`, while this text claimed otherwise: #215.)
     ///
     /// [`spawn`](Self::spawn) fails with [`Error::Spawn`] if `dir` is not
     /// an existing directory — running somewhere else instead would make
@@ -1391,6 +1394,9 @@ impl TerminalBuilder {
     /// `TERM=xterm-256color` — matching the escape sequences the emulator
     /// speaks, and deterministic regardless of the host environment.
     ///
+    /// The child starts in the test process's working directory unless
+    /// [`current_dir`](Self::current_dir) names another.
+    ///
     /// # Errors
     ///
     /// [`Error::Spawn`] when the configuration cannot produce a runnable
@@ -1427,8 +1433,18 @@ impl TerminalBuilder {
 
         let mut cmd = CommandBuilder::new(program);
         cmd.args(&self.args);
-        if let Some(dir) = &self.cwd {
-            cmd.cwd(dir);
+        // Always set: without a cwd the PTY layer falls back to $HOME, which
+        // made a relative program path and a directory-sensitive program
+        // behave unlike every other Rust process API while `current_dir`'s
+        // rustdoc promised the opposite (#215). The test process's own
+        // directory is the default `std::process::Command` gives.
+        match &self.cwd {
+            Some(dir) => cmd.cwd(dir),
+            None => {
+                if let Ok(here) = std::env::current_dir() {
+                    cmd.cwd(here);
+                }
+            }
         }
         if self.env_clear {
             cmd.env_clear();

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -650,8 +650,25 @@ impl ExitStatus {
         self.code
     }
 
-    /// The name of the signal that terminated the child, if it died from a
-    /// signal (e.g. `"Hangup"`, `"Killed: 9"`). `None` for a normal exit.
+    /// The signal that terminated the child, if it died from one, as the
+    /// host C library describes it — `strsignal(3)`. `None` for a normal
+    /// exit.
+    ///
+    /// The spelling is the platform's, not this crate's: `SIGTERM` reads
+    /// `"Terminated"` on glibc and `"Terminated: 15"` on macOS, `SIGKILL`
+    /// `"Killed"` and `"Killed: 9"`. A portable assertion therefore uses
+    /// `contains`, never `==`:
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().args(["-c", "sleep 30"]).spawn("sh")?;
+    /// t.signal(termlens::Signal::Term)?;
+    /// let status = t.wait_exit()?;
+    /// let signal = status.signal().expect("killed, not exited");
+    /// assert!(signal.contains("Terminated"), "status: {status}");
+    /// # Ok(())
+    /// # }
+    /// ```
     ///
     /// Distinguishing "the app exited 1" from "something killed the app" is
     /// the difference between a failing test and a failing test *harness* —
@@ -2245,8 +2262,23 @@ impl Terminal {
         self.write_input(bytes, what)
     }
 
-    /// Click the primary button at `(col, row)` (0-based, like
-    /// [`Screen::cell`]). Sends a press — and, when the application's
+    /// Click the primary button at `(col, row)` — **column first**, 0-based:
+    /// the geometry order of [`TerminalBuilder::size`] and [`Screen::size`],
+    /// and the reverse of the `(row, col)` that [`Screen::find`] and
+    /// [`Screen::cell`] use for cell addresses. The hand-off from a search
+    /// to a click is where the two orders meet, so write the swap out:
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// let s = t.screen();
+    /// let (row, col) = s.find("MENU").expect("the menu is on screen");
+    /// t.click(col, row)?; // find gives (row, col); click takes (col, row)
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Sends a press — and, when the application's
     /// tracking mode reports them, a release — encoded exactly as the
     /// tracking mode and encoding **the application enabled** (SGR 1006
     /// or the legacy byte form).
@@ -2596,11 +2628,12 @@ impl Terminal {
     ///    correctly. `wait_idle` will not declare idleness while an update
     ///    is open.
     ///
-    /// Applications that emit DEC 2026 synchronized updates need none of
-    /// this — [`wait_frame`](Self::wait_frame) sees only complete frames
-    /// and hands back the one it matched.
-    /// After a [`resize`](Self::resize), also see the stale-frame trap
-    /// documented there.
+    /// Applications that emit DEC 2026 synchronized updates get rule 3 for
+    /// free from [`wait_frame`](Self::wait_frame), which sees only complete
+    /// frames and hands back the one it matched — but not rule 1: a
+    /// predicate true of a frame you did not mean returns that frame
+    /// (`docs/DESIGN.md` §2, rule 4). After a [`resize`](Self::resize),
+    /// also see the stale-frame trap documented there.
     ///
     /// # Errors
     ///
@@ -2730,6 +2763,28 @@ impl Terminal {
     /// let frame = t.wait_frame(|screen| screen.contains("Frame ready"))?;
     /// assert!(frame.contains("Frame ready"));
     /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    ///
+    /// A complete frame is not necessarily the frame that answers your
+    /// input. The cursor sits at the last frame *returned*, so after
+    /// `send(key)` a predicate that is also true of the pre-key screen gets
+    /// the pre-key frame, if that one was never returned — rule 4 of
+    /// `docs/DESIGN.md` §2. Name what the key changes:
+    ///
+    /// ```
+    /// # fn main() -> termlens::Result<()> {
+    /// let mut t = termlens::Terminal::builder()
+    ///     .timeout(std::time::Duration::from_secs(10))
+    ///     .args(["-c", r"printf '\033[?2026hcount 1\033[?2026l'; read k; printf '\033[?2026h count 2\033[?2026l'; read quit"])
+    ///     .spawn("sh")?;
+    /// t.wait_until(|s| s.contains("count 1"))?;
+    /// t.send(termlens::Key::Enter)?;                         // the app will paint "count 2"
+    /// let frame = t.wait_frame(|s| s.contains("count"))?;     // true of the pre-key frame too…
+    /// assert!(!frame.contains("count 2"));                    // …and that is the one you get
+    /// let frame = t.wait_frame(|s| s.contains("count 2"))?;   // what the key changed
+    /// assert!(frame.contains("count 2"));
+    /// # t.send(termlens::Key::Enter)?; t.wait_exit()?; Ok(())
     /// # }
     /// ```
     ///

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -10,6 +10,7 @@ use std::collections::VecDeque;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::{self, Read, Write};
+use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex, PoisonError};
@@ -713,6 +714,14 @@ struct EmuState {
     last_activity: Instant,
     /// Set once the PTY read side reaches EOF; nothing more can arrive.
     eof: bool,
+    /// The emulator panicked while processing output, with its message.
+    ///
+    /// Set on the reader thread; read by every screen-based wait, which
+    /// fails at once rather than running to a deadline against a grid that
+    /// stopped advancing (#211). Once set, the emulator is never called
+    /// again — after a panic its state means nothing — so the snapshot
+    /// frozen in `snapshot_cache` is what every later observation returns.
+    emu_panic: Option<String>,
     /// The reader is holding the incomplete tail of a multi-byte character
     /// for the next read. The emulator never sees a partial character now
     /// that decoding happens before it (#217), so this is what keeps
@@ -793,13 +802,19 @@ impl EmuState {
             graphics,
             term_name,
         } = responder;
+        let emu_snapshot = emu.snapshot();
         Self {
             emu,
             last_activity: Instant::now(),
             eof: false,
             utf8_pending: false,
+            emu_panic: None,
             generation: 0,
-            snapshot_cache: None,
+            // Seeded so a frozen screen always exists: an emulator that
+            // panics on its very first read must still leave the error and
+            // `screen()` something true to show, and the blank grid it was
+            // spawned with is exactly that.
+            snapshot_cache: Some((0, emu_snapshot)),
             frames_seen: 0,
             frames: VecDeque::with_capacity(FRAME_HISTORY),
             timings: VecDeque::new(),
@@ -969,8 +984,28 @@ impl EmuState {
     }
 
     /// Build a snapshot and stamp on the state the emulator does not own.
+    ///
+    /// After the emulator has panicked this returns the last screen taken
+    /// before it did, and never calls into the emulator again: its grid is
+    /// then in whatever state the panic left it, and reading it could panic
+    /// a second time — on the *test* thread, where it would surface as a
+    /// crash rather than as the typed error the waits produce (#211).
     fn build_snapshot(&self) -> Screen {
+        if self.emu_panic.is_some() {
+            if let Some((_, screen)) = &self.snapshot_cache {
+                return screen.clone();
+            }
+        }
         self.emu.snapshot().with_repaints(self.frames_seen)
+    }
+
+    /// The error every screen-based wait returns once the emulator has
+    /// failed. `None` while it is healthy.
+    fn emulator_failure(&self) -> Option<Error> {
+        self.emu_panic.as_ref().map(|detail| Error::Emulator {
+            detail: detail.clone(),
+            screen: self.peek_snapshot(),
+        })
     }
 
     /// One-line diagnosis when a query went unanswered, appended to every
@@ -1104,10 +1139,13 @@ impl Default for TerminalBuilder {
 impl TerminalBuilder {
     /// Terminal size as columns × rows. Defaults to 80×24.
     ///
-    /// Both dimensions must be non-zero and at most **1000**;
+    /// Both dimensions must be at least **2** and at most **1000**;
     /// [`spawn`](Self::spawn) rejects anything else with [`Error::Size`]
     /// rather than letting the emulator meet a size no terminal can have,
-    /// or one it can only serve slowly enough to look broken.
+    /// or one it can only serve slowly enough to look broken. The floor is
+    /// 2 rather than 1 on *both* axes because the emulator panics at one
+    /// column on a double-width character and at one row on a line that
+    /// wraps — `check_size` says why.
     ///
     /// # What a large grid costs
     ///
@@ -1437,7 +1475,7 @@ impl TerminalBuilder {
     /// [`current_dir`](Self::current_dir), a bare program name under
     /// [`env_clear`](Self::env_clear) with no `PATH` to resolve it) or the
     /// program cannot be executed; [`Error::Size`] when the configured
-    /// [`size`](Self::size) has a zero dimension or one past the
+    /// [`size`](Self::size) has a dimension below 2 or past the
     /// 1000-per-axis limit; [`Error::Pty`] when the PTY cannot be opened.
     pub fn spawn(self, program: impl AsRef<OsStr>) -> Result<Terminal> {
         let program = program.as_ref();
@@ -1677,6 +1715,8 @@ fn strip_paste_markers(text: &str) -> String {
 /// 5000x5000 was accepted and turned the first wait into a 16-second
 /// timeout that blamed the predicate.
 const MAX_DIMENSION: u16 = 1000;
+/// The smallest grid the emulator can serve. Not 1: see `check_size`.
+const MIN_DIMENSION: u16 = 2;
 
 /// The value termlens can truthfully report for a terminfo capability, or
 /// `None` to decline it.
@@ -1800,16 +1840,33 @@ fn pixel_span(cells: u16, per_cell: Option<u16>) -> u16 {
 
 /// Reject a terminal size that cannot work, or cannot work usefully.
 ///
-/// A terminal has at least one row and one column. Letting a zero reach
-/// the emulator is not a graceful degradation: in debug builds vt100
-/// panics on an overflowing subtraction, and in release builds (the
-/// stress workflow runs `--release`) the arithmetic wraps, `spawn` and
-/// `resize` return `Ok`, and vt100 panics on the first printable byte —
-/// on the reader thread, where nothing propagates it. The drain dies
-/// silently, every later snapshot is blank, and a careless test goes
-/// green. Zeroes arrive from ordinary arithmetic (`resize(cols - 1, …)`
-/// in a loop), so this must be a typed error, not a panic in a
-/// dependency.
+/// Letting a zero reach the emulator is not a graceful degradation: in
+/// debug builds vt100 panics on an overflowing subtraction, and in release
+/// builds (the stress workflow runs `--release`) the arithmetic wraps,
+/// `spawn` and `resize` return `Ok`, and vt100 panics on the first
+/// printable byte — on the reader thread, where nothing propagates it. The
+/// drain dies silently, every later snapshot is blank, and a careless test
+/// goes green. Zeroes arrive from ordinary arithmetic (`resize(cols - 1, …)`
+/// in a loop), so this must be a typed error, not a panic in a dependency.
+///
+/// The floor is **2 per axis**, not 1, and each axis has its own reason —
+/// the guard against zero was one value too low on both (#211):
+///
+/// - `cols == 1` and a double-width character: vt100 computes
+///   `size.cols - width` with `cols = 1` and `width = 2`. Rows are
+///   irrelevant; `1x8` printing `汉` is enough.
+/// - `rows == 1` and a line that *wraps* past the last column. Columns are
+///   irrelevant: an entirely ordinary `80x1` printing a 100-character line
+///   panics, and so do `20x1` and `2x1`. A one-row terminal that scrolls by
+///   newline rather than by wrapping is fine, which is what made this look
+///   like an exotic case rather than an everyday one.
+///
+/// Both panic on the reader thread, in both profiles, so the symptom is the
+/// one described above: a frozen screen and a wait that runs to its
+/// deadline. Measured at the floor: `2x8` and `2x2` with a wide character
+/// render correctly, and `1x2` with a wrap does too — so 2 per axis is the
+/// smallest guard that closes both, and the narrowest useful terminal is
+/// still allowed.
 ///
 /// The upper bound exists for the mirror-image reason. Nothing rejected an
 /// implausible size, and a snapshot costs O(cells), so a transposed or
@@ -1818,10 +1875,12 @@ fn pixel_span(cells: u16, per_cell: Option<u16>) -> u16 {
 /// out, with a message about the predicate and no hint that the size was
 /// the problem. A named error at the call site is the whole fix.
 fn check_size(cols: u16, rows: u16) -> Result<()> {
-    if cols == 0 || rows == 0 {
+    if cols < MIN_DIMENSION || rows < MIN_DIMENSION {
         return Err(Error::Size(format!(
-            "a terminal needs at least one column and one row, got {cols}x{rows} \
-             (columns x rows)"
+            "a terminal needs at least {MIN_DIMENSION} columns and {MIN_DIMENSION} \
+             rows, got {cols}x{rows} (columns x rows); at one column the emulator \
+             panics on a double-width character, and at one row it panics on a line \
+             that wraps"
         )));
     }
     if cols > MAX_DIMENSION || rows > MAX_DIMENSION {
@@ -1889,6 +1948,21 @@ fn query_shape(query: &Query) -> String {
     }
 }
 
+/// A panic payload as a message, for [`Error::Emulator`].
+///
+/// Call it as `panic_detail(&*payload)`: `&payload` on a
+/// `Box<dyn Any + Send>` unsizes to a `&dyn Any` whose concrete type is the
+/// *box*, so every downcast below misses and the message is lost.
+fn panic_detail(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "the emulator panicked with no message".to_owned()
+    }
+}
+
 /// Drain the PTY into the emulator until EOF. Runs on a dedicated thread.
 fn reader_loop(
     mut reader: Box<dyn Read + Send>,
@@ -1930,6 +2004,14 @@ fn reader_loop(
             // lock but WRITTEN after it is released; the state lock
             // and the writer lock are never held together.
             let replies = shared.mutate(|state| {
+                // A panicked emulator is never fed again: its grid is in
+                // whatever state the panic left it. The loop still runs, so
+                // the PTY keeps draining and the child does not block
+                // writing into a full buffer — the same reason the reply
+                // queue never backpressures the reader.
+                if state.emu_panic.is_some() {
+                    return Vec::new();
+                }
                 // Counted before the chunk is processed, so a query
                 // inside it is recorded against *this* read: output
                 // batched into the same write as the probe must not
@@ -1937,42 +2019,60 @@ fn reader_loop(
                 state.reads += 1;
                 let mut replies: Vec<Vec<u8>> = Vec::new();
                 let mut offset = 0;
-                while offset < chunk.len() {
-                    let processed = state.emu.process(&chunk[offset..]);
-                    offset += processed.consumed;
-                    match processed.stop {
-                        Some(Stop::FrameComplete(span)) => {
-                            state.frames_seen += 1;
-                            // Through `build_snapshot`, so a retained
-                            // frame carries the repaint count like every
-                            // other snapshot. Taking it straight from the
-                            // emulator left `Screen::repaints()` at zero
-                            // on exactly the screens `wait_frame` hands
-                            // back — the ones most likely to be asked.
-                            let frame = state.build_snapshot();
-                            if state.frames.len() == FRAME_HISTORY {
-                                state.frames.pop_front();
+                // The emulation is a dependency running on a thread whose
+                // panics propagate nowhere, so it is caught here and turned
+                // into a fact about the terminal that every wait can report
+                // (#211). AssertUnwindSafe: on the panic path `state` is
+                // only ever read again through the frozen snapshot.
+                let processing = panic::catch_unwind(AssertUnwindSafe(|| {
+                    while offset < chunk.len() {
+                        let processed = state.emu.process(&chunk[offset..]);
+                        offset += processed.consumed;
+                        match processed.stop {
+                            Some(Stop::FrameComplete(span)) => {
+                                state.frames_seen += 1;
+                                // Through `build_snapshot`, so a retained
+                                // frame carries the repaint count like every
+                                // other snapshot. Taking it straight from the
+                                // emulator left `Screen::repaints()` at zero
+                                // on exactly the screens `wait_frame` hands
+                                // back — the ones most likely to be asked.
+                                let frame = state.build_snapshot();
+                                if state.frames.len() == FRAME_HISTORY {
+                                    state.frames.pop_front();
+                                }
+                                state.frames.push_back((state.frames_seen, frame));
+                                // Timings outlive the frame ring: a
+                                // performance line is held over a run, not
+                                // over the last eight repaints.
+                                if state.timings.len() == FRAME_TIMING_HISTORY {
+                                    state.timings.pop_front();
+                                }
+                                state.timings.push_back(FrameTiming {
+                                    index: state.frames_seen,
+                                    duration: span.duration,
+                                    printable: span.printable,
+                                });
                             }
-                            state.frames.push_back((state.frames_seen, frame));
-                            // Timings outlive the frame ring: a
-                            // performance line is held over a run, not
-                            // over the last eight repaints.
-                            if state.timings.len() == FRAME_TIMING_HISTORY {
-                                state.timings.pop_front();
+                            Some(Stop::Query(query)) => {
+                                if let Some(reply) = state.answer(&query) {
+                                    replies.push(reply);
+                                }
                             }
-                            state.timings.push_back(FrameTiming {
-                                index: state.frames_seen,
-                                duration: span.duration,
-                                printable: span.printable,
-                            });
+                            None => {}
                         }
-                        Some(Stop::Query(query)) => {
-                            if let Some(reply) = state.answer(&query) {
-                                replies.push(reply);
-                            }
-                        }
-                        None => {}
                     }
+                }));
+                if let Err(payload) = processing {
+                    // Freeze the last good screen before `touch()` can
+                    // invalidate the cache, so the error carries the grid as
+                    // it stood when the emulator was last coherent.
+                    let frozen = state
+                        .snapshot_cache
+                        .take()
+                        .map_or_else(|| state.build_snapshot(), |(_, screen)| screen);
+                    state.emu_panic = Some(panic_detail(&*payload));
+                    state.snapshot_cache = Some((state.generation, frozen));
                 }
                 state.utf8_pending = utf8_pending;
                 state.touch();
@@ -2714,6 +2814,8 @@ impl Terminal {
     /// # Errors
     ///
     /// [`Error::Timeout`] / [`Error::Eof`], each carrying the screen.
+    /// [`Error::Emulator`] if the emulation itself failed, in which case the
+    /// grid stopped advancing and no predicate over it means anything.
     pub fn wait_until(&mut self, predicate: impl FnMut(&Screen) -> bool) -> Result<()> {
         self.wait_until_deadline(predicate, self.default_timeout)
     }
@@ -2749,6 +2851,11 @@ impl Terminal {
             }
             seen_generation = Some(state.generation);
 
+            // Before the predicate: a frozen screen can still satisfy one,
+            // and a match on a grid that stopped advancing is not an answer.
+            if let Some(failure) = state.emulator_failure() {
+                return Some(Err(failure));
+            }
             let screen = state.peek_snapshot();
             if predicate(&screen) {
                 return Some(Ok(()));
@@ -2899,6 +3006,9 @@ impl Terminal {
         let cursor = self.frame_cursor;
         let mut seen_frame = None;
         let outcome = self.shared.wait_until(deadline, |state| {
+            if let Some(failure) = state.emulator_failure() {
+                return Some(Err(failure));
+            }
             if state.frames_seen > cursor && seen_frame != Some(state.frames_seen) {
                 seen_frame = Some(state.frames_seen);
                 // Oldest unobserved frame first: several frames can
@@ -3039,6 +3149,11 @@ impl Terminal {
         let deadline = Instant::now() + timeout;
         let mut guard = self.shared.lock();
         loop {
+            // Ahead of the EOF shortcut: a stream that stopped because the
+            // emulator died is not a stream that went quiet.
+            if let Some(failure) = guard.emulator_failure() {
+                return Err(failure);
+            }
             if guard.eof {
                 return Ok(());
             }
@@ -3283,9 +3398,9 @@ impl Terminal {
     ///
     /// # Errors
     ///
-    /// [`Error::Size`] if either dimension is zero (a terminal has at least
-    /// one row and one column) or past the 1000-per-axis limit, before the
-    /// PTY or the grid is touched; [`Error::Write`] when the child has
+    /// [`Error::Size`] if either dimension is below 2 or past the
+    /// 1000-per-axis limit, before the PTY or the grid is touched;
+    /// [`Error::Write`] when the child has
     /// released the terminal, carrying the final screen; [`Error::Pty`] if
     /// the ioctl fails.
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<()> {
@@ -3390,11 +3505,181 @@ impl Drop for Terminal {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
 
-    use super::{cells_between, check_mouse_in_grid, history_note, Scroll, ScrollChord};
+    use super::{
+        cells_between, check_mouse_in_grid, check_size, history_note, panic_detail, reader_loop,
+        EmuState, Graphics, Monitor, Responder, Scroll, ScrollChord,
+    };
+    use crate::emu::{Emulator, InputModes, ModeState, MouseEncoding, Processed};
     use crate::screen::{Cell, Style, TermState};
     use crate::{Error, Screen};
+
+    /// An emulator that renders one line and then panics, so the reader's
+    /// failure path can be exercised without waiting for a vt100 bug to
+    /// come back (#211).
+    struct PanickingEmulator {
+        reads: usize,
+    }
+
+    impl PanickingEmulator {
+        fn screen() -> Screen {
+            let cells = vec![
+                Cell::new("o".into(), Style::default(), false, false),
+                Cell::new("k".into(), Style::default(), false, false),
+            ];
+            Screen::from_parts(2, 1, 0, 2, true, cells, TermState::default())
+        }
+    }
+
+    impl Emulator for PanickingEmulator {
+        fn process(&mut self, _bytes: &[u8]) -> Processed {
+            // The worst case: it fails on first contact, before any wait has
+            // taken a snapshot of its own. What the error carries then is the
+            // grid the terminal was spawned with, which is still true.
+            self.reads += 1;
+            panic!("attempt to subtract with overflow");
+        }
+        fn snapshot(&self) -> Screen {
+            assert_eq!(
+                self.reads, 0,
+                "the emulator must never be asked for a screen after it panicked"
+            );
+            Self::screen()
+        }
+        fn mid_sequence(&self) -> bool {
+            false
+        }
+        fn in_sync_update(&self) -> bool {
+            false
+        }
+        fn input_modes(&self) -> InputModes {
+            InputModes {
+                mouse: crate::MouseMode::None,
+                mouse_encoding: MouseEncoding::Legacy,
+                bracketed_paste: false,
+                application_cursor: false,
+                focus_events: false,
+            }
+        }
+        fn mode_state(&self, _mode: u32) -> ModeState {
+            ModeState::NotRecognized
+        }
+        fn set_size(&mut self, _rows: u16, _cols: u16) {}
+    }
+
+    fn panicking_state() -> Monitor<EmuState> {
+        Monitor::new(EmuState::new(
+            Box::new(PanickingEmulator { reads: 0 }),
+            Responder {
+                respond: false,
+                background: (0, 0, 0),
+                foreground: (0, 0, 0),
+                cell_size: None,
+                graphics: Graphics::default(),
+                term_name: "xterm-256color".into(),
+            },
+            Arc::new(AtomicUsize::new(0)),
+        ))
+    }
+
+    /// The reader turns an emulator panic into state every wait can report,
+    /// instead of dying and leaving the grid frozen (#211).
+    #[test]
+    fn an_emulator_panic_is_recorded_rather_than_lost() {
+        let shared = panicking_state();
+        let writer: super::SharedWriter = Arc::new(std::sync::Mutex::new(None));
+        let pending = AtomicUsize::new(0);
+        let queued = AtomicUsize::new(0);
+
+        assert!(
+            shared.lock().emulator_failure().is_none(),
+            "healthy to start"
+        );
+
+        // The emulator panics on the first chunk. The reader must catch it,
+        // record it, and still drain to EOF — a reader that stops draining
+        // leaves the child blocked writing into a full buffer.
+        // (A "thread panicked" line on stderr here is the caught panic, and
+        // is expected: the default hook still runs.)
+        reader_loop(
+            Box::new(std::io::Cursor::new(b"first\nsecond\n".to_vec())),
+            &shared,
+            &writer,
+            None,
+            &pending,
+            &queued,
+        );
+
+        let guard = shared.lock();
+        let failure = guard
+            .emulator_failure()
+            .expect("the panic must be recorded, not swallowed");
+        match failure {
+            Error::Emulator { detail, screen } => {
+                assert!(
+                    detail.contains("attempt to subtract with overflow"),
+                    "the emulator's own message belongs in the error: {detail}"
+                );
+                // The frozen screen: the last one taken while the emulator
+                // was still coherent, and `snapshot` is never called again
+                // (PanickingEmulator asserts if it is).
+                assert_eq!(screen.size(), (2, 1));
+                assert_eq!(screen.text().trim_end(), "ok");
+            }
+            other => panic!("expected Error::Emulator, got {other}"),
+        }
+        assert!(
+            guard.eof,
+            "the drain must keep running to EOF after a panic"
+        );
+    }
+
+    #[test]
+    fn a_panic_payload_becomes_the_error_detail() {
+        assert_eq!(panic_detail(&"borrowed"), "borrowed");
+        assert_eq!(panic_detail(&String::from("owned")), "owned");
+        assert_eq!(
+            panic_detail(&7_u32),
+            "the emulator panicked with no message"
+        );
+
+        // Through a real `catch_unwind` payload, which is the only shape
+        // that matters: `&payload` on the returned `Box<dyn Any + Send>`
+        // unsizes to a `&dyn Any` holding the box, and every downcast
+        // misses. This asserts the deref the caller has to write.
+        let literal = super::panic::catch_unwind(|| panic!("static message")).unwrap_err();
+        assert_eq!(panic_detail(&*literal), "static message");
+        let formatted = super::panic::catch_unwind(|| panic!("{} {}", "formatted", 7)).unwrap_err();
+        assert_eq!(panic_detail(&*formatted), "formatted 7");
+    }
+
+    /// One column panics on a wide character and one row panics on a wrap,
+    /// in both profiles, so the floor is two per axis (#211).
+    #[test]
+    fn the_size_floor_is_two_on_both_axes() {
+        for (cols, rows) in [
+            (0, 24),
+            (80, 0),
+            (0, 0),
+            (1, 8),
+            (80, 1),
+            (1, 1),
+            (2, 1),
+            (1, 2),
+        ] {
+            let err = check_size(cols, rows).expect_err(&format!("{cols}x{rows} must be refused"));
+            assert!(matches!(err, Error::Size(_)), "{cols}x{rows}: {err}");
+        }
+        for (cols, rows) in [(2, 2), (2, 8), (80, 24), (1000, 1000)] {
+            assert!(
+                check_size(cols, rows).is_ok(),
+                "{cols}x{rows} must be allowed"
+            );
+        }
+        assert!(check_size(1001, 24).is_err());
+    }
 
     /// The modifier bits ride on the wheel code exactly as on a button.
     #[test]

--- a/crates/termlens/src/utf8.rs
+++ b/crates/termlens/src/utf8.rs
@@ -1,0 +1,149 @@
+//! Invalid UTF-8 becomes U+FFFD before it reaches the emulator.
+//!
+//! The backend's parser drops a byte it cannot decode, so a stray `0xE9` in
+//! a Latin-1 file name vanished from the grid and every column to its right
+//! shifted left (#217) — a terminal shows a replacement character there and
+//! keeps the columns where they are. Decoding happens here, once, on the
+//! reader thread, so both parsers (the primary and the attribute shadow)
+//! see the same valid stream.
+//!
+//! A multi-byte character can be split across two reads; the incomplete tail
+//! is carried over rather than replaced, and only becomes U+FFFD when the
+//! next bytes prove it was never going to complete — or at EOF.
+
+/// Replacement character, as bytes.
+const REPLACEMENT: &[u8] = "\u{FFFD}".as_bytes();
+
+/// A streaming UTF-8 sanitizer: valid sequences pass through unchanged,
+/// invalid ones become U+FFFD, and an incomplete trailing sequence waits for
+/// the next chunk.
+#[derive(Debug, Default)]
+pub(crate) struct Utf8Sanitizer {
+    /// The incomplete tail of the previous chunk — at most three bytes.
+    carry: Vec<u8>,
+}
+
+impl Utf8Sanitizer {
+    /// Sanitize one chunk. The result is always valid UTF-8; bytes that
+    /// might still complete a character are held back for the next call.
+    pub(crate) fn feed(&mut self, bytes: &[u8]) -> Vec<u8> {
+        let mut input: Vec<u8>;
+        let mut rest: &[u8] = if self.carry.is_empty() {
+            bytes
+        } else {
+            input = std::mem::take(&mut self.carry);
+            input.extend_from_slice(bytes);
+            &input
+        };
+        let mut out = Vec::with_capacity(rest.len());
+        loop {
+            match std::str::from_utf8(rest) {
+                Ok(_) => {
+                    out.extend_from_slice(rest);
+                    break;
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    out.extend_from_slice(&rest[..valid]);
+                    match e.error_len() {
+                        // Definitely invalid: one replacement per rejected
+                        // sequence, then carry on after it.
+                        Some(bad) => {
+                            out.extend_from_slice(REPLACEMENT);
+                            rest = &rest[valid + bad..];
+                        }
+                        // Could still complete: hold it for the next chunk.
+                        None => {
+                            self.carry.extend_from_slice(&rest[valid..]);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// True while a partial character is being held back — the stream ends
+    /// mid-character, which `wait_idle` must not read as silence.
+    pub(crate) fn pending(&self) -> bool {
+        !self.carry.is_empty()
+    }
+
+    /// At end of stream: whatever is still held back was never completed.
+    pub(crate) fn finish(&mut self) -> Vec<u8> {
+        if self.carry.is_empty() {
+            return Vec::new();
+        }
+        self.carry.clear();
+        REPLACEMENT.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(bytes: &[u8]) -> String {
+        String::from_utf8(bytes.to_vec()).expect("sanitizer output is valid UTF-8")
+    }
+
+    #[test]
+    fn valid_input_passes_through_untouched() {
+        let mut san = Utf8Sanitizer::default();
+        assert_eq!(
+            s(&san.feed("ascii and 汉字 and 🦀".as_bytes())),
+            "ascii and 汉字 and 🦀"
+        );
+        assert!(!san.pending());
+    }
+
+    #[test]
+    fn an_invalid_byte_becomes_one_replacement_and_the_columns_hold() {
+        let mut san = Utf8Sanitizer::default();
+        assert_eq!(s(&san.feed(b"caf\xe9 done")), "caf\u{FFFD} done");
+        assert!(!san.pending());
+    }
+
+    #[test]
+    fn a_character_split_across_two_reads_is_reassembled() {
+        let mut san = Utf8Sanitizer::default();
+        let bytes = "ab汉cd".as_bytes(); // 汉 is E6 B1 89
+        let first = san.feed(&bytes[..3]); // "ab" + E6
+        assert_eq!(s(&first), "ab");
+        assert!(san.pending(), "the lead byte is held, not replaced");
+        let second = san.feed(&bytes[3..]);
+        assert_eq!(s(&second), "汉cd");
+        assert!(!san.pending());
+    }
+
+    #[test]
+    fn a_lead_byte_the_next_read_does_not_continue_is_replaced_then() {
+        let mut san = Utf8Sanitizer::default();
+        assert_eq!(s(&san.feed(b"ab\xe9")), "ab");
+        assert!(san.pending());
+        assert_eq!(s(&san.feed(b"cd")), "\u{FFFD}cd");
+        assert!(!san.pending());
+    }
+
+    #[test]
+    fn a_partial_character_at_eof_is_one_replacement() {
+        let mut san = Utf8Sanitizer::default();
+        assert_eq!(s(&san.feed(b"x\xf0\x9f")), "x");
+        assert!(san.pending());
+        assert_eq!(s(&san.finish()), "\u{FFFD}");
+        assert!(!san.pending());
+        assert!(san.finish().is_empty());
+    }
+
+    #[test]
+    fn every_invalid_sequence_is_replaced_separately() {
+        let mut san = Utf8Sanitizer::default();
+        // Two stray continuation bytes, then a truncated three-byte lead
+        // followed by ASCII.
+        assert_eq!(
+            s(&san.feed(b"a\x80\x80b\xe6\xb1c")),
+            "a\u{FFFD}\u{FFFD}b\u{FFFD}c"
+        );
+    }
+}

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -106,6 +106,34 @@ fn envs_and_env_preserve_order_and_duplicates() -> termlens::Result<()> {
 }
 
 #[test]
+fn env_clear_hands_the_child_exactly_the_builder_environment() -> termlens::Result<()> {
+    // Enumerate the whole environment rather than probing one name, so a
+    // leaked variable cannot arrive unnoticed: SHELL did, filled in by the
+    // PTY layer from the host's login shell (#221). `/usr/bin/env` is spawned
+    // directly — no shell, which would add PWD and friends of its own — and
+    // by absolute path, because PATH is gone.
+    let mut t = Terminal::builder()
+        .env_clear()
+        .env("MARKER", "1")
+        .spawn("/usr/bin/env")?;
+    assert!(t.wait_exit()?.success());
+    let screen = t.screen();
+    let mut vars: Vec<String> = screen
+        .text()
+        .lines()
+        .filter(|line| line.contains('='))
+        .map(str::to_owned)
+        .collect();
+    vars.sort();
+    assert_eq!(
+        vars,
+        ["MARKER=1", "SHELL=/bin/sh", "TERM=xterm-256color"],
+        "the child's environment is not a function of the builder alone:\n{screen}"
+    );
+    Ok(())
+}
+
+#[test]
 fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termlens::Result<()> {
     // Probe HOME, not PATH: shells synthesize a compiled-in default PATH
     // when none is inherited, so PATH can't distinguish "inherited" from

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -29,6 +29,25 @@ fn an_empty_program_name_is_a_short_typed_error() {
 }
 
 #[test]
+fn the_default_working_directory_is_the_test_process_s() -> termlens::Result<()> {
+    // Without `current_dir` the child used to start in $HOME — the PTY
+    // layer's fallback — while `current_dir`'s rustdoc said it inherited the
+    // test runner's (#215). Pinned here so the default cannot move quietly.
+    let mut t = Terminal::builder().spawn("/bin/pwd")?;
+    assert!(t.wait_exit()?.success());
+    let reported = std::path::PathBuf::from(t.screen().row_text(0).trim());
+    let expected = std::env::current_dir()?;
+    assert_eq!(
+        reported.canonicalize()?,
+        expected.canonicalize()?,
+        "child ran in {} rather than the test process's {}",
+        reported.display(),
+        expected.display()
+    );
+    Ok(())
+}
+
+#[test]
 fn a_missing_working_directory_fails_instead_of_running_elsewhere() {
     let missing = std::env::temp_dir().join("termlens-no-such-dir-xyz");
     assert!(!missing.is_dir(), "test precondition");

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -110,6 +110,58 @@ fn a_file_is_not_a_working_directory() {
     let _ = std::fs::remove_file(&file);
 }
 
+/// One column panics the emulator on a double-width character, and one row
+/// panics it on a line that wraps — on the reader thread, in both profiles,
+/// where the symptom is a frozen screen and a wait that runs to its
+/// deadline while cargo prints `test result: ok` (#211). The guard against
+/// zero was one value too low on each axis.
+#[test]
+fn a_single_row_or_column_is_refused_like_a_zero() {
+    for (cols, rows) in [(1u16, 8u16), (80, 1), (1, 1), (2, 1), (1, 2)] {
+        let err = Terminal::builder()
+            .size(cols, rows)
+            .args(["-c", "true"])
+            .spawn("/bin/sh")
+            .expect_err(&format!("{cols}x{rows} must be refused"));
+        assert!(matches!(err, Error::Size(_)), "{cols}x{rows}: got {err}");
+        assert!(
+            err.to_string().contains("at least 2"),
+            "the message must name the floor: {err}"
+        );
+    }
+}
+
+/// The two shapes that used to kill the emulator thread, at the smallest
+/// size still allowed. Both must render — the floor is the smallest guard
+/// that closes the panics, not a retreat from small terminals.
+#[test]
+fn the_narrowest_allowed_terminal_renders_both_trigger_shapes() -> termlens::Result<()> {
+    // Trigger A was one column meeting a double-width character.
+    let mut wide = Terminal::builder()
+        .size(2, 8)
+        .timeout(Duration::from_secs(5))
+        .args(["-c", r"printf '\346\261\211'; read guard"])
+        .spawn("/bin/sh")?;
+    wide.wait_until(|s| s.contains("汉"))?;
+    assert_eq!(wide.screen().row_text(0).trim_end(), "汉");
+    wide.send(termlens::Key::Enter)?;
+    wide.wait_exit()?;
+
+    // Trigger B was one row meeting a line that wraps.
+    let mut wrap = Terminal::builder()
+        .size(2, 2)
+        .timeout(Duration::from_secs(5))
+        .args(["-c", r"printf 'abcZ'; read guard"])
+        .spawn("/bin/sh")?;
+    wrap.wait_until(|s| s.contains("Z"))?;
+    let screen = wrap.screen();
+    assert_eq!(screen.row_text(0).trim_end(), "ab", "{screen}");
+    assert_eq!(screen.row_text(1).trim_end(), "cZ", "{screen}");
+    wrap.send(termlens::Key::Enter)?;
+    wrap.wait_exit()?;
+    Ok(())
+}
+
 /// A zero dimension used to reach vt100, which panicked on an
 /// overflowing subtraction in debug builds and — worse — panicked on the
 /// *reader thread* in release builds, killing the drain silently.
@@ -139,17 +191,22 @@ fn resize_to_zero_is_refused_without_touching_the_pty_or_the_grid() -> termlens:
         .spawn("/bin/sh")?;
     t.wait_until(|s| s.contains("ready"))?;
 
-    for (cols, rows) in [(0u16, 24u16), (80, 0), (0, 0)] {
+    // Zero, and — the value the guard used to let through — one, on each
+    // axis (#211). `resize(cols - 1, …)` walked down in a loop reaches both
+    // by ordinary arithmetic.
+    for (cols, rows) in [(0u16, 24u16), (80, 0), (0, 0), (1, 24), (80, 1), (1, 1)] {
         let err = t
             .resize(cols, rows)
-            .expect_err("a terminal cannot have a zero dimension");
+            .expect_err("a terminal needs at least two columns and two rows");
         assert!(matches!(err, Error::Size(_)), "{cols}x{rows}: got {err}");
     }
-
     // The grid is untouched and the terminal still works.
     assert_eq!(t.screen().size(), (80, 24));
     t.resize(70, 20)?;
     assert_eq!(t.screen().size(), (70, 20));
+    // …and the floor itself is a legal size to resize to.
+    t.resize(2, 2)?;
+    assert_eq!(t.screen().size(), (2, 2));
     t.send(termlens::Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -48,6 +48,31 @@ fn the_default_working_directory_is_the_test_process_s() -> termlens::Result<()>
 }
 
 #[test]
+fn a_bare_program_name_under_env_clear_is_refused_with_the_remedies() {
+    // env_clear drops PATH, and the PTY layer's only diagnostic for the bare
+    // name that then cannot resolve was "Unable to resolve the PATH" (#222).
+    let err = Terminal::builder().env_clear().spawn("sh").unwrap_err();
+    assert!(matches!(err, Error::Spawn { .. }), "{err}");
+    let msg = err.to_string();
+    for needed in ["`sh`", "env_clear", "PATH", "absolute path"] {
+        assert!(msg.contains(needed), "missing {needed:?} in: {msg}");
+    }
+    // Either remedy works: a PATH of the test's own…
+    let with_path = Terminal::builder()
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .args(["-c", "true"])
+        .spawn("sh");
+    assert!(with_path.is_ok(), "{:?}", with_path.err());
+    // …or an absolute path, which never needed one.
+    let absolute = Terminal::builder()
+        .env_clear()
+        .args(["-c", "true"])
+        .spawn("/bin/sh");
+    assert!(absolute.is_ok(), "{:?}", absolute.err());
+}
+
+#[test]
 fn a_missing_working_directory_fails_instead_of_running_elsewhere() {
     let missing = std::env::temp_dir().join("termlens-no-such-dir-xyz");
     assert!(!missing.is_dir(), "test precondition");

--- a/crates/termlens/tests/inspect.rs
+++ b/crates/termlens/tests/inspect.rs
@@ -64,3 +64,34 @@ fn inspect_runs_and_reports_cli_failures() {
         String::from_utf8_lossy(&missing_program.stderr)
     );
 }
+
+#[test]
+fn inspect_survives_a_reader_that_closes_early() {
+    use std::io::Read;
+    use std::process::Stdio;
+
+    // 200x1000 cells is far more than a pipe holds, so once the read end is
+    // closed the write gets EPIPE — which println! turned into a panic and
+    // exit 101 (#223). A viewer piped into `head` must exit cleanly.
+    let bin = inspect_bin();
+    let mut child = Command::new(&bin)
+        .args(["--size", "200x1000", "sh", "-c", "yes | head -n 2000"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn the inspect example");
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut first = [0u8; 16];
+    let _ = stdout.read(&mut first);
+    drop(stdout);
+    let status = child.wait().expect("inspect did not exit");
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("stderr is piped")
+        .read_to_string(&mut stderr)
+        .expect("stderr is readable");
+    assert!(!stderr.contains("panicked"), "inspect panicked:\n{stderr}");
+    assert_eq!(status.code(), Some(0), "stderr:\n{stderr}");
+}

--- a/crates/termlens/tests/readme_example.rs
+++ b/crates/termlens/tests/readme_example.rs
@@ -16,11 +16,12 @@ fn readme_example_compiles_and_runs() -> termlens::Result<()> {
         .timeout(Duration::from_secs(5))
         .spawn(util::fixture_bin("hello-tui"))?;
 
-    // The README waits on "Ready" and snapshots. The fixture's last byte is
-    // the bottom-right corner, so the corner is waited on as well — rule 2
-    // of `docs/DESIGN.md` §2: a whole-screen snapshot must wait on the last
+    // The same shape as the README's predicate: the status text AND the
+    // bottom-right corner, which is the fixture's last byte — rule 2 of
+    // `docs/DESIGN.md` §2: a whole-screen snapshot must wait on the last
     // thing the application paints, or it races the rest of the frame at a
-    // chunk boundary.
+    // chunk boundary. The README waited on the first marker alone until
+    // #216; a reviewer diffing the two should see no discrepancy in shape.
     t.wait_until(|screen| screen.contains("status: ready") && screen.contains("╯"))?;
     // The README's most distinctive line, compiled against the `insta` the
     // crate itself dev-depends on. A dev-dependency is present in every

--- a/crates/termlens/tests/styles.rs
+++ b/crates/termlens/tests/styles.rs
@@ -76,6 +76,27 @@ fn styled_screen_snapshot() -> termlens::Result<()> {
 /// renderings were identical in the grid — the one failure mode where a
 /// green test certifies the bug it was written to catch.
 #[test]
+fn a_highlight_over_a_wide_character_is_one_span() -> termlens::Result<()> {
+    // A wide character's continuation column used to snapshot unstyled, so
+    // a bar over CJK or emoji rendered as two spans with a hole (#218).
+    let mut t = sh(r"printf '\033[48;2;30;30;46mab汉cd\033[0m'; read guard")?;
+    t.wait_until(|s| s.contains("cd"))?;
+    let s = t.screen();
+    let bar = termlens::Color::Rgb(30, 30, 46);
+    let styled = s.with_styles().to_string();
+    assert!(styled.contains("0: 0-5 bg=#1e1e2e"), "{styled}");
+    assert_eq!(
+        s.cell(0, 3).unwrap().style().bg,
+        bar,
+        "the continuation column"
+    );
+    assert_eq!(s.find_by(|c| c.style().bg == bar), Some((0, 0)));
+    t.send(termlens::Key::Enter)?;
+    t.wait_exit()?;
+    Ok(())
+}
+
+#[test]
 fn a_masked_field_is_distinguishable_from_clear_text() -> termlens::Result<()> {
     // The cursor is pinned for the same reason, plus one specific to this
     // test: the styled comparison below asserts a *difference*, so an

--- a/crates/termlens/tests/utf8.rs
+++ b/crates/termlens/tests/utf8.rs
@@ -1,0 +1,63 @@
+//! Bytes that are not UTF-8 reach the grid as U+FFFD, and the columns after
+//! them stay where a terminal puts them (#217).
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+fn sh(script: &str) -> termlens::Result<Terminal> {
+    Terminal::builder()
+        .timeout(Duration::from_secs(5))
+        .args(["-c", script])
+        .spawn("/bin/sh")
+}
+
+#[test]
+fn an_invalid_byte_is_a_replacement_character_and_the_columns_hold() -> termlens::Result<()> {
+    // A Latin-1 `é` in a file name, a corrupted log line: the byte used to
+    // be deleted from the grid, so `done` sat one column too far left and
+    // nothing on the Screen said a byte had gone.
+    let mut t = sh(r"printf 'raw: caf\351 done'; read guard")?;
+    t.wait_until(|s| s.contains("done"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "raw: caf\u{FFFD} done");
+    assert_eq!(s.cell(0, 8).unwrap().contents(), "\u{FFFD}");
+    assert_eq!(s.find("done"), Some((0, 10)));
+    t.send(Key::Enter)?;
+    t.wait_exit()?;
+    Ok(())
+}
+
+#[test]
+fn a_character_split_across_two_writes_is_still_one_character() -> termlens::Result<()> {
+    // 汉 is E6 B1 89. The lead byte arrives in one read and the rest in
+    // another; the sanitizer must carry it, not replace it.
+    let mut t = sh(r"printf 'ab\346'; sleep 0.2; printf '\261\211cd'; read guard")?;
+    t.wait_until(|s| s.contains("cd"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "ab汉cd");
+    assert_eq!(s.find("cd"), Some((0, 4)));
+    t.send(Key::Enter)?;
+    t.wait_exit()?;
+    Ok(())
+}
+
+#[test]
+fn wait_idle_does_not_call_a_half_written_character_silence() -> termlens::Result<()> {
+    // The application stops for 600ms in the middle of a character. That is
+    // not idleness — the stream ends mid-character — so `wait_idle` must
+    // hold until the character completes, and the screen it returns to must
+    // show it whole.
+    let mut t = sh(r"printf 'ab\346'; sleep 0.6; printf '\261\211cd'; read guard")?;
+    t.wait_until(|s| s.contains("ab"))?;
+    t.wait_idle_for(Duration::from_millis(150), Duration::from_secs(5))?;
+    let s = t.screen();
+    assert_eq!(
+        s.row_text(0).trim_end(),
+        "ab汉cd",
+        "wait_idle returned on a half-written character:\n{s}"
+    );
+    t.send(Key::Enter)?;
+    t.wait_exit()?;
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -327,9 +327,15 @@ the PTY. Three rules make such waits deterministic:
    `wait_idle` first. That is a heuristic (silence ≠ proof of a finished
    render — see above), and it is the honest tool for the job.
 
-Applications that bracket repaints in DEC 2026 synchronized updates need
-none of this discipline: `wait_frame` evaluates predicates only on
-complete frames.
+4. **`wait_frame` removes the torn-frame race, not rule 1.** An
+   application that brackets its repaints in DEC 2026 synchronized updates
+   lets `wait_frame` evaluate predicates only on complete frames, so half a
+   row can never match — but a predicate true of frames you did not mean
+   returns one of them. `send(key)` then `wait_frame(|s| s.contains("MENU"))`
+   hands back the oldest not-yet-returned frame showing a menu, which can
+   be the one painted *before* the key. Name what the key changes, exactly
+   as rule 1 asks. The frame you get carries its own `repaints()`, so how
+   far behind the live screen it is can be checked rather than assumed.
 
 ### The resize stale-frame trap
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,11 @@
 # rustfmt/clippy output is reproducible across machines.
 #
 # This is NOT the MSRV. The minimum supported Rust version is declared as
-# `rust-version` in Cargo.toml and verified by the `msrv` CI job.
+# `rust-version` in Cargo.toml and verified by the `msrv` CI job, which
+# runs `cargo check --workspace --locked --all-targets` with
+# `RUSTUP_TOOLCHAIN` set to that version — because rustup honours this file
+# over the toolchain the job installs, and without the override the job
+# checked stable for months (#213).
 [toolchain]
 channel = "stable"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes the whole of milestone `v0.9`: the seventeen issues filed from the 0.8.0 audit, each reproduced against the release before it was written down and each fixed here with a test that fails without the fix.

Fourteen commits, one per issue (three group naturally). Every commit is individually `cargo fmt --all --check` clean, signed off, and carries its `Closes #NNN`.

### The silent passes — a gate that reported OK on something it never checked

- **#213** the `msrv` job has never compiled at the MSRV. `dtolnay/rust-toolchain` installs the version from `Cargo.toml`, then `rust-toolchain.toml`'s `channel = "stable"` overrides it for `cargo check` — that file's own comment claims the job verifies the MSRV. Fixed with `RUSTUP_TOOLCHAIN`, plus a step that **asserts** the active rustc before anything compiles, so the no-op cannot come back quietly. Now also `--all-targets`.
- **#214** both policy scripts fed `git rev-list` through a process substitution, which hides its exit status: a range git could not resolve walked zero commits and printed OK. They now refuse an unresolvable *and* an empty range. **Fixed in `ecosystem/standards/` and synced here byte-identically**; the ecosystem's own suite gained the unreadable-range cases.
- **#226** no job ran the default feature set — the one `cargo add termlens --dev` produces. `no-default-features` is now `features` and runs all four, plus clippy on the default set.
- **#227** CONTRIBUTING §1 promises every gate is reproducible locally and was missing two. Both added, and a new `gates-listed` job fails when a `cargo` gate in `ci.yml` has no counterpart in that block — so the list cannot drift a third time.

### The emulator

- **#211** one column meeting a double-width character, and one row meeting a line that *wraps*, both panic vt100 on the reader thread — in debug **and** release — while `cargo test` prints `test result: ok` over a suite that has stopped testing anything. `80x1` is an ordinary shape. Two halves: the floor is now 2 per axis (#49's "no path can reach the emulator with a zero" was satisfied exactly one value too low), and the reader wraps the emulation in `catch_unwind` so a panic becomes the new `Error::Emulator` — with the emulator's own message and the last screen before the failure — instead of an eternal timeout against a frozen grid.
- **#217** a byte that is not UTF-8 was deleted from the grid and every column after it shifted left. vt100 drops both the undecodable byte *and* the U+FFFD its own parser substitutes, so decoding now happens once on the reader thread, and the replacement travels through the backend as a noncharacter it will draw. A character split across two reads is carried, not replaced; `wait_idle` no longer calls a stream that stopped mid-character silence.
- **#218** a wide character's continuation column carried no style, so a highlight over CJK or emoji rendered as two spans with a hole and `cell().style()` reported `Default` — while DESIGN §3 rule 5 and `find_by`'s rustdoc promised the opposite.
- **#212** `find`'s single-row path searched the row padded to the terminal width while `contains` searched trimmed text, so `find("password: ")` returned a hit on a screen where the field was empty. Both rustdocs state the invariant that they can never disagree.

### The spawn contract

- **#215** the child started in `$HOME` — the PTY layer's fallback — while `current_dir`'s rustdoc promised the test runner's directory.
- **#221** `env_clear()` leaked the machine's login shell through `SHELL`.
- **#222** `env_clear()` drops `PATH`, so a bare program name failed with "Unable to resolve the PATH", naming neither cause nor remedy.
- **#223** `inspect … | head` panicked on the broken pipe and exited 101.

### Documents that said the opposite of the behaviour

**#216** the README's own first example was the race DESIGN §2 rule 2 forbids · **#219** `rect_text` claimed to be the only column-first API while `click`, `drag`, `scroll` and `resize` all are · **#220** `wait_frame` was described as needing none of `wait_until`'s discipline · **#224** `ExitStatus::signal()` returns the host libc's `strsignal`, so both its examples were wrong on one of the two supported platforms · **#225** `bold` and `dim` are one intensity state, so `ESC[1;2m` reports dim only.

### Two judgement calls worth a reviewer's attention

1. **The 2x2 floor is a behaviour change, not purely a fix.** A test using `size(80, 1)` now gets `Error::Size` where it previously got a silently dead harness. It is in the CHANGELOG under **Changed**. `2x8` and `2x2` render both trigger shapes, so the floor is the smallest guard that closes the panics rather than a retreat from small terminals.
2. **The default working directory moved** from `$HOME` to the test process's own (#215). It is what `current_dir`'s rustdoc already promised and what `std::process::Command` does, but a suite that relied on the old fallback needs `.current_dir(…)` explicitly. Also **Changed**.

### Verification

Locally, on this branch: `fmt`; clippy under all four feature configurations; the full suite under `--all-features`, default, `--no-default-features`, and `--no-default-features --features decode`; **the release profile**, which is what `stress.yml` runs; `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features`; `cargo +1.85 check --workspace --locked --all-targets`; and both policy scripts over the range.

Two of the gates this PR *changes* — the `msrv` job now genuinely running at 1.85, and the new `gates-listed` job — get their first real exercise on this PR rather than locally, so those two check results are the ones worth reading.
