### PR TITLE
docs: document terminal size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,13 @@ design. termlens's position:
   [stress workflow](.github/workflows/stress.yml) on Linux and macOS —
   wait/timing changes don't merge without surviving it.
 
-## Known limitations (v0.8)
+## Known limitations
 
+- **Terminal dimensions are 2–1000 cells per axis.** At one column, a
+  double-width character overflows the backend's arithmetic; at one row, a
+  line that wraps does the same (a one-row terminal that scrolls by newline
+  is fine). Larger grids are refused because every snapshot costs one entry
+  per cell.
 - Scrollback is **bounded** (1000 rows by default), **text only** — a
   scrolled-off row has no styles and no cell addressing — and is **not
   reflowed** by a `resize`: rows keep the width they were captured at, by


### PR DESCRIPTION
## Summary

- document the 2–1000 cell range for each terminal axis
- explain the distinct one-column and one-row failure modes
- remove the stale v0.8 marker from the Known limitations heading

## Testing

- `git diff --check`
- `.github/scripts/check-dco.sh origin/main..HEAD`
- `.github/scripts/check-no-ai-attribution.sh origin/main..HEAD`

Cargo checks were not run because the Rust toolchain is not installed locally. This is a README-only change; the existing size validation tests remain unchanged.

Closes #231
