### PR TITLE
docs: restore four changelog entries lost in a conflict resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ listed under a **Changed** or **Removed** heading.
 
 ### Changed
 
+- **`Screen::row_text` rejects an out-of-bounds row instead of returning an
+  ambiguous empty string.** Callers with a potentially invalid index should
+  bounds-check against `rows()` first, or use `cell(row, 0)` and treat `None`
+  as absent. (#260)
+
+- **`Terminal::drag` takes four column-first coordinate arguments instead of
+  two unlabelled tuples.** This matches the other mouse methods and prevents a
+  row-first `Screen::find` result from being passed through transposed. (#257)
+
+- **`Style` is non-exhaustive so new terminal attributes can be added without
+  another breaking change.** Downstream struct literals should migrate to
+  `Style::default()` followed by assignments to relevant fields. (#259)
+
+- **The `inspect` example clears the child environment by default.** It keeps
+  `PATH` so bare program names work; `--env` adds selected values and
+  `--inherit-env` restores the previous behavior. (#263)
+
 ### Fixed
 
 - **docs.rs labels APIs gated by the `decode` and `insta` features.** Optional


### PR DESCRIPTION
`[Unreleased]` on `main` has an empty **Changed** section, and the entries from #268, #269, #270 and #271 are missing. All four PRs had them correctly placed when they were merged.

**What happened.** Those four conflicted with each other on the same changelog lines, so I rebased each onto `main` as it moved and resolved the collision with a script. It rebuilt the conflict region from the `### Heading` blocks it found inside that region — which works when the conflict brackets a heading, and finds nothing when the conflict falls *inside* a section, as it did from #269 onward. With nothing found it wrote an empty string, and I did not assert the result was non-empty. It failed quietly, which is the one way a mistake like this survives review.

**What this changes.** The four entries, restored verbatim as their authors wrote them, in merge order under **Changed**. No code changes; the implementations were each verified before merge and are unaffected.

Verified after restoring: all five merged issues are referenced in `[Unreleased]`, and `extract-changelog.sh Unreleased` prints all five entries, so the next release's notes will carry them.