### PR TITLE
fix: make Style non-exhaustive

### DIFF
--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -37,7 +37,11 @@ pub enum Color {
 ///
 /// Inspect them per cell via [`Cell::style`], or snapshot them wholesale
 /// with [`Screen::with_styles`] (plain snapshots stay text-only).
+/// More terminal attributes may be added in future releases. To construct a
+/// style for comparison, start from `Style::default()` and assign the fields
+/// relevant to the assertion rather than using a struct literal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub struct Style {
     /// Foreground color.
     pub fg: Color,


### PR DESCRIPTION
## What & why

Mark `Style` as non-exhaustive while the crate is pre-1.0, so future terminal attributes can be represented without another breaking change. The API docs and changelog explain how downstream comparisons should construct a style from `Style::default()`.

A dedicated builder is intentionally omitted: default plus field assignment remains concise and avoids adding API surface solely for test expectations.

Closes #259.

## Checklist

- [x] Linked an issue (or explained above why none exists)
- [x] Tests added/updated for the change (existing style integration suite covers field access and comparisons)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets --all-features` are clean
- [x] **All commits are signed off** (`git commit -s`) — see [CONTRIBUTING.md §5](../CONTRIBUTING.md)
- [x] **No AI attribution trailers** (no AI co-authors, "Generated with" footers, or bot identities) — see [CONTRIBUTING.md §6](../CONTRIBUTING.md)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (user-facing changes only)
- [x] Snapshot changes (if any) were reviewed with `cargo insta review`, not blind-accepted (N/A: no snapshots changed)
