### PR TITLE
docs: label feature-gated APIs on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ listed under a **Changed** or **Removed** heading.
   cell and style assertions. Every Rust block in it is compiled against the
   crate in CI, and the README shows the one-line install for Claude Code.
 
+### Fixed
+
+- **docs.rs labels APIs gated by the `decode` and `insta` features.** Optional
+  items no longer appear to be available in every build. (#258)
+
 ## [0.9.0] - 2026-09-05
 
 ### Added

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -13,6 +13,7 @@ authors.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["insta"]

--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -301,6 +301,7 @@ impl GraphicsPayload {
     /// size. [`DecodeError::TooLarge`] covers declared dimensions or sixel
     /// commands beyond the 4096-pixel and related safety limits.
     #[cfg(feature = "decode")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "decode")))]
     pub fn decode(&self) -> Result<Bitmap, DecodeError> {
         let data = self.data.as_deref().ok_or(DecodeError::NotCaptured)?;
         match self.protocol {
@@ -386,6 +387,7 @@ impl GraphicsPayload {
 /// be about the picture — "the day at week 30 is Primer's brightest green" —
 /// rather than about its size in bytes.
 #[cfg(feature = "decode")]
+#[cfg_attr(docsrs, doc(cfg(feature = "decode")))]
 #[derive(Clone, PartialEq, Eq)]
 pub struct Bitmap {
     width: u32,
@@ -493,6 +495,7 @@ const MAX_SIXEL_REGISTERS: usize = 65_536;
 
 /// Why a payload could not be decoded.
 #[cfg(feature = "decode")]
+#[cfg_attr(docsrs, doc(cfg(feature = "decode")))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DecodeError {

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -105,6 +105,7 @@
 //! override any of them.
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod emu;
 mod error;
@@ -117,6 +118,7 @@ mod wait;
 
 pub use error::{Error, Result};
 #[cfg(feature = "decode")]
+#[cfg_attr(docsrs, doc(cfg(feature = "decode")))]
 pub use graphics::{Bitmap, DecodeError};
 pub use graphics::{
     GraphicsAction, GraphicsFormat, GraphicsPayload, GraphicsProtocol, GraphicsSeen,
@@ -134,6 +136,7 @@ pub use terminal::{
 /// default), so [`assert_screen_snapshot!`] always agrees with the `insta`
 /// version doing the snapshotting.
 #[cfg(feature = "insta")]
+#[cfg_attr(docsrs, doc(cfg(feature = "insta")))]
 pub use insta;
 
 /// Snapshot-assert anything that displays like a [`Screen`].
@@ -152,6 +155,7 @@ pub use insta;
 /// # }
 /// ```
 #[cfg(feature = "insta")]
+#[cfg_attr(docsrs, doc(cfg(feature = "insta")))]
 #[macro_export]
 macro_rules! assert_screen_snapshot {
     ($screen:expr) => {


### PR DESCRIPTION
## What & why

Configure docs.rs to expose feature-gated API badges, and annotate the public `decode` and `insta` APIs with their required features.

Closes #258.

## Checklist

- [x] Linked an issue (or explained above why none exists)
- [x] Tests added/updated for the change (documentation output verified directly)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`) — see [CONTRIBUTING.md §5](../CONTRIBUTING.md)
- [x] **No AI attribution trailers** (no AI co-authors, "Generated with" footers, or bot identities) — see [CONTRIBUTING.md §6](../CONTRIBUTING.md)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (user-facing changes only)
- [x] Snapshot changes (if any) were reviewed with `cargo insta review`, not blind-accepted (N/A: no snapshots changed)
