### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-05
+
 ### Added
 
 - **`Error::Emulator`: an emulator panic is a diagnosis, not a timeout.** The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "form-echo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "crossterm",
 ]
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "hello-tui"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "crossterm",
  "termlens",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "image-echo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "miniz_oxide",
 ]
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "resize-echo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "crossterm",
 ]
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -612,7 +612,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.8.0"
+version = "0.9.0"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "fixtures/*"]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.


### PR DESCRIPTION
docs/RELEASING.md steps 2–4 for 0.9.0.

- `workspace.package.version` 0.8.0 → 0.9.0; `cargo check --workspace` refreshed the lockfile.
- CHANGELOG: `[Unreleased]` → `[0.9.0] - 2026-09-05`, with a fresh empty `[Unreleased]` above it. `extract-changelog.sh 0.9.0` prints the section; `Unreleased` prints nothing.
- Doc-named versions: nothing names 0.8 as current (the announcement post and an install.yml comment refer to it historically).

Green main: the tree merged in #243 (595e825) is byte-identical, `deny.toml` aside, to the branch head the stress workflow passed 10/10 shards on (https://github.com/vyncint/termlens/actions/runs/33936252643).

After the squash-merge: `git tag v0.9.0` on main and push it; release.yml checks tag == crate version, runs CI, cargo-semver-checks against 0.8.0, publishes via Trusted Publishing, and cuts the GitHub Release from this CHANGELOG section. Minor bump: `Screen::mouse_modes`/`MouseModes`, `Terminal::snapshot_after`/`wait_stable`, and `bin!` are additive; the two behaviour changes (2x2 floor, cwd default) were already in `[Unreleased]` under **Changed**.