### PR TITLE
ci: defend the Windows build and give the suite a Windows runner to ask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,25 @@ jobs:
       - run: cargo test --workspace
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
+  # The crate compiles for Windows and nothing ran the compiler to prove it
+  # (#149): that build was rotting unwatched, and the cost of watching it is
+  # one cross-target clippy on a Linux runner — no Windows machine involved.
+  # `cargo check`/`clippy` need only the target's std, which rustup installs;
+  # linking and running are what need Windows, and those are windows.yml.
+  windows-check:
+    name: windows-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+          components: clippy
+          targets: x86_64-pc-windows-msvc
+      - run: cargo clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc -- -D warnings
+
   # CONTRIBUTING §1 promises that every gate above is reproducible locally
   # and that the workflow is the source of truth when the two disagree. It
   # disagreed twice before anyone noticed (#227); this is the check that
@@ -214,7 +233,7 @@ jobs:
   required-green:
     name: required-green
     if: always()
-    needs: [fmt, clippy, test, features, msrv, docs, deny, zizmor, gates-listed, skill]
+    needs: [fmt, clippy, test, features, windows-check, msrv, docs, deny, zizmor, gates-listed, skill]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every needed job succeeded

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,81 @@
+name: windows
+
+# The Windows machine this project does not otherwise have (#149).
+#
+# Windows is not a CI leg: the suite drives `/bin/sh` at 99 sites (#249) and
+# ConPTY re-renders rather than forwards, so a required leg today would be
+# red on the shell before it said anything about the crate. This workflow
+# runs on demand instead — against any ref — and reports rather than gates:
+# the whole suite with nothing stopping early, then the ConPTY probe
+# (`tests/conpty_probe.rs`), which prints per escape sequence whether the
+# master read what the child wrote. Both logs are the artifact; the pass
+# count and the probe table go to the job summary so no download is needed.
+#
+# The build itself is defended on every PR by ci.yml's `windows-check`,
+# from a Linux runner. This is the half that needs the OS.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [windows-cfg]
+
+permissions: {}
+
+# One report per ref at a time; a newer dispatch supersedes an older one.
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  suite:
+    name: suite (windows-latest)
+    runs-on: windows-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - name: Build everything first, so a compile error is not read as a test failure
+        run: cargo build --workspace --all-targets --all-features
+      - name: Run the whole suite without stopping
+        # A red suite is the expected outcome until #249 lands; the log is
+        # the deliverable, so the step must not end the job.
+        continue-on-error: true
+        run: cargo test --workspace --all-features --no-fail-fast 2>&1 | tee suite.log
+      - name: Ask ConPTY what it forwards
+        continue-on-error: true
+        run: cargo test -p termlens --all-features --test conpty_probe -- --ignored --nocapture 2>&1 | tee probe.log
+      - name: Summarize
+        run: |
+          {
+            echo "## Suite"
+            echo
+            echo '```'
+            grep -E '^test result:|Running (unittests|tests/)|Doc-tests' suite.log || true
+            echo '```'
+            echo
+            echo "### Failed tests"
+            echo
+            echo '```'
+            grep -E '^test .* \.\.\. FAILED$' suite.log | sort || echo "(none)"
+            echo '```'
+            echo
+            echo "## ConPTY probe"
+            echo
+            echo '```'
+            sed -n '/^conpty probe on/,$p' probe.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-report
+          path: |
+            suite.log
+            probe.log
+          if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,8 +16,6 @@ name: windows
 
 on:
   workflow_dispatch:
-  push:
-    branches: [windows-cfg]
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,3 +13,4 @@ rules:
       - stress.yml
       - release.yml
       - install.yml
+      - windows.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features
 cargo deny check                          # cargo install cargo-deny
 pipx run zizmor==1.29.0 --persona=pedantic .github/workflows/   # workflow audit; needs GH_TOKEN for the online checks
 cargo +1.85 check --workspace --locked --all-targets    # the MSRV: `rust-version` in Cargo.toml
+cargo clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc -- -D warnings   # the Windows build, from any host: `rustup target add x86_64-pc-windows-msvc` once
 ```
 
 The list is written out here rather than left as a pointer because a first

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -681,14 +681,19 @@ impl ExitStatus {
     ///
     /// ```no_run
     /// # fn main() -> termlens::Result<()> {
+    /// # #[cfg(unix)] {
     /// # let mut t = termlens::Terminal::builder().args(["-c", "sleep 30"]).spawn("sh")?;
     /// t.signal(termlens::Signal::Term)?;
     /// let status = t.wait_exit()?;
     /// let signal = status.signal().expect("killed, not exited");
     /// assert!(signal.contains("Terminated"), "status: {status}");
+    /// # }
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// Always `None` on Windows, which has no signals; the example is Unix
+    /// for that reason.
     ///
     /// Distinguishing "the app exited 1" from "something killed the app" is
     /// the difference between a failing test and a failing test *harness* —
@@ -1448,10 +1453,14 @@ impl TerminalBuilder {
         // env_clear removes PATH with everything else, and a bare name then
         // has nothing to resolve against; the PTY layer's "Unable to resolve
         // the PATH" named neither the cause nor a remedy (#222).
-        if self.env_clear
-            && !self.envs.iter().any(|(k, _)| k == "PATH")
-            && !program.to_string_lossy().contains('/')
-        {
+        //
+        // "Bare" is "has no directory part", asked of the path rather than
+        // of the string: `D:\\a\\x.exe` contains no `/` and is not bare, and
+        // the first Windows run said it was (#149).
+        let bare = std::path::Path::new(program)
+            .parent()
+            .is_none_or(|dir| dir.as_os_str().is_empty());
+        if self.env_clear && !self.envs.iter().any(|(k, _)| k == "PATH") && bare {
             return spawn_err(format!(
                 "`{}` is a bare program name and env_clear() removed PATH, so nothing can \
                  resolve it — give an absolute path, or set a PATH with .env(\"PATH\", …)",

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -187,10 +187,28 @@ const DROP_REAP_GRACE: Duration = Duration::from_secs(2);
 /// macOS runners; Linux, whose teardown is not revoke-based, ran the same
 /// suite 100/100). Holding this lock during both edges means the kernel
 /// never sees the two windows overlap. Steady-state I/O is unaffected.
+///
+/// Unix only. ConPTY has no device table: each pseudoconsole is a pair of
+/// pipes of its own, so there is nothing for one terminal's teardown to
+/// revoke from under another's spawn, and the lock would be a tax paid for
+/// a race that cannot happen (#149). Linux keeps it on purpose — its cost
+/// is unmeasurable against a spawn, and dropping it there is a behaviour
+/// change the stress workflow would need to bless, not a cleanup.
+#[cfg(unix)]
 static PTY_LIFECYCLE: Mutex<()> = Mutex::new(());
 
-fn pty_lifecycle_guard() -> std::sync::MutexGuard<'static, ()> {
-    PTY_LIFECYCLE.lock().unwrap_or_else(PoisonError::into_inner)
+/// The lifecycle lock, held — or `None` on a platform with nothing to
+/// serialize. Callers hold and drop it the same way either way.
+type LifecycleGuard = Option<std::sync::MutexGuard<'static, ()>>;
+
+#[cfg(unix)]
+fn pty_lifecycle_guard() -> LifecycleGuard {
+    Some(PTY_LIFECYCLE.lock().unwrap_or_else(PoisonError::into_inner))
+}
+
+#[cfg(not(unix))]
+fn pty_lifecycle_guard() -> LifecycleGuard {
+    None
 }
 
 /// Attempts to open a PTY before giving up, and the step between them. The
@@ -221,7 +239,7 @@ const PTY_OPEN_BACKOFF: Duration = Duration::from_millis(25);
 /// classifying an `anyhow` error by its text is guesswork, a permanent fault
 /// still reports its own message at the end, and the cost of being wrong is
 /// under two seconds on a spawn that was going to fail anyway.
-fn open_pty(size: PtySize) -> Result<(PtyPair, std::sync::MutexGuard<'static, ()>)> {
+fn open_pty(size: PtySize) -> Result<(PtyPair, LifecycleGuard)> {
     let pty = native_pty_system();
     let mut last = String::new();
     for attempt in 0..PTY_OPEN_ATTEMPTS {

--- a/crates/termlens/tests/common/mod.rs
+++ b/crates/termlens/tests/common/mod.rs
@@ -28,7 +28,11 @@ pub(crate) fn fixture_bin(name: &str) -> PathBuf {
         },
         PathBuf::from,
     );
-    let bin = target_dir.join(profile).join(name);
+    // `.exe` on Windows, nothing elsewhere — the same rule Cargo used to
+    // name the artifact this path has to find.
+    let bin = target_dir
+        .join(profile)
+        .join(format!("{name}{}", std::env::consts::EXE_SUFFIX));
 
     let mut built = BUILT.lock().unwrap();
     if !built.iter().any(|b| b == name) {

--- a/crates/termlens/tests/conpty_probe.rs
+++ b/crates/termlens/tests/conpty_probe.rs
@@ -1,0 +1,285 @@
+//! What the PTY layer forwards, byte for byte. A diagnostic, not a test.
+//!
+//! On Unix a PTY is a pipe with a line discipline: what the child writes is
+//! what the master reads. ConPTY is not — it renders the child's output into
+//! a screen of its own and re-emits *that*, so the sequences arriving at
+//! termlens's emulator on Windows are whatever ConPTY chose to say, not what
+//! the application wrote. Which sequences survive decides which features
+//! termlens can honestly claim there: the query responder, `wait_frame`,
+//! graphics, links, character sets (#149, step 3).
+//!
+//! Nobody working on this crate has a Windows machine, so the questions are
+//! asked all at once and answered by a CI run: `.github/workflows/windows.yml`
+//! runs this with `--ignored --nocapture` and keeps the output. On Unix the
+//! same probe prints every sequence forwarded verbatim, which is what makes
+//! it possible to develop and trust the probe itself without Windows.
+//!
+//! Each case writes the bytes to a file and has the platform's own file
+//! printer (`cat`, or `cmd /d /c type`) send them through the PTY: nothing
+//! between the bytes and the console but a program every install has, and
+//! no shell quoting to decode. The verdict per case is whether the exact
+//! sent bytes appear somewhere in what the master read.
+
+use std::io::{self, Read};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+struct Case {
+    name: &'static str,
+    /// What the feature needs to survive the round trip.
+    why: &'static str,
+    bytes: &'static [u8],
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "plain text",
+        why: "control: a case that cannot fail",
+        bytes: b"hello",
+    },
+    Case {
+        name: "SGR bold red",
+        why: "style assertions",
+        bytes: b"\x1b[1;31mred\x1b[0m",
+    },
+    Case {
+        name: "DECSET 2026 frame",
+        why: "wait_frame: a frame is the bracket, not the bytes inside it",
+        bytes: b"\x1b[?2026hframe\x1b[?2026l",
+    },
+    Case {
+        name: "DA1 query",
+        why: "the query responder: absent here means ConPTY answered it itself",
+        bytes: b"\x1b[c",
+    },
+    Case {
+        name: "DSR 6 cursor position",
+        why: "the query responder",
+        bytes: b"\x1b[6n",
+    },
+    Case {
+        name: "OSC 11 background query",
+        why: "background_rgb reaches the child only if this reaches us",
+        bytes: b"\x1b]11;?\x07",
+    },
+    Case {
+        name: "XTGETTCAP TN",
+        why: "the terminfo name reply",
+        bytes: b"\x1bP+q544e\x1b\\",
+    },
+    Case {
+        name: "OSC 8 hyperlink",
+        why: "Screen::links",
+        bytes: b"\x1b]8;;http://example.invalid\x1b\\label\x1b]8;;\x1b\\",
+    },
+    Case {
+        name: "OSC 52 clipboard write",
+        why: "Screen::clipboard",
+        bytes: b"\x1b]52;c;aGVsbG8=\x07",
+    },
+    Case {
+        name: "OSC 2 title",
+        why: "Screen::title",
+        bytes: b"\x1b]2;a title\x07",
+    },
+    Case {
+        name: "DEC Special Graphics",
+        why: "charset translation: box-drawing via ESC ( 0",
+        bytes: b"\x1b(0lqk\x1b(B",
+    },
+    Case {
+        name: "mouse tracking + SGR encoding",
+        why: "Screen::mouse_modes",
+        bytes: b"\x1b[?1000h\x1b[?1006h\x1b[?1006l\x1b[?1000l",
+    },
+    Case {
+        name: "bracketed paste",
+        why: "paste() wraps only when the child asked",
+        bytes: b"\x1b[?2004h\x1b[?2004l",
+    },
+    Case {
+        name: "focus reporting",
+        why: "focus events",
+        bytes: b"\x1b[?1004h\x1b[?1004l",
+    },
+    Case {
+        name: "cursor shape DECSCUSR",
+        why: "Screen::cursor_shape",
+        bytes: b"\x1b[2 q",
+    },
+    Case {
+        name: "kitty graphics",
+        why: "GraphicsPayload: a 1x1 RGB transmit-and-display",
+        bytes: b"\x1b_Ga=T,f=24,s=1,v=1;AAAA\x1b\\",
+    },
+    Case {
+        name: "sixel",
+        why: "GraphicsPayload",
+        bytes: b"\x1bPq#0;2;0;0;0#0~-\x1b\\",
+    },
+    Case {
+        name: "HTS then TBC 3",
+        why: "tab stops (#262)",
+        bytes: b"\x1bH\x1b[3g",
+    },
+    Case {
+        name: "alternate screen",
+        why: "the mode termlens reports",
+        bytes: b"\x1b[?1049hinside\x1b[?1049l",
+    },
+    Case {
+        name: "bell",
+        why: "Screen::bells",
+        bytes: b"\x07",
+    },
+    Case {
+        name: "tab",
+        why: "HT reaches the emulator as HT, not as spaces",
+        bytes: b"a\tb",
+    },
+];
+
+/// One temp file per case per process, so parallel probes never share one.
+static SEQ: AtomicUsize = AtomicUsize::new(0);
+
+fn other(e: impl std::fmt::Display) -> io::Error {
+    io::Error::other(e.to_string())
+}
+
+/// Every byte visibly: ESC as `\e`, other controls as `\xNN`, printable
+/// ASCII as itself. Non-ASCII is escaped too — the verdict is about bytes.
+fn escape(bytes: &[u8]) -> String {
+    let mut out = String::new();
+    for &b in bytes {
+        match b {
+            0x1b => out.push_str("\\e"),
+            0x20..=0x7e if b != b'\\' => out.push(b as char),
+            _ => out.push_str(&format!("\\x{b:02x}")),
+        }
+    }
+    out
+}
+
+/// Spawn `cmd`, read the master until it closes, and return every byte.
+///
+/// The master is closed only after the child has exited and had a moment
+/// to be flushed: on Unix the reader then sees EOF or `EIO`; on Windows
+/// closing the pseudoconsole is what ends the output pipe. The reader
+/// thread is joined rather than abandoned so nothing outlives the case.
+fn through_pty(mut cmd: CommandBuilder) -> io::Result<Vec<u8>> {
+    let pty = native_pty_system();
+    let pair = pty
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(other)?;
+    let mut reader = pair.master.try_clone_reader().map_err(other)?;
+    let collector = thread::spawn(move || {
+        let mut out = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => out.extend_from_slice(&buf[..n]),
+            }
+        }
+        out
+    });
+    cmd.env("TERM", "xterm-256color");
+    let mut child = pair.slave.spawn_command(cmd).map_err(other)?;
+    drop(pair.slave);
+    child.wait()?;
+    thread::sleep(Duration::from_millis(500));
+    drop(pair.master);
+    collector
+        .join()
+        .map_err(|_| io::Error::other("the reader thread panicked"))
+}
+
+/// The platform's own way to print a file, with no shell in between.
+fn print_file(path: &PathBuf) -> CommandBuilder {
+    let mut cmd = if cfg!(windows) {
+        let mut c = CommandBuilder::new("cmd.exe");
+        c.args(["/d", "/c", "type"]);
+        c
+    } else {
+        CommandBuilder::new("cat")
+    };
+    cmd.arg(path);
+    cmd
+}
+
+fn probe(case: &Case) -> io::Result<Vec<u8>> {
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "termlens-conpty-probe-{}-{n}.bin",
+        std::process::id()
+    ));
+    std::fs::write(&path, case.bytes)?;
+    let result = through_pty(print_file(&path));
+    let _ = std::fs::remove_file(&path);
+    result
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Prints, per sequence, whether the master read exactly what the child
+/// wrote. Fails only when a probe cannot run at all — a verdict of "absent"
+/// is a finding, not a failure.
+#[test]
+#[ignore = "diagnostic: prints what the PTY layer forwards; run with --ignored --nocapture"]
+fn what_the_pty_layer_forwards() -> io::Result<()> {
+    println!();
+    println!(
+        "conpty probe on {} {} — {} cases",
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        CASES.len()
+    );
+    println!("verdict  case                             why");
+    let mut forwarded = 0;
+    let mut details = Vec::new();
+    for case in CASES {
+        let got = probe(case)?;
+        let ok = contains(&got, case.bytes);
+        forwarded += usize::from(ok);
+        println!(
+            "{:<8} {:<32} {}",
+            if ok { "verbatim" } else { "ABSENT" },
+            case.name,
+            case.why
+        );
+        if !ok {
+            details.push((case.name, escape(case.bytes), escape(&got)));
+        }
+    }
+    println!();
+    println!("{forwarded}/{} forwarded verbatim", CASES.len());
+    for (name, sent, got) in &details {
+        println!();
+        println!("[{name}]");
+        println!("  sent: {sent}");
+        println!("  read: {got}");
+    }
+
+    // The suite's other dependency on the host: whether a `sh` resolves at
+    // all. Reported, not judged — #249 is what removes the dependency.
+    let mut sh = CommandBuilder::new("sh");
+    sh.args(["-c", "echo sh-ok"]);
+    println!();
+    match through_pty(sh) {
+        Ok(out) if contains(&out, b"sh-ok") => println!("sh: resolves and runs"),
+        Ok(out) => println!("sh: spawned, but printed {}", escape(&out)),
+        Err(e) => println!("sh: does not spawn ({e})"),
+    }
+    Ok(())
+}

--- a/crates/termlens/tests/conpty_probe.rs
+++ b/crates/termlens/tests/conpty_probe.rs
@@ -20,9 +20,10 @@
 //! no shell quoting to decode. The verdict per case is whether the exact
 //! sent bytes appear somewhere in what the master read.
 
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
@@ -164,6 +165,24 @@ fn escape(bytes: &[u8]) -> String {
     out
 }
 
+/// How long one case may take before it is reported as hung rather than
+/// waited on. A file printer is done in milliseconds; a console that is
+/// waiting for something it was never told is the finding, not a reason
+/// to lose the rest of the table.
+const CASE_DEADLINE: Duration = Duration::from_secs(20);
+
+/// What a terminal says to `CSI 6 n`: the cursor is at row 1, column 1.
+///
+/// ConPTY is created with `PSEUDOCONSOLE_INHERIT_CURSOR`, and a console so
+/// created asks its host terminal where the cursor is before it starts the
+/// child — and waits. termlens's responder answers that query as it would
+/// any other, which is why the real harness runs; a probe that only reads
+/// would hang on its first case, and the first run of it did. Answered
+/// here for the same reason a terminal answers it: because something is
+/// waiting on it.
+const CURSOR_REPLY: &[u8] = b"\x1b[1;1R";
+const CURSOR_QUERY: &[u8] = b"\x1b[6n";
+
 /// Spawn `cmd`, read the master until it closes, and return every byte.
 ///
 /// The master is closed only after the child has exited and had a moment
@@ -181,13 +200,32 @@ fn through_pty(mut cmd: CommandBuilder) -> io::Result<Vec<u8>> {
         })
         .map_err(other)?;
     let mut reader = pair.master.try_clone_reader().map_err(other)?;
+    let mut writer = pair.master.take_writer().map_err(other)?;
     let collector = thread::spawn(move || {
         let mut out = Vec::new();
         let mut buf = [0u8; 4096];
+        let mut answered = 0;
         loop {
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => break,
                 Ok(n) => out.extend_from_slice(&buf[..n]),
+            }
+            // Every cursor-position query seen so far gets exactly one
+            // reply, whoever asked: the console at startup, or a child
+            // whose query was forwarded — which is itself a verdict.
+            let asked = out
+                .windows(CURSOR_QUERY.len())
+                .filter(|w| *w == CURSOR_QUERY)
+                .count();
+            while answered < asked {
+                if writer
+                    .write_all(CURSOR_REPLY)
+                    .and_then(|()| writer.flush())
+                    .is_err()
+                {
+                    break;
+                }
+                answered += 1;
             }
         }
         out
@@ -216,16 +254,35 @@ fn print_file(path: &PathBuf) -> CommandBuilder {
     cmd
 }
 
-fn probe(case: &Case) -> io::Result<Vec<u8>> {
-    let n = SEQ.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!(
-        "termlens-conpty-probe-{}-{n}.bin",
-        std::process::id()
-    ));
-    std::fs::write(&path, case.bytes)?;
-    let result = through_pty(print_file(&path));
-    let _ = std::fs::remove_file(&path);
-    result
+/// Run `f` on its own thread and give it [`CASE_DEADLINE`]. A case that
+/// never comes back is reported, and its thread abandoned: this is a
+/// diagnostic, and the table is worth more than a clean exit.
+fn bounded<T: Send + 'static>(
+    f: impl FnOnce() -> io::Result<T> + Send + 'static,
+) -> io::Result<Option<T>> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(f());
+    });
+    match rx.recv_timeout(CASE_DEADLINE) {
+        Ok(result) => result.map(Some),
+        Err(_) => Ok(None),
+    }
+}
+
+/// `Some(bytes)` the master read, or `None` when the case hung.
+fn probe(case: &'static Case) -> io::Result<Option<Vec<u8>>> {
+    bounded(move || {
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "termlens-conpty-probe-{}-{n}.bin",
+            std::process::id()
+        ));
+        std::fs::write(&path, case.bytes)?;
+        let result = through_pty(print_file(&path));
+        let _ = std::fs::remove_file(&path);
+        result
+    })
 }
 
 fn contains(haystack: &[u8], needle: &[u8]) -> bool {
@@ -249,36 +306,43 @@ fn what_the_pty_layer_forwards() -> io::Result<()> {
     let mut forwarded = 0;
     let mut details = Vec::new();
     for case in CASES {
-        let got = probe(case)?;
-        let ok = contains(&got, case.bytes);
-        forwarded += usize::from(ok);
-        println!(
-            "{:<8} {:<32} {}",
-            if ok { "verbatim" } else { "ABSENT" },
-            case.name,
-            case.why
-        );
-        if !ok {
-            details.push((case.name, escape(case.bytes), escape(&got)));
+        let (verdict, got) = match probe(case)? {
+            None => ("HUNG", None),
+            Some(got) if contains(&got, case.bytes) => ("verbatim", Some(got)),
+            Some(got) => ("ABSENT", Some(got)),
+        };
+        forwarded += usize::from(verdict == "verbatim");
+        println!("{verdict:<8} {:<32} {}", case.name, case.why);
+        // The control case is printed whatever its verdict: what the
+        // console wraps around five plain bytes is the shape of everything
+        // else it emits.
+        if verdict != "verbatim" || case.name == "plain text" {
+            let read = got
+                .as_deref()
+                .map_or_else(|| format!("(nothing within {CASE_DEADLINE:?})"), escape);
+            details.push((case.name, escape(case.bytes), read));
         }
     }
     println!();
     println!("{forwarded}/{} forwarded verbatim", CASES.len());
-    for (name, sent, got) in &details {
+    for (name, sent, read) in &details {
         println!();
         println!("[{name}]");
         println!("  sent: {sent}");
-        println!("  read: {got}");
+        println!("  read: {read}");
     }
 
     // The suite's other dependency on the host: whether a `sh` resolves at
     // all. Reported, not judged — #249 is what removes the dependency.
-    let mut sh = CommandBuilder::new("sh");
-    sh.args(["-c", "echo sh-ok"]);
     println!();
-    match through_pty(sh) {
-        Ok(out) if contains(&out, b"sh-ok") => println!("sh: resolves and runs"),
-        Ok(out) => println!("sh: spawned, but printed {}", escape(&out)),
+    match bounded(|| {
+        let mut sh = CommandBuilder::new("sh");
+        sh.args(["-c", "echo sh-ok"]);
+        through_pty(sh)
+    }) {
+        Ok(Some(out)) if contains(&out, b"sh-ok") => println!("sh: resolves and runs"),
+        Ok(Some(out)) => println!("sh: spawned, but printed {}", escape(&out)),
+        Ok(None) => println!("sh: spawned, then hung"),
         Err(e) => println!("sh: does not spawn ({e})"),
     }
     Ok(())

--- a/crates/termlens/tests/process.rs
+++ b/crates/termlens/tests/process.rs
@@ -3,7 +3,9 @@
 
 use std::time::{Duration, Instant};
 
-use termlens::{Error, Key, Signal, Terminal};
+#[cfg(unix)]
+use termlens::Signal;
+use termlens::{Error, Key, Terminal};
 
 #[test]
 fn current_dir_runs_the_child_where_asked() -> termlens::Result<()> {
@@ -36,6 +38,7 @@ fn pid_reports_the_direct_child() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg(unix)]
 fn signal_term_exercises_the_graceful_shutdown_path() -> termlens::Result<()> {
     let mut t = Terminal::builder()
         .timeout(Duration::from_secs(10))
@@ -55,6 +58,7 @@ fn signal_term_exercises_the_graceful_shutdown_path() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg(unix)]
 fn signal_after_reap_is_a_typed_error_not_a_stray_kill() {
     let mut t = Terminal::builder()
         .timeout(Duration::from_secs(10))


### PR DESCRIPTION
Refs #149 — steps 2 and 4 of the plan there, and the instrument for step 3. Step 1 (#249) is untouched and is what stands between this and a required Windows leg.

## What this is

**The Windows build compiles today and nothing defended it.** Cross-checked from Linux: every workspace target builds for `x86_64-pc-windows-msvc` except `tests/process.rs`, which needed three `#[cfg(unix)]` gates. So:

- **`windows-check`** (ci.yml, required-green): `cargo clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc -- -D warnings` on **ubuntu-latest** — no Windows runner. `check`/`clippy` need only the target's std. ~40s. Listed in CONTRIBUTING §1 for `gates-listed`.
- **`windows.yml`** — the Windows machine the project does not have. `workflow_dispatch` against any ref; runs the whole suite with `--no-fail-fast` (non-blocking — it is red on `/bin/sh` until #249), then the probe below, and puts the pass count, failed-test list and probe table in the job summary. Logs are the artifact.
- **`tests/conpty_probe.rs`** — `#[ignore]`d diagnostic. Sends 21 escape sequences through the PTY layer via the platform's own file printer (`cat` / `cmd /d /c type`, no shell quoting) and prints per sequence whether the master read exactly what the child wrote. On Unix: 21/21 verbatim, which is what makes the probe itself testable here. On Windows the ABSENT rows are the step-3 findings: DA1/DSR/OSC 11 absent means ConPTY answered the child itself and `Graphics::Sixel`/`background_rgb`/`cell_size` never reach it; 2026 absent means `wait_frame` cannot be honest there.

**Step 2, the honest `cfg`:**
- `PTY_LIFECYCLE` is `#[cfg(unix)]`; `pty_lifecycle_guard()` returns `Option<MutexGuard>` — `None` where there is no device table to race on. Linux **keeps** the lock deliberately: its cost is unmeasurable against a spawn, and dropping it there is a behaviour change the stress workflow would need to bless, not a cleanup. Flagging that as the one judgement call.
- `fixture_bin` looks for `<name><EXE_SUFFIX>` — it asserted on `target/debug/hello-tui` and would have failed on Windows before any test ran.
- `Terminal::signal` was already gated at definition and re-export; only the test file and one doctest lagged.
- `TerminalBuilder::validate` judged "bare program name" by "contains no `/`" — `D:\a\…\hello-tui.exe` contains none, so `bin!` was refused under `env_clear` before spawning. Now "has no directory part", asked of the path.

## What the three runs on this branch measured

Written up in full as [the step-3 comment on #149](https://github.com/vyncint/termlens/issues/149#issuecomment-5577871420); the short form:

- **Suite on `windows-latest`** ([run 3](https://github.com/vyncint/termlens/actions/runs/34177903731)): 274 passed, 163 failed. Unit tests 210/210. 121 of the failures name a shell — #249. The rest are ConPTY, and they match the probe row for row.
- **Probe: 21 sequences in, 6 out verbatim.** Eaten outright: DA1, OSC 11, XTGETTCAP, mouse modes, focus, kitty, sixel, HTS/TBC. Rewritten but equivalent: SGR, OSC 2→0, DEC Special Graphics→UTF-8, tab→CUF, OSC 8 with a ConPTY-synthesized id. **DEC 2026 arrives reordered — the bracket closes before the content** — which is why every `wait_frame` test times out with frames observed but never matching.
- **Every child gets a preamble**: `\e[6n \e[?9001h \e[?1004h \e[m \e]0;<exe>\a \e[?25h`. The `6n` is `INHERIT_CURSOR` asking the host where the cursor is, and the child does not start until it is answered — termlens's responder does, which is why the harness runs there at all; the probe's first version only read, and hung (run 1). The `1004h` is why `focus_events()` is true from byte one on Windows.

Two Windows bugs in termlens itself came out of it and are fixed here (`bin!` refused an absolute `D:\…\x.exe` as bare; the `ExitStatus::signal` doctest did not compile off Unix). Run 3 shows both `bin!` tests passing on Windows.

The step-3 decision this supports: **Windows — screen assertions yes, frame assertions no**, with the eaten list above as the documented `#[cfg_attr(windows, ignore)]` set once #249 lets the leg run.

## Not in this PR

- #249. The 99 `sh` sites are a migration of their own, one file per commit.
- README wording. The owner's plan reconciles "planned" vs "inherent" through step 3's written outcome; this PR produces the data, not the sentence.
- A CHANGELOG entry: nothing a Unix consumer can observe changed.
