### PR TITLE
ci(install): run the fresh-consumer check daily

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -11,7 +11,7 @@
 #   * A **fresh dependency resolution**. Our CI resolves against the committed
 #     lockfile; a consumer does not, so a dependency's own release can break
 #     the published crate days after it was published with nothing changed
-#     here. That is why this runs weekly and not only at publish.
+#     here. That is why this runs daily and not only at publish.
 #   * A feature that resolves in this workspace and nowhere else. `decode` is
 #     off by default and pulls a dependency of its own, which makes it exactly
 #     the shape of thing that works until someone outside tries it.
@@ -36,9 +36,16 @@ on:
       version:
         description: "Version to verify (default: the newest published)"
         required: false
-  # Scheduled runs are disabled. Uncomment the block below to restore them.
-  # schedule:
-  #   - cron: "37 7 * * 1" # Mondays, after the stress run
+  # Daily, deliberately. This job is the only one that sees a *fresh*
+  # `cargo add termlens`, and that is the build that breaks between releases
+  # without any change here: tinyvec 1.13.0 (2026-09-03) did not compile, so
+  # for four hours every new consumer of the published 0.8.0 failed to build
+  # while every check in this repository stayed green on the committed
+  # lockfile. #208 turned the weekly cron off; a weekly run would have
+  # missed that window entirely. Both legs together cost under a minute
+  # (~20s Ubuntu, ~30s macOS), so a day is the right latency for the price.
+  schedule:
+    - cron: "37 7 * * *" # 07:37 UTC, after Dependabot's morning
 
 permissions:
   contents: read


### PR DESCRIPTION
Restores a schedule for `install.yml` — **daily**, `install.yml` only; `stress.yml` stays off. This reverses half of #208, so the reasoning is written out here for the record.

### What happened

`tinyvec 1.13.0` was published 2026-09-03 21:13 UTC and does not compile (`use alloc::vec::{self, Vec}` shadows the `vec!` macro; Lokathor/tinyvec#225). termlens 0.8.0 → `unicode-normalization` → `tinyvec`, and termlens is the only path to it in a typical TUI test suite. Measured against the published crate, on stable 1.97.1, editions 2021 and 2024:

```
$ cargo add termlens --dev && cargo build
error: cannot find macro `vec` in this scope
   --> tinyvec-1.13.0/src/tinyvec.rs:710:21
error: could not compile `tinyvec`
```

Every check in this repository stayed green, because `Cargo.lock` pins 1.12.0. Upstream shipped 1.13.1 at 01:26 the next morning and a fresh resolve now picks it up; ratatui's documented example passes end to end again. The window was about four hours — and it opened in the same week ratatui's testing recipe started sending readers to `cargo add termlens --dev`.

### Why daily, and why only this job

- `install.yml` is the **only** job that performs a fresh dependency resolution against the *published* crate. `test`, `features` and `msrv` all build the committed lockfile, so they structurally cannot see this class of failure.
- A weekly Monday run would have missed a Thursday-night-to-Friday-morning window outright. Daily gives a real chance at a short window and bounds a long one to a day.
- Cost: from the last three runs, `consume (ubuntu-latest)` is ~20 s and `consume (macos-latest)` ~30 s. Daily is roughly 10 Ubuntu-minutes and 15 macOS-minutes a month.
- `stress.yml` is a different animal — many minutes across five machines — and #208's reason for turning it off stands. Not touched.

The cron time keeps #208's chosen minute and moves the day-of-week to every day; the block comment says why, so the next person deciding about schedules has the incident in front of them rather than a bare cron line.

### Not done here

- No CHANGELOG entry: workflow configuration, not user-facing (same call as #208).
- Nothing about the `tinyvec` pin itself. Bounding a transitive dependency's version from here would be the wrong layer; the upstream fix is out.

Verified: the YAML parses and every existing trigger (`release`, `workflow_call`, `workflow_dispatch`) is unchanged. A manual dispatch of the current `install.yml` was started at 02:05 UTC today to confirm the fresh consumer builds again on 1.13.1.
