### PR TITLE
ci: run the suite on windows-latest, and say what Windows is

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,27 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - run: cargo clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc -- -D warnings
 
+  # The Windows leg (#149): the whole suite over ConPTY, with the tests that
+  # ConPTY cannot honour marked `#[cfg_attr(windows, ignore = "…")]`, each
+  # with its reason. Non-required while it earns it — `continue-on-error`
+  # keeps a ConPTY surprise from blocking a Unix fix, and required-green does
+  # not list it. Promoting it is two edits: drop continue-on-error, add it
+  # to required-green's needs. windows.yml is the dispatchable version with
+  # the ConPTY probe and the report.
+  windows:
+    name: windows (non-required)
+    runs-on: windows-latest
+    continue-on-error: true
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - run: cargo test --workspace --all-features
+
   # CONTRIBUTING §1 promises that every gate above is reproducible locally
   # and that the workflow is the source of truth when the two disagree. It
   # disagreed twice before anyone noticed (#227); this is the check that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- **Windows.** The crate builds and the whole suite runs on `windows-latest`
+  in CI, over ConPTY. Screen assertions work; the features ConPTY renders
+  away — `wait_frame`, graphics, the responder's outbound claims, mouse
+  modes, focus reporting, link ids — are documented as Unix-only in the
+  README, with their tests marked so and the probe that measured them in
+  `tests/conpty_probe.rs`. Two things a Windows user would have hit first
+  are fixed on the way: `bin!` refused an absolute `C:\…` path as a bare
+  program name, and a child that had exited was still "listening" — a
+  pseudoconsole never reports EOF, so the reaped child now closes the
+  terminal there. (#149)
+
 - **A skill for AI coding agents.** `skills/termlens/SKILL.md` teaches an
   agent how to test a terminal program with termlens without the mistakes
   agents make on their own: no `sleep`, `snapshot_after` for whole-screen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "emit"
 version = "0.9.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "encode_unicode"

--- a/README.md
+++ b/README.md
@@ -329,8 +329,26 @@ design. termlens's position:
   it would against a real terminal. On Linux the kernel discards silently,
   so that loss is undetectable and goes unreported; macOS blocks instead,
   where it is counted and named.
-- Unix only for now (Linux + macOS in CI). The PTY layer (`portable-pty`)
-  supports ConPTY, so Windows is planned, not designed out.
+- **Windows: screen assertions yes, frame assertions no.** The crate builds
+  and the whole suite runs on `windows-latest` in CI, over ConPTY through
+  `portable-pty`. ConPTY is not a passthrough — it renders the child's
+  output into a screen of its own and re-emits *that* — so what termlens
+  can honestly claim there is what survives the re-render: the grid (text,
+  cells, styles, cursor, wide characters, box drawing, title, links by URL,
+  clipboard, bracketed paste, cursor shape, bell, the alternate screen),
+  resize, typed input, `wait_until` / `wait_stable` / `snapshot_after`,
+  `bin!`. What it cannot claim, and documents as Unix-only: `wait_frame` and
+  `frame_timings` (ConPTY closes a DEC 2026 bracket *before* the content it
+  wrapped); `GraphicsPayload` and everything under `graphics` (kitty and
+  sixel never arrive); the responder's outbound claims — `Graphics`,
+  `background_rgb`, `foreground_rgb`, `cell_size` — since DA1, OSC 10/11,
+  XTGETTCAP and DECRQM are answered by ConPTY itself and never reach
+  termlens; `mouse_modes` and `mouse_mode`; `focus_events` (ConPTY turns
+  1004 on for itself); link ids (ConPTY assigns its own); `Terminal::signal`;
+  and bytes that are not UTF-8 (Rust's console stdio refuses to write
+  them). The tests for each are `#[cfg_attr(windows, ignore = "…")]` with
+  the reason in the attribute; the probe that measured all of this is
+  `tests/conpty_probe.rs`, and the `windows` workflow re-runs it on demand.
 - A child that writes and exits within its first milliseconds can lose
   output to the OS PTY teardown (macOS especially). Long-lived TUIs are
   unaffected; for run-and-exit programs, end the script with a `read` and

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -3033,13 +3033,16 @@ impl Terminal {
     ///
     /// ```
     /// # fn main() -> termlens::Result<()> {
+    /// # #[cfg(unix)] {
     /// let mut t = termlens::Terminal::builder()
     ///     .timeout(std::time::Duration::from_secs(10))
     ///     .args(["-c", r"printf '\033[?2026hFrame ready\033[?2026l'; read quit"])
     ///     .spawn("sh")?;
     /// let frame = t.wait_frame(|screen| screen.contains("Frame ready"))?;
     /// assert!(frame.contains("Frame ready"));
-    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?;
+    /// # }
+    /// # Ok(())
     /// # }
     /// ```
     ///
@@ -3051,6 +3054,7 @@ impl Terminal {
     ///
     /// ```
     /// # fn main() -> termlens::Result<()> {
+    /// # #[cfg(unix)] {
     /// let mut t = termlens::Terminal::builder()
     ///     .timeout(std::time::Duration::from_secs(10))
     ///     .args(["-c", r"printf '\033[?2026hcount 1\033[?2026l'; read k; printf '\033[?2026h count 2\033[?2026l'; read quit"])
@@ -3061,9 +3065,15 @@ impl Terminal {
     /// assert!(!frame.contains("count 2"));                    // …and that is the one you get
     /// let frame = t.wait_frame(|s| s.contains("count 2"))?;   // what the key changed
     /// assert!(frame.contains("count 2"));
-    /// # t.send(termlens::Key::Enter)?; t.wait_exit()?; Ok(())
+    /// # t.send(termlens::Key::Enter)?; t.wait_exit()?;
+    /// # }
+    /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// (Unix in the example, because `wait_frame` is: ConPTY closes a DEC
+    /// 2026 bracket before the content it wrapped — see the README's Windows
+    /// note.)
     ///
     /// # Errors
     ///

--- a/crates/termlens/tests/backpressure.rs
+++ b/crates/termlens/tests/backpressure.rs
@@ -5,46 +5,51 @@
 //! application that never reads its replies — lives in `drain.rs`, next to
 //! the deadlock it must never cause.
 //!
-//! Stays on `/bin/sh` on purpose (#249): reading replies byte for byte
-//! needs the terminal in raw mode, which the std-only `emit` fixture cannot
-//! set — see the note in `drain.rs`.
 
 use std::time::Duration;
 
 use termlens::{Key, Terminal};
 
+mod common;
+
 /// Ask `n` cursor-position queries back to back, then read everything, and
 /// count the answers. Each DSR reply carries exactly one `R`.
 ///
-/// Read in **one continuous `dd` of exactly the expected byte count**, and
+/// Read in **one continuous read of exactly the expected byte count**, and
 /// the shape of that read is load-bearing in both directions — stress taught
 /// me twice.
 ///
 /// A single read sized by a *timeout* stops at the first gap longer than its
 /// `VTIME`, so on a busy runner it ends early and measures scheduling: 310 of
 /// 400 on macOS. Replacing it with a retry loop was worse, and for a reason
-/// worth remembering — each retry is a `fork`+`exec` of `dd`, and **nothing
-/// reads the terminal in between**, so on a slow runner the input queue
-/// overflows in those gaps and the kernel discards: 235 of 400.
+/// worth remembering — each retry was a `fork`+`exec` of `dd`, and **nothing
+/// read the terminal in between**, so on a slow runner the input queue
+/// overflowed in those gaps and the kernel discarded: 235 of 400.
 ///
 /// Exactly-sized works because every reply here is `ESC[1;1R`, six bytes,
 /// identical — the cursor cannot move while the queries are being asked,
-/// since a DSR query prints nothing. So `dd` stops the instant it has them
-/// all, with no gap for the queue to overflow through, and `time 100` bounds
-/// it at ten seconds of silence if answers really are missing.
+/// since a DSR query prints nothing. So `--read-count` returns the instant
+/// it has them all, with no gap for the queue to overflow through, and the
+/// terminal's deadline bounds it if answers really are missing.
 fn answered(n: usize) -> termlens::Result<usize> {
-    let script = format!(
-        "stty -icanon -echo min 0 time 100; i=0; \
-         while [ $i -lt {n} ]; do printf '\\033[6n'; i=$((i+1)); done; \
-         printf ASKED; \
-         got=$(dd bs=1 count=$(({n} * 6)) 2>/dev/null | tr -cd 'R' | wc -c | tr -d ' '); \
-         printf ' GOT[%s] DONE' \"$got\"; read guard"
-    );
-    let mut t = Terminal::builder()
-        .size(80, 6)
-        .timeout(Duration::from_secs(30))
-        .args(["-c", &script])
-        .spawn("/bin/sh")?;
+    let queries = r"\e[6n".repeat(n);
+    let expected = (n * 6).to_string();
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .size(80, 6)
+            .timeout(Duration::from_secs(30)),
+        &[
+            "--raw-mode",
+            "--raw",
+            &queries,
+            "ASKED GOT[",
+            "--read-count",
+            &expected,
+            "R",
+            "] DONE",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("DONE"))?;
     let text = t.screen().text();
     let count = text
@@ -90,24 +95,30 @@ fn a_batch_of_probes_is_answered_in_full() -> termlens::Result<()> {
 /// startup batch lands in a single read. On a slow one the application's
 /// writes dribble out, the same 400 queries arrive in hundreds of reads, and
 /// 64 slots ran out again — 235 of 400 on a loaded macOS runner, at the same
-/// number twice. A fork per query reproduces that arrival shape on purpose.
+/// number twice. One `--raw` step per query reproduces that arrival shape on
+/// purpose: every step is its own `write(2)`.
 #[test]
 fn fine_grained_arrival_is_answered_in_full() -> termlens::Result<()> {
     for n in [100usize, 400] {
-        // `$(true)` forks per iteration, so each query is written separately
-        // and the reader sees it in its own read.
-        let script = format!(
-            "stty -icanon -echo min 0 time 100; i=0; \
-             while [ $i -lt {n} ]; do x=$(true); printf '\\033[6n'; i=$((i+1)); done; \
-             printf ASKED; \
-             got=$(dd bs=1 count=$(({n} * 6)) 2>/dev/null | tr -cd 'R' | wc -c | tr -d ' '); \
-             printf ' GOT[%s] DONE' \"$got\"; read guard"
-        );
-        let mut t = Terminal::builder()
-            .size(80, 6)
-            .timeout(Duration::from_secs(40))
-            .args(["-c", &script])
-            .spawn("/bin/sh")?;
+        let expected = (n * 6).to_string();
+        let mut steps: Vec<&str> = vec!["--raw-mode"];
+        for _ in 0..n {
+            steps.extend(["--raw", r"\e[6n"]);
+        }
+        steps.extend([
+            "ASKED GOT[",
+            "--read-count",
+            &expected,
+            "R",
+            "] DONE",
+            "--wait",
+        ]);
+        let mut t = common::spawn_emit(
+            Terminal::builder()
+                .size(80, 6)
+                .timeout(Duration::from_secs(40)),
+            &steps,
+        )?;
         t.wait_until(|s| s.contains("DONE"))?;
         let text = t.screen().text();
         let got: usize = text

--- a/crates/termlens/tests/backpressure.rs
+++ b/crates/termlens/tests/backpressure.rs
@@ -69,6 +69,10 @@ fn answered(n: usize) -> termlens::Result<usize> {
 /// queue was filling because the reader could build replies faster than the
 /// writer issued one `write(2)` each.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn a_batch_of_probes_is_answered_in_full() -> termlens::Result<()> {
     // 200 and 400 are the sizes the issue measured losses at (94 and 161
     // answered).
@@ -98,6 +102,10 @@ fn a_batch_of_probes_is_answered_in_full() -> termlens::Result<()> {
 /// number twice. One `--raw` step per query reproduces that arrival shape on
 /// purpose: every step is its own `write(2)`.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn fine_grained_arrival_is_answered_in_full() -> termlens::Result<()> {
     for n in [100usize, 400] {
         let expected = (n * 6).to_string();

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -52,11 +52,7 @@ fn exit_codes_are_reported() -> termlens::Result<()> {
 
 #[test]
 fn signal_deaths_are_reported_as_signals_not_exit_codes() -> termlens::Result<()> {
-    // Stays on `/bin/sh`: a process that signals itself is what this test
-    // is about, and the std-only fixture has no `kill`.
-    let mut t = Terminal::builder()
-        .args(["-c", "read guard; kill -TERM $$"])
-        .spawn("/bin/sh")?;
+    let mut t = emit(&["--wait", "--kill-self"])?;
     t.send(Key::Enter)?;
     let status = t.wait_exit()?;
     assert!(!status.success());

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -139,13 +139,15 @@ fn env_clear_hands_the_child_exactly_the_builder_environment() -> termlens::Resu
 
 #[test]
 fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termlens::Result<()> {
-    // Probe HOME, not PATH: shells synthesize a compiled-in default PATH
-    // when none is inherited, so PATH can't distinguish "inherited" from
-    // "defaulted". HOME is always set for the test process and never
-    // synthesized by a non-interactive shell.
+    // Probe a variable the parent always has and no program synthesizes:
+    // HOME on Unix, USERPROFILE on Windows, which has no HOME unless a shell
+    // put one there. Not PATH: shells synthesize a compiled-in default when
+    // none is inherited, so PATH can't distinguish "inherited" from
+    // "defaulted".
+    let inherited = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
     assert!(
-        std::env::var_os("HOME").is_some(),
-        "test needs HOME in the parent env"
+        std::env::var_os(inherited).is_some(),
+        "test needs {inherited} in the parent env"
     );
     let mut t = common::spawn_emit(
         Terminal::builder()
@@ -153,9 +155,9 @@ fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termlens::
             .env_clear()
             .envs([("KEPT_AFTER", "also")]),
         &[
-            "home=",
+            "inherited=",
             "--env",
-            "HOME",
+            inherited,
             " term=",
             "--env",
             "TERM",
@@ -171,8 +173,8 @@ fn env_clear_blocks_inheritance_but_keeps_explicit_vars_and_term() -> termlens::
     t.wait_until(|s| s.contains("before=yes after=also"))?;
     let screen = t.screen();
     assert!(
-        screen.contains("home=unset"),
-        "HOME leaked through env_clear:\n{screen}"
+        screen.contains("inherited=unset"),
+        "{inherited} leaked through env_clear:\n{screen}"
     );
     assert!(
         screen.contains("term=xterm-256color"),

--- a/crates/termlens/tests/basic.rs
+++ b/crates/termlens/tests/basic.rs
@@ -51,6 +51,7 @@ fn exit_codes_are_reported() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(windows, ignore = "Windows has no signals")]
 fn signal_deaths_are_reported_as_signals_not_exit_codes() -> termlens::Result<()> {
     let mut t = emit(&["--wait", "--kill-self"])?;
     t.send(Key::Enter)?;

--- a/crates/termlens/tests/builder_validation.rs
+++ b/crates/termlens/tests/builder_validation.rs
@@ -327,7 +327,7 @@ fn the_limit_is_inclusive_and_resize_honours_it() -> termlens::Result<()> {
     // Refused without disturbing the grid, like the zero case.
     assert_eq!(t.screen().size(), (1000, 1000));
 
-    t.send_str("\n")?;
+    t.send(termlens::Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
 }

--- a/crates/termlens/tests/charset.rs
+++ b/crates/termlens/tests/charset.rs
@@ -70,6 +70,10 @@ fn shift_out_and_shift_in_select_the_designated_set() -> termlens::Result<()> {
 /// correspondence check — run on every snapshot — is what proves the two
 /// grids stayed the same shape through the rewrite.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY translates charset designations itself and re-emits its own rendering (#149)"
+)]
 fn a_styled_border_keeps_its_style() -> termlens::Result<()> {
     let mut t = emit(&["--raw", r"\e(0\e[31mqqq\e[0m\e(B end", "DONE", "--wait"])?;
     t.wait_until(|s| s.contains("DONE"))?;
@@ -112,6 +116,10 @@ fn a_hard_reset_returns_to_ascii() -> termlens::Result<()> {
 /// it stays. It used to parse cleanly and do nothing, so text printed after
 /// an application's teardown reset kept rendering as box drawing (#233).
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY translates charset designations itself and re-emits its own rendering (#149)"
+)]
 fn a_soft_reset_returns_to_ascii_without_clearing_the_screen() -> termlens::Result<()> {
     let mut t = emit(&[
         "--raw",
@@ -226,6 +234,10 @@ fn a_pending_single_shift_does_not_survive_ris() -> termlens::Result<()> {
 /// it, so a graphics byte after them stays a letter. The old GL-only
 /// consume left the shift pending and turned that `l` into `┌`.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY translates charset designations itself and re-emits its own rendering (#149)"
+)]
 fn a_multibyte_character_consumes_a_single_shift() -> termlens::Result<()> {
     let mut t = emit(&[
         "--raw",

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -122,6 +122,10 @@ fn undelivered_replies_are_named_where_the_kernel_makes_them_visible() {
 /// The ordinary case must be untouched: an application that reads its
 /// replies still gets every one of them.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn replies_still_reach_an_application_that_reads_them() -> termlens::Result<()> {
     let mut t = common::spawn_emit(
         Terminal::builder().timeout(Duration::from_secs(10)),

--- a/crates/termlens/tests/drain.rs
+++ b/crates/termlens/tests/drain.rs
@@ -7,30 +7,33 @@
 //! the one failure the harness must never produce, since a hung harness
 //! cannot report anything at all.
 //!
-//! These stay on `/bin/sh` on purpose (#249): every program here puts the
-//! terminal in raw mode with `stty -icanon -echo` so replies are neither
-//! echoed onto the grid nor held for a newline, and the std-only `emit`
-//! fixture has no way to set a terminal mode.
+//! Every program here runs in `--raw-mode`, so replies are neither echoed
+//! onto the grid nor held for a newline.
 
 use std::time::{Duration, Instant};
 
 use termlens::{Error, Terminal};
 
+mod common;
+
 /// ~1000 cursor-position queries generate ~8 KB of replies — past the
 /// noncanonical tty buffer — from a child that never reads its input.
-const FLOOD: &str = r"stty -icanon -echo; i=0; while [ $i -lt 1000 ]; do printf '\033[6n'; i=$((i+1)); done; printf 'DONE\n'; sleep 3";
+fn flood() -> termlens::Result<Terminal> {
+    let queries = r"\e[6n".repeat(1000);
+    common::spawn_emit(
+        Terminal::builder()
+            .size(80, 24)
+            .env_clear()
+            // answer_queries defaults to true: this is the default config.
+            .timeout(Duration::from_secs(10)),
+        &["--raw-mode", "--raw", &queries, "DONE\n", "--sleep", "3s"],
+    )
+}
 
 #[test]
 fn a_child_that_never_reads_its_replies_cannot_wedge_the_drain() {
     let start = Instant::now();
-    let mut t = Terminal::builder()
-        .size(80, 24)
-        .env_clear()
-        // answer_queries defaults to true: this is the default config.
-        .timeout(Duration::from_secs(10))
-        .args(["-c", FLOOD])
-        .spawn("/bin/sh")
-        .expect("spawn");
+    let mut t = flood().expect("spawn");
 
     // The child's own output must keep arriving: the drain is alive.
     t.wait_until(|s| s.contains("DONE"))
@@ -64,13 +67,7 @@ fn a_child_that_never_reads_its_replies_cannot_wedge_the_drain() {
 /// exchange for a well-behaved one actually getting its answers.
 #[test]
 fn undelivered_replies_are_named_where_the_kernel_makes_them_visible() {
-    let mut t = Terminal::builder()
-        .size(80, 24)
-        .env_clear()
-        .timeout(Duration::from_secs(10))
-        .args(["-c", FLOOD])
-        .spawn("/bin/sh")
-        .expect("spawn");
+    let mut t = flood().expect("spawn");
 
     // Let the whole flood land first. The child prints DONE *after* its
     // last query, so once that is on screen the drain has read every
@@ -126,17 +123,19 @@ fn undelivered_replies_are_named_where_the_kernel_makes_them_visible() {
 /// replies still gets every one of them.
 #[test]
 fn replies_still_reach_an_application_that_reads_them() -> termlens::Result<()> {
-    let mut t = Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo; printf 'abc\033[6n'; ",
-                r#"reply=$(head -c 6 | tr '\033' 'E'); "#,
-                r#"printf '\nunblocked:%s' "$reply"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = common::spawn_emit(
+        Terminal::builder().timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "abc",
+            "--csi",
+            "6n",
+            "\nunblocked:",
+            "--read",
+            "6",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("unblocked:E[1;4R"))?;
     t.send(termlens::Key::Enter)?;
     assert!(t.wait_exit()?.success());

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -160,6 +160,10 @@ fn a_needle_finds_text_in_the_other_normalization_form() -> termlens::Result<()>
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "Rust's console stdio refuses to write bytes that are not UTF-8, so the fixture cannot send them on Windows (#149)"
+)]
 fn unicode_torture_renders_with_correct_widths() -> termlens::Result<()> {
     let mut t = spawn_fixture("unicode-torture")?;
     // Wait on the cursor, not on contains("done"): the predicate would turn

--- a/crates/termlens/tests/frames.rs
+++ b/crates/termlens/tests/frames.rs
@@ -29,6 +29,10 @@ fn spawn_form_echo() -> termlens::Result<Terminal> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn the_frame_completed_before_the_call_is_evaluated() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     // The fixture's first synchronized frame has long completed by the time
@@ -40,6 +44,10 @@ fn the_frame_completed_before_the_call_is_evaluated() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_frame_is_internally_consistent() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -62,6 +70,10 @@ fn a_frame_is_internally_consistent() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_torn_repaint_is_never_observed() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -115,6 +127,10 @@ fn apps_without_synchronized_output_time_out_with_guidance() {
 /// the only evidence available. The last completed frame can be
 /// arbitrarily old.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn wait_frame_timeouts_embed_the_live_screen_not_the_last_frame() {
     let mut t = emit(
         Terminal::builder().timeout(Duration::from_millis(400)),
@@ -151,6 +167,10 @@ fn wait_frame_timeouts_embed_the_live_screen_not_the_last_frame() {
 /// counter ticking 1, 2, 3 in a single write used to be visible only
 /// at 3.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn every_frame_of_a_burst_is_observable_in_order() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder().timeout(Duration::from_secs(10)),
@@ -178,6 +198,10 @@ fn every_frame_of_a_burst_is_observable_in_order() -> termlens::Result<()> {
 /// The retention bound is real and documented: beyond it, the oldest
 /// frames are dropped.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_burst_longer_than_the_retention_bound_drops_its_oldest_frames() -> termlens::Result<()> {
     // 12 frames in one write, against a retention bound of 8.
     let mut burst = String::new();
@@ -203,6 +227,10 @@ fn a_burst_longer_than_the_retention_bound_drops_its_oldest_frames() -> termlens
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn wait_frame_fails_fast_on_eof() {
     let mut t = emit(
         Terminal::builder().timeout(Duration::from_secs(30)),
@@ -290,6 +318,10 @@ fn a_defensive_mode_reset_keeps_the_never_emitted_diagnosis() {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_begin_end_pair_that_drew_nothing_is_still_a_frame() {
     // Deliberate: `frames_seen` counts repaints, not changes. An
     // application that opens and closes a synchronized update completed a
@@ -314,6 +346,10 @@ fn a_begin_end_pair_that_drew_nothing_is_still_a_frame() {
 /// the retained frame, and the assertion after it read the old screen. A
 /// regression in which the key stopped working was invisible.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_superseded_frame_no_longer_satisfies_a_wait() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder().timeout(Duration::from_secs(10)),
@@ -345,6 +381,10 @@ fn a_superseded_frame_no_longer_satisfies_a_wait() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn one_frame_cannot_satisfy_two_waits() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder().timeout(Duration::from_secs(10)),
@@ -366,6 +406,10 @@ fn one_frame_cannot_satisfy_two_waits() -> termlens::Result<()> {
 /// The burst is observable in emission order, which means out of order it
 /// is *not*: a frame already returned is behind the cursor.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_burst_frame_asked_for_out_of_order_is_gone() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder().timeout(Duration::from_millis(700)),
@@ -386,6 +430,10 @@ fn a_burst_frame_asked_for_out_of_order_is_gone() -> termlens::Result<()> {
 /// `wait_frame` returns the instant the predicate saw, which can differ
 /// from the live grid by the time the call returns.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn the_returned_frame_is_the_matched_instant_not_the_live_screen() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder().timeout(Duration::from_secs(10)),
@@ -455,6 +503,10 @@ fn a_resize_stops_offering_frames_drawn_at_the_old_size() -> termlens::Result<()
 /// runs. The grid is now resized and the cursor taken before the signal,
 /// under one lock, so there is no gap for a frame to fall into.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn the_repaint_answering_a_resize_is_offered_to_wait_frame() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -473,6 +525,10 @@ fn the_repaint_answering_a_resize_is_offered_to_wait_frame() -> termlens::Result
 /// every repaint — the tear is real, documented, and wanted for
 /// diagnosis. `wait_frame`'s return value is the frame-consistent read.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_snapshot_can_be_mid_frame_for_a_synchronized_application() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder()
@@ -540,6 +596,10 @@ fn a_wait_idle_timeout_names_an_unfinished_frame() {
 /// *inside* one synchronized update, so it is the outlier the series has to
 /// show.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn the_timing_series_shows_a_deliberately_slow_repaint() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -608,6 +668,10 @@ fn the_timing_series_shows_a_deliberately_slow_repaint() -> termlens::Result<()>
 /// Timings are per frame even when a burst arrives in one read — the markers
 /// are stamped at the byte that carried them, not when the read landed.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_burst_in_one_read_is_timed_per_frame() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder()

--- a/crates/termlens/tests/graphics.rs
+++ b/crates/termlens/tests/graphics.rs
@@ -44,6 +44,10 @@ fn run(mode: &str) -> termlens::Result<(Terminal, Screen)> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn a_transmitted_image_is_counted_and_described() -> termlens::Result<()> {
     let (_terminal, screen) = run("kitty")?;
     let seen = screen.graphics();
@@ -65,6 +69,10 @@ fn a_transmitted_image_is_counted_and_described() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn an_image_is_stamped_with_the_cell_it_was_placed_on() -> termlens::Result<()> {
     // The fixture moves to row 2, column 5 (1-based) and transmits there.
     // This is the one fact about an image that lives in the grid rather than
@@ -80,6 +88,10 @@ fn an_image_is_stamped_with_the_cell_it_was_placed_on() -> termlens::Result<()> 
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn a_chunked_transmission_is_one_image_not_three() -> termlens::Result<()> {
     // The protocol caps a payload at 4096 bytes and continues with `m=1`, so
     // every image of consequence arrives in several escapes. Counting each
@@ -105,6 +117,10 @@ fn a_chunked_transmission_is_one_image_not_three() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn a_delete_is_not_an_image_transmitted() -> termlens::Result<()> {
     // An application that tears down what it drew and one that draws twice
     // as much are opposite behaviours; folding a delete into the image count
@@ -155,6 +171,10 @@ fn the_image_leaves_the_text_around_it_alone() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn a_bounded_capture_keeps_the_counts_and_drops_the_bytes() -> termlens::Result<()> {
     // The budget is a memory bound, not an observation bound: every count
     // and every declared fact survives it, and only the data goes.
@@ -188,6 +208,10 @@ mod decoded {
     const BLUE: [u8; 4] = [0x00, 0x00, 0xff, 0xff];
 
     #[test]
+    #[cfg_attr(
+        windows,
+        ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+    )]
     fn a_kitty_image_decodes_into_the_pixels_that_were_drawn() -> termlens::Result<()> {
         // The claim the whole feature exists for: not "an image of about the
         // right size went out", but "*this* image went out".
@@ -216,6 +240,10 @@ mod decoded {
     }
 
     #[test]
+    #[cfg_attr(
+        windows,
+        ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+    )]
     fn a_sixel_decodes_into_the_pixels_that_were_painted() -> termlens::Result<()> {
         let (_terminal, screen) = run("sixel")?;
         let seen = screen.graphics();
@@ -236,6 +264,10 @@ mod decoded {
     }
 
     #[test]
+    #[cfg_attr(
+        windows,
+        ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+    )]
     fn a_delete_refuses_to_decode_and_says_why() -> termlens::Result<()> {
         let (_terminal, screen) = run("delete")?;
         let seen = screen.graphics();
@@ -248,6 +280,10 @@ mod decoded {
     }
 
     #[test]
+    #[cfg_attr(
+        windows,
+        ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+    )]
     fn an_uncaptured_payload_names_the_bound_rather_than_guessing() -> termlens::Result<()> {
         let mut terminal = Terminal::builder()
             .size(40, 10)

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -22,6 +22,10 @@ fn spawn_form_echo() -> termlens::Result<Terminal> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn clicks_round_trip_through_the_apps_tracking_mode() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -51,6 +55,10 @@ fn clicks_round_trip_through_the_apps_tracking_mode() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn modifier_chords_round_trip_through_crossterms_parser() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -73,6 +81,10 @@ fn modifier_chords_round_trip_through_crossterms_parser() -> termlens::Result<()
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn paste_is_one_event_under_bracketed_paste() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -104,6 +116,10 @@ fn paste_falls_back_to_plain_bytes_without_the_mode() -> termlens::Result<()> {
 /// A paste marker inside the text must not end the paste early: the app
 /// would see the remainder as ordinary key presses (paste injection).
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn an_embedded_paste_marker_cannot_end_the_paste() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -122,6 +138,10 @@ fn an_embedded_paste_marker_cannot_end_the_paste() -> termlens::Result<()> {
 /// key produces — every real terminal converts, and raw mode (which
 /// clears ICRNL) means nothing downstream will.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "the wire is read in raw mode, a tcsetattr, and ConPTY turns typed bytes into console events rather than forwarding them (#149)"
+)]
 fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
     let mut t = util::spawn_emit(
         Terminal::builder().timeout(Duration::from_secs(10)),
@@ -162,6 +182,10 @@ fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
 /// two encodings agree below column 95, sending the wrong one fails only
 /// past a position boundary.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "the wire is read in raw mode, a tcsetattr, and ConPTY turns typed bytes into console events rather than forwarding them (#149)"
+)]
 fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
     let mut t = util::spawn_emit(
         Terminal::builder()
@@ -209,6 +233,10 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
 /// Everything the mouse API can express, captured off the wire under
 /// SGR encoding with full (any-event) tracking.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "the wire is read in raw mode, a tcsetattr, and ConPTY turns typed bytes into console events rather than forwarding them (#149)"
+)]
 fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Result<()> {
     let mut t = util::spawn_emit(
         // Wide enough that the captured wire stays on one row.
@@ -271,6 +299,10 @@ fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Res
 /// did it start, where is it now", and wrong for every application that does
 /// something *along* the path.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "the wire is read in raw mode, a tcsetattr, and ConPTY turns typed bytes into console events rather than forwarding them (#149)"
+)]
 fn a_drag_reports_one_motion_per_cell_crossed() -> termlens::Result<()> {
     let mut t = util::spawn_emit(
         Terminal::builder()
@@ -316,6 +348,10 @@ fn a_drag_reports_one_motion_per_cell_crossed() -> termlens::Result<()> {
 /// The mode-aware refusals are untouched: under plain `?1000` the
 /// application asked not to hear about motion, so it hears none.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "the wire is read in raw mode, a tcsetattr, and ConPTY turns typed bytes into console events rather than forwarding them (#149)"
+)]
 fn press_release_tracking_still_gets_no_motion_at_all() -> termlens::Result<()> {
     let mut t = util::spawn_emit(
         Terminal::builder()
@@ -367,6 +403,10 @@ fn drag_is_refused_when_the_mode_cannot_express_it() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "the wire is read in raw mode, a tcsetattr, and ConPTY turns typed bytes into console events rather than forwarding them (#149)"
+)]
 fn arrows_follow_the_apps_cursor_key_mode() -> termlens::Result<()> {
     // The program enables DECCKM (CSI ?1 h), reads 3 bytes, reports them,
     // then disables it and reads again — one terminal, both modes.
@@ -428,6 +468,10 @@ fn clicking_without_mouse_tracking_is_a_typed_error() {
 /// path wrapped or panicked). Refuse with the position and the grid size
 /// at the time of the call — including after a shrink `resize`.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn mouse_events_outside_the_grid_are_refused() -> termlens::Result<()> {
     let mut t = Terminal::builder()
         .size(20, 5)
@@ -488,6 +532,10 @@ fn mouse_events_outside_the_grid_are_refused() -> termlens::Result<()> {
 /// unfocused branch of a UI was not merely unasserted, it was **unreachable**
 /// — no input existed that could enter it, so the code never ran.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn focus_events_reach_the_application_in_both_directions() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     // Assert on the frame the wait returned rather than waiting again: the
@@ -516,6 +564,10 @@ fn focus_events_reach_the_application_in_both_directions() -> termlens::Result<(
 /// events it did not request is not what a terminal does, and the bytes
 /// would be misparsed as keys.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY turns focus reporting on for itself, so focus_events() is true from the first byte (#149)"
+)]
 fn focus_events_are_refused_without_mode_1004() -> termlens::Result<()> {
     // hello-tui enables the alternate screen and nothing else.
     let mut t = Terminal::builder()
@@ -621,8 +673,10 @@ fn typed_input_to_a_live_child_that_has_not_read_yet_succeeds() -> termlens::Res
     )?;
     t.wait_until(|s| s.contains("READY"))?;
 
-    // Sent while the child is sleeping, well before its read.
-    t.send_str("pending\n")?;
+    // Sent while the child is sleeping, well before its read. Enter, not a
+    // bare LF: ConPTY's cooked input ends a line at CR.
+    t.send_str("pending")?;
+    t.send(Key::Enter)?;
     t.wait_until(|s| s.contains("got:pending"))?;
     assert!(t.wait_exit()?.success());
     Ok(())
@@ -632,6 +686,10 @@ fn typed_input_to_a_live_child_that_has_not_read_yet_succeeds() -> termlens::Res
 /// whole mechanism: it exists to put this write and the previous one in
 /// separate reads.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn send_after_delays_then_delivers() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;
@@ -659,6 +717,10 @@ fn send_after_delays_then_delivers() -> termlens::Result<()> {
 /// The byte-level identity behind the hazard is pinned deterministically in
 /// `keys.rs`; the merge itself is a race, so nothing here asserts on it.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_separated_esc_is_decoded_as_an_esc() -> termlens::Result<()> {
     let mut t = spawn_form_echo()?;
     t.wait_frame(|s| s.contains("form-echo ready"))?;

--- a/crates/termlens/tests/input.rs
+++ b/crates/termlens/tests/input.rs
@@ -1,10 +1,10 @@
 //! Typed input beyond plain keys: mouse (mode-aware), modifier chords,
 //! bracketed paste, and cursor-key modes.
 //!
-//! The programs that read what termlens typed off the wire stay on
-//! `/bin/sh` on purpose (#249): they put the terminal in raw mode with
-//! `stty -icanon -echo` first, and the std-only `emit` fixture cannot set a
-//! terminal mode. Everything that only prints goes through the fixture.
+//! The programs that read what termlens typed off the wire run the `emit`
+//! fixture in `--raw-mode`, so the bytes arrive as sent and unechoed, and
+//! print them with ESC drawn as `E` — or as hex where the exact bytes are
+//! the point.
 
 use std::time::{Duration, Instant};
 
@@ -88,18 +88,12 @@ fn paste_is_one_event_under_bracketed_paste() -> termlens::Result<()> {
 
 #[test]
 fn paste_falls_back_to_plain_bytes_without_the_mode() -> termlens::Result<()> {
-    // A plain shell never enables mode 2004; the paste must arrive as
+    // A program that never enables mode 2004; the paste must arrive as
     // raw bytes with no ESC[200~ wrapper.
-    let mut t = Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo; ",
-                r#"reply=$(head -c 5); printf 'got:%s' "$reply"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = util::spawn_emit(
+        Terminal::builder().timeout(Duration::from_secs(10)),
+        &["--raw-mode", "got:", "--read", "5", "--wait"],
+    )?;
     t.paste("plain")?;
     t.wait_until(|s| s.contains("got:plain"))?;
     t.send(Key::Enter)?;
@@ -129,22 +123,22 @@ fn an_embedded_paste_marker_cannot_end_the_paste() -> termlens::Result<()> {
 /// clears ICRNL) means nothing downstream will.
 #[test]
 fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
-    let mut t = Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                // -icrnl is what raw mode does (crossterm's
-                // enable_raw_mode clears it): without it the line
-                // discipline rewrites our CR back to LF before the app
-                // ever sees it. READY marks the settings as applied —
-                // pasting earlier would race them.
-                r"stty -icanon -echo -icrnl; printf READY; ",
-                // Render the three bytes as hex so the wire is visible.
-                r"head -c 3 | od -An -tx1 | tr -d ' \n'; printf ' WIRE-EOF'; read guard"
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = util::spawn_emit(
+        Terminal::builder().timeout(Duration::from_secs(10)),
+        &[
+            // -icrnl is what raw mode does (crossterm's enable_raw_mode
+            // clears it): without it the line discipline rewrites our CR
+            // back to LF before the app ever sees it. READY marks the
+            // settings as applied — pasting earlier would race them.
+            "--no-icrnl",
+            "READY",
+            // The three bytes as hex, so the wire is visible.
+            "--read-hex",
+            "3",
+            " WIRE-EOF",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("READY"))?;
 
     t.paste("a\nb")?;
@@ -169,25 +163,28 @@ fn a_pasted_line_break_arrives_as_carriage_return() -> termlens::Result<()> {
 /// past a position boundary.
 #[test]
 fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
-    let mut t = Terminal::builder()
-        .size(120, 24)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo; printf '\033[?1000h\033[?1005h'; printf READY; ",
-                r"head -c 7 | od -An -tx1 | tr -d ' \n'; printf ' WIRE-EOF'; ",
-                // A loop with a sentinel, not a bare `read guard`: the
-                // padding below is a separate write from the click, so
-                // whether head's buffered read swallows it or leaves it
-                // queued is a race. A bare guard loses that race — it
-                // consumes a padding newline, the shell exits, and the
-                // final write below hits a dead PTY with EIO. Only QUIT
-                // ends this script, so the padding cannot end it early.
-                r#"while read guard; do [ "$guard" = QUIT ] && exit 0; done"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = util::spawn_emit(
+        Terminal::builder()
+            .size(120, 24)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\e[?1000h\e[?1005h",
+            "READY",
+            "--read-hex",
+            "7",
+            " WIRE-EOF",
+            // A sentinel, not a bare `--wait`: the padding below is a
+            // separate write from the click, so whether the buffered read
+            // swallows it or leaves it queued is a race. A bare wait loses
+            // that race — it consumes a padding newline, the program exits,
+            // and the final write below hits a dead PTY with EIO. Only QUIT
+            // ends this program, so the padding cannot end it early.
+            "--wait-for",
+            "QUIT",
+        ],
+    )?;
     t.wait_until(|s| s.contains("READY"))?;
 
     // Column 100 is 0x85 as a bare byte; UTF-8 must send c2 85.
@@ -213,21 +210,26 @@ fn mouse_reports_follow_the_utf8_encoding() -> termlens::Result<()> {
 /// SGR encoding with full (any-event) tracking.
 #[test]
 fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Result<()> {
-    let mut t = Terminal::builder()
+    let mut t = util::spawn_emit(
         // Wide enough that the captured wire stays on one row.
-        .size(200, 24)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                // `min 0 time 20` rather than an exact byte count: the drag
-                // reports one motion per cell crossed, so the length depends
-                // on the path.
-                r"stty -icanon -echo min 0 time 20; printf '\033[?1003h\033[?1006h'; printf READY; ",
-                r#"wire=$(dd bs=1 count=200 2>/dev/null | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+        Terminal::builder()
+            .size(200, 24)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\e[?1003h\e[?1006h",
+            "READY",
+            // `--read-quiet` rather than an exact byte count: the drag
+            // reports one motion per cell crossed, so the length depends
+            // on the path. The `|` follows the read, so waiting for it
+            // waits for the wire.
+            "--read-quiet",
+            "200",
+            "|",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("READY"))?;
 
     // Right-click: SGR button 2. Ctrl-click: 0 + 16. Wheel left: 66.
@@ -270,17 +272,22 @@ fn buttons_modifiers_drag_and_horizontal_wheel_reach_the_wire() -> termlens::Res
 /// something *along* the path.
 #[test]
 fn a_drag_reports_one_motion_per_cell_crossed() -> termlens::Result<()> {
-    let mut t = Terminal::builder()
-        .size(200, 24)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo min 0 time 20; printf '\033[?1002h\033[?1006h'; printf READY; ",
-                r#"wire=$(dd bs=1 count=300 2>/dev/null | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = util::spawn_emit(
+        Terminal::builder()
+            .size(200, 24)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\e[?1002h\e[?1006h",
+            "READY",
+            // The `|` follows the read, so waiting for it waits for the wire.
+            "--read-quiet",
+            "300",
+            "|",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("READY"))?;
 
     // Seven cells crossed, from column 5 to column 12 on row 4.
@@ -310,17 +317,22 @@ fn a_drag_reports_one_motion_per_cell_crossed() -> termlens::Result<()> {
 /// application asked not to hear about motion, so it hears none.
 #[test]
 fn press_release_tracking_still_gets_no_motion_at_all() -> termlens::Result<()> {
-    let mut t = Terminal::builder()
-        .size(200, 24)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo min 0 time 20; printf '\033[?1000h\033[?1006h'; printf READY; ",
-                r#"wire=$(dd bs=1 count=100 2>/dev/null | tr '\033' 'E'); printf '|%s|' "$wire"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = util::spawn_emit(
+        Terminal::builder()
+            .size(200, 24)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\e[?1000h\e[?1006h",
+            "READY",
+            // The `|` follows the read, so waiting for it waits for the wire.
+            "--read-quiet",
+            "100",
+            "|",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("READY"))?;
     t.drag(termlens::MouseButton::Left, 5, 4, 12, 4)?;
     t.wait_until(|s| s.row_text(0).contains("|"))?;
@@ -356,20 +368,28 @@ fn drag_is_refused_when_the_mode_cannot_express_it() -> termlens::Result<()> {
 
 #[test]
 fn arrows_follow_the_apps_cursor_key_mode() -> termlens::Result<()> {
-    // The script enables DECCKM (CSI ?1 h), reads 3 bytes, reports them,
+    // The program enables DECCKM (CSI ?1 h), reads 3 bytes, reports them,
     // then disables it and reads again — one terminal, both modes.
-    let mut t = Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo; printf '[?1hAPP '; ",
-                r#"a=$(head -c 3 | tr '' 'E'); printf 'got:%s ' "$a"; "#,
-                r"printf '[?1lNORM '; ",
-                r#"b=$(head -c 3 | tr '' 'E'); printf 'got:%s' "$b"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = util::spawn_emit(
+        Terminal::builder().timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--csi",
+            "?1h",
+            "APP ",
+            "got:",
+            "--read",
+            "3",
+            " ",
+            "--csi",
+            "?1l",
+            "NORM ",
+            "got:",
+            "--read",
+            "3",
+            "--wait",
+        ],
+    )?;
 
     t.wait_until(|s| s.contains("APP"))?;
     t.send(Key::Up)?;

--- a/crates/termlens/tests/inspect.rs
+++ b/crates/termlens/tests/inspect.rs
@@ -2,23 +2,32 @@
 
 use std::path::PathBuf;
 use std::process::{Command, Output};
+use std::sync::OnceLock;
 
-fn inspect_bin() -> PathBuf {
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let status = Command::new(cargo)
-        .args(["build", "-p", "termlens", "--example", "inspect"])
-        .status()
-        .expect("failed to run cargo build for the inspect example");
-    assert!(status.success(), "cargo build --example inspect failed");
+/// Built once per test process, whichever test asks first. Every test used
+/// to run its own `cargo build`, and two of them in parallel could race a
+/// relink: one unlinks and rewrites the example while the other's
+/// `Command::new` finds nothing there — `NotFound`, once, on a macOS runner
+/// (#278). Same shape as `common::fixture_bin`'s guard, for the same reason.
+fn inspect_bin() -> &'static PathBuf {
+    static BIN: OnceLock<PathBuf> = OnceLock::new();
+    BIN.get_or_init(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let status = Command::new(cargo)
+            .args(["build", "-p", "termlens", "--example", "inspect"])
+            .status()
+            .expect("failed to run cargo build for the inspect example");
+        assert!(status.success(), "cargo build --example inspect failed");
 
-    let test_exe = std::env::current_exe().expect("test executable path is available");
-    let profile_dir = test_exe
-        .parent()
-        .and_then(|deps| deps.parent())
-        .expect("test executable is under target/<profile>/deps");
-    profile_dir
-        .join("examples")
-        .join(format!("inspect{}", std::env::consts::EXE_SUFFIX))
+        let test_exe = std::env::current_exe().expect("test executable path is available");
+        let profile_dir = test_exe
+            .parent()
+            .and_then(|deps| deps.parent())
+            .expect("test executable is under target/<profile>/deps");
+        profile_dir
+            .join("examples")
+            .join(format!("inspect{}", std::env::consts::EXE_SUFFIX))
+    })
 }
 
 fn run_inspect(bin: &PathBuf, args: &[&str]) -> Output {
@@ -32,7 +41,7 @@ fn run_inspect(bin: &PathBuf, args: &[&str]) -> Output {
 fn inspect_runs_and_reports_cli_failures() {
     let bin = inspect_bin();
 
-    let sized = run_inspect(&bin, &["--size", "12x3", "sh", "-c", "stty size"]);
+    let sized = run_inspect(bin, &["--size", "12x3", "sh", "-c", "stty size"]);
     assert!(
         sized.status.success(),
         "inspect failed: {}",
@@ -48,7 +57,7 @@ fn inspect_runs_and_reports_cli_failures() {
         "exit status missing from:\n{stdout}"
     );
 
-    let bad_size = run_inspect(&bin, &["--size", "12", "sh"]);
+    let bad_size = run_inspect(bin, &["--size", "12", "sh"]);
     assert_eq!(bad_size.status.code(), Some(1));
     assert!(
         String::from_utf8_lossy(&bad_size.stderr).contains("expected e.g. 120x40"),
@@ -56,7 +65,7 @@ fn inspect_runs_and_reports_cli_failures() {
         String::from_utf8_lossy(&bad_size.stderr)
     );
 
-    let missing_program = run_inspect(&bin, &["/definitely/not/a/program"]);
+    let missing_program = run_inspect(bin, &["/definitely/not/a/program"]);
     assert_eq!(missing_program.status.code(), Some(1));
     assert!(
         String::from_utf8_lossy(&missing_program.stderr).starts_with("inspect:"),
@@ -68,7 +77,7 @@ fn inspect_runs_and_reports_cli_failures() {
 #[test]
 fn inspect_clears_and_selectively_sets_the_child_environment() {
     let bin = inspect_bin();
-    let output = Command::new(&bin)
+    let output = Command::new(bin)
         .env("TERMLENS_INSPECT_LEAK", "secret")
         .args(["--env", "KEPT=yes"])
         .args(["sh", "-c", "printf ${TERMLENS_INSPECT_LEAK-unset}:$KEPT"])
@@ -80,7 +89,7 @@ fn inspect_clears_and_selectively_sets_the_child_environment() {
         "cleared/selected environment missing from:\n{stdout}"
     );
 
-    let inherited = Command::new(&bin)
+    let inherited = Command::new(bin)
         .env("TERMLENS_INSPECT_INHERITED", "yes")
         .args(["--inherit-env"])
         .args(["sh", "-c", "printf inherited:$TERMLENS_INSPECT_INHERITED"])
@@ -102,7 +111,7 @@ fn inspect_survives_a_reader_that_closes_early() {
     // closed the write gets EPIPE — which println! turned into a panic and
     // exit 101 (#223). A viewer piped into `head` must exit cleanly.
     let bin = inspect_bin();
-    let mut child = Command::new(&bin)
+    let mut child = Command::new(bin)
         .args(["--size", "200x1000", "sh", "-c", "yes | head -n 2000"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -132,7 +141,7 @@ fn inspect_prints_its_usage_for_help_and_for_a_missing_program() {
     let bin = inspect_bin();
 
     for flag in ["--help", "-h"] {
-        let help = run_inspect(&bin, &[flag]);
+        let help = run_inspect(bin, &[flag]);
         assert_eq!(
             help.status.code(),
             Some(0),
@@ -148,7 +157,7 @@ fn inspect_prints_its_usage_for_help_and_for_a_missing_program() {
         assert!(help.stderr.is_empty(), "{flag} wrote to stderr");
     }
 
-    let version = run_inspect(&bin, &["--version"]);
+    let version = run_inspect(bin, &["--version"]);
     assert_eq!(version.status.code(), Some(0));
     assert!(
         String::from_utf8_lossy(&version.stdout)
@@ -156,7 +165,7 @@ fn inspect_prints_its_usage_for_help_and_for_a_missing_program() {
         "--version names the crate version"
     );
 
-    let none = run_inspect(&bin, &[]);
+    let none = run_inspect(bin, &[]);
     assert_eq!(
         none.status.code(),
         Some(1),
@@ -169,7 +178,7 @@ fn inspect_prints_its_usage_for_help_and_for_a_missing_program() {
         String::from_utf8_lossy(&none.stderr)
     );
 
-    let unknown = run_inspect(&bin, &["--bogus", "sh"]);
+    let unknown = run_inspect(bin, &["--bogus", "sh"]);
     assert_eq!(unknown.status.code(), Some(1));
     assert!(
         String::from_utf8_lossy(&unknown.stderr).contains("unknown option \"--bogus\""),
@@ -197,7 +206,7 @@ fn inspect_takes_its_deadline_and_silence_window_from_flags() {
         (&["--timeout"][..], "--timeout needs a SECONDS argument"),
         (&["--idle"][..], "--idle needs a MILLIS argument"),
     ] {
-        let out = run_inspect(&bin, args);
+        let out = run_inspect(bin, args);
         assert_eq!(out.status.code(), Some(1), "{args:?}");
         let stderr = String::from_utf8_lossy(&out.stderr);
         assert!(stderr.contains(expect), "{args:?}: got {stderr:?}");
@@ -214,7 +223,7 @@ fn inspect_takes_its_deadline_and_silence_window_from_flags() {
     // still on the screen it prints.
     let started = std::time::Instant::now();
     let cut = run_inspect(
-        &bin,
+        bin,
         &[
             "--timeout",
             "1",
@@ -264,7 +273,7 @@ fn inspect_resolves_a_relative_program_path_from_its_working_directory() {
     std::os::unix::fs::symlink("/bin/echo", &echo)
         .expect("link /bin/echo into the scratch directory");
 
-    let out = Command::new(&bin)
+    let out = Command::new(bin)
         .current_dir(&scratch)
         .args(["./echo", "relative path resolved"])
         .output()

--- a/crates/termlens/tests/observe.rs
+++ b/crates/termlens/tests/observe.rs
@@ -106,6 +106,10 @@ fn a_bell_is_observable_and_a_title_terminator_is_not_a_bell() -> termlens::Resu
 /// must render as text in every terminal, so it must never go out as an
 /// image.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn graphics_payloads_are_observable_and_absence_is_assertable() -> termlens::Result<()> {
     let mut plain = emit(&["box art: +--+", " DONE", "--wait"])?;
     plain.wait_until(|s| s.contains("DONE"))?;
@@ -147,6 +151,10 @@ fn graphics_payloads_are_observable_and_absence_is_assertable() -> termlens::Res
 /// The kitty graphics query used to escape the timeout note entirely: no
 /// answer *and* no diagnosis, alone among the startup probes.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn a_blocked_kitty_graphics_query_is_named_in_the_timeout() -> termlens::Result<()> {
     let mut t = common::spawn_emit(
         Terminal::builder()
@@ -170,6 +178,10 @@ fn a_blocked_kitty_graphics_query_is_named_in_the_timeout() -> termlens::Result<
 /// A transmission is an instruction, not a question, so it must not put a
 /// query diagnosis into an unrelated timeout of an application that draws.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward kitty or sixel payloads (#149)"
+)]
 fn a_kitty_transmission_does_not_pollute_the_timeout() -> termlens::Result<()> {
     let mut t = common::spawn_emit(
         Terminal::builder()
@@ -195,6 +207,10 @@ fn a_kitty_transmission_does_not_pollute_the_timeout() -> termlens::Result<()> {
 /// frames used to be built straight from the emulator, which skipped the
 /// count and left it at zero.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn a_frame_from_wait_frame_carries_the_repaint_count() -> termlens::Result<()> {
     let mut t = emit(&[
         "READY",

--- a/crates/termlens/tests/process.rs
+++ b/crates/termlens/tests/process.rs
@@ -45,15 +45,7 @@ fn pid_reports_the_direct_child() -> termlens::Result<()> {
 #[test]
 #[cfg(unix)]
 fn signal_term_exercises_the_graceful_shutdown_path() -> termlens::Result<()> {
-    // Stays on `/bin/sh`: trapping a signal is what this test is about, and
-    // the std-only fixture has no way to install a handler.
-    let mut t = Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            "trap 'printf got-term; exit 7' TERM; printf ready; while :; do sleep 0.05; done",
-        ])
-        .spawn("sh")?;
+    let mut t = emit(&["--on-term", "got-term", "7", "ready", "--idle"])?;
     t.wait_until(|s| s.contains("ready"))?;
 
     t.signal(Signal::Term)?;

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -25,6 +25,10 @@ fn probe(steps: &[&str]) -> termlens::Result<Terminal> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn cursor_position_reports_the_position_at_the_query() -> termlens::Result<()> {
     // After printing "abc" the cursor sits at row 1, col 4 (1-based on the
     // wire); the CPR reply is exactly 6 bytes: ESC [ 1 ; 4 R.
@@ -45,6 +49,10 @@ fn cursor_position_reports_the_position_at_the_query() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn device_attribute_probes_are_unblocked() -> termlens::Result<()> {
     // DA1 reply is ESC [ ? 6 2 ; 2 2 c = 9 bytes. This is also the exact
     // pattern kitty-protocol probes rely on: the DA1 answer arriving tells
@@ -65,6 +73,10 @@ fn device_attribute_probes_are_unblocked() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn background_color_query_gets_the_configured_answer() -> termlens::Result<()> {
     // OSC 11 reply: ESC ] 1 1 ; rgb:1e1e/1e1e/2e2e BEL = 24 bytes.
     let mut t = common::spawn_emit(
@@ -88,6 +100,10 @@ fn background_color_query_gets_the_configured_answer() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn foreground_color_query_gets_the_configured_answer() -> termlens::Result<()> {
     // OSC 10 reply: ESC ] 1 0 ; rgb:cdcd/d6d6/f4f4 BEL = 24 bytes.
     let mut t = common::spawn_emit(
@@ -111,6 +127,10 @@ fn foreground_color_query_gets_the_configured_answer() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn text_area_size_reports_the_real_grid() -> termlens::Result<()> {
     // XTWINOPS 18 reply: ESC [ 8 ; 24 ; 80 t = 10 bytes.
     let mut t = probe(&[
@@ -231,6 +251,10 @@ fn wait_frame_timeouts_carry_the_query_note() {
 /// using synchronized output can turn it on against termlens — so
 /// `wait_frame` works against a program nobody modified for us.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn an_app_that_probes_for_synchronized_output_gets_it() -> termlens::Result<()> {
     let mut t = probe(&[
         // Ask "is mode 2026 supported?" and put the DECRPM reply on row 1,
@@ -259,6 +283,10 @@ fn an_app_that_probes_for_synchronized_output_gets_it() -> termlens::Result<()> 
 /// The reply must be truthful, not merely present: a mode we do not
 /// track exactly is reported as "not recognized" rather than guessed.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn mode_reports_are_truthful() -> termlens::Result<()> {
     let mut t = probe(&[
         "--raw-mode",
@@ -290,6 +318,10 @@ fn mode_reports_are_truthful() -> termlens::Result<()> {
 /// The families we recognize but cannot answer are now named in the
 /// timeout instead of hanging silently.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn decrqss_and_palette_queries_are_named() {
     for (label, query, shape) in [
         ("DECRQSS", r"\eP$qm\e\\", "^[P$qm"),
@@ -307,6 +339,10 @@ fn decrqss_and_palette_queries_are_named() {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn replies_are_not_echoed_into_the_screen() -> termlens::Result<()> {
     // The reply travels the input path; unless the app prints it, it must
     // never appear in the grid. Raw mode keeps the line discipline from
@@ -334,6 +370,10 @@ fn replies_are_not_echoed_into_the_screen() -> termlens::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
     // The loop this closes on itself: the application probes `?1000$p`, is
     // told "not recognized", concludes the terminal has no mouse and never
@@ -376,6 +416,10 @@ fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
 /// for a member other than the last one enabled — which is every probe
 /// after crossterm's three-at-once enable — was answered "not recognized".
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn decrqm_answers_each_mouse_tracking_mode_on_its_own() -> termlens::Result<()> {
     // Reply values: 1 = set, 2 = reset, 0 = not recognized. The reply is
     // `ESC [ ? <mode> ; <value> $ y`, so its length follows the mode's.
@@ -432,6 +476,10 @@ fn decrqm_answers_each_mouse_tracking_mode_on_its_own() -> termlens::Result<()> 
 /// honesty rule's precondition. Before, an application probing for focus
 /// support was told "not recognized" even right after enabling it.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn decrqm_answers_for_focus_reporting() -> termlens::Result<()> {
     // Reply values: 1 = set, 2 = reset, 0 = not recognized.
     for (sequence, expect, label) in [
@@ -473,6 +521,10 @@ fn decrqm_answers_for_focus_reporting() -> termlens::Result<()> {
 /// Pixel geometry: unset it stays unanswered and named, set it makes the
 /// two escape replies and `TIOCGWINSZ` agree instead of contradicting.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn cell_size_answers_the_pixel_reports_and_the_ioctl() -> termlens::Result<()> {
     // Unset: no reply, and the query is named in the next timeout.
     let mut mute = common::spawn_emit(
@@ -524,6 +576,7 @@ fn cell_size_answers_the_pixel_reports_and_the_ioctl() -> termlens::Result<()> {
 /// both — otherwise an application gets two different answers to the same
 /// question depending on how it asks.
 #[test]
+#[cfg_attr(windows, ignore = "TIOCGWINSZ is a Unix ioctl")]
 fn tiocgwinsz_agrees_with_the_declared_cell_size() -> termlens::Result<()> {
     let mut t = common::spawn_emit(
         Terminal::builder()
@@ -565,6 +618,10 @@ fn tiocgwinsz_agrees_with_the_declared_cell_size() -> termlens::Result<()> {
 /// reach its pixel path at all. The default claims nothing, which is what
 /// makes the declaration meaningful.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
     // Default: DA1 has no `4`, and the kitty probe goes unanswered.
     let mut plain = common::spawn_emit(
@@ -636,6 +693,10 @@ fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
 /// halves matter: a known capability is answered truthfully, and an unknown
 /// one is *explicitly* declined — which is what turns a hang into a decision.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn xtgettcap_answers_what_it_knows_and_declines_the_rest() -> termlens::Result<()> {
     // TN=544e, colors=636f6c6f7273, and a made-up name that must be refused.
     // Wide enough that the three replies stay on one row.
@@ -680,6 +741,10 @@ fn xtgettcap_answers_what_it_knows_and_declines_the_rest() -> termlens::Result<(
 /// `TN` reports whatever `TERM` the child was actually given, so an
 /// application cannot get two different answers to "which terminal is this?".
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn xtgettcap_tn_follows_the_configured_term() -> termlens::Result<()> {
     let mut t = common::spawn_emit(
         Terminal::builder()
@@ -713,6 +778,10 @@ fn xtgettcap_tn_follows_the_configured_term() -> termlens::Result<()> {
 /// application that reads it and then matches input against it will not
 /// match what arrives.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY answers or eats the child's queries itself, so they never reach the responder (#149)"
+)]
 fn xtgettcap_key_capabilities_match_what_send_emits() -> termlens::Result<()> {
     // kcuu1 = 6b63757531; the value must be ESC [ A = 1b5b41.
     let mut t = common::spawn_emit(

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -1,16 +1,11 @@
 //! The query responder: capability-probing apps get real answers instead
 //! of hanging, and whatever stays unanswered is named in timeout errors.
 //!
-//! Each shell script here genuinely BLOCKS on the terminal's reply
-//! (`head -c N` reads exactly the reply bytes), then prints a marker the
-//! test waits for — the marker appearing proves the app was unblocked.
-//!
-//! Those stay on `/bin/sh` on purpose (#249): reading a reply byte for byte
-//! needs the terminal in raw mode (`stty -icanon -echo`), which the
-//! std-only `emit` fixture cannot set. The programs that only *ask* and
-//! then block on a line — the ones whose point is that no answer comes —
-//! go through the fixture: `--wait` blocks on a line exactly as `head` did
-//! in canonical mode.
+//! Each program here genuinely BLOCKS on the terminal's reply — `--read N`
+//! reads exactly the reply bytes, in raw mode so the line discipline
+//! neither echoes them nor holds them for a newline — then prints a marker
+//! the test waits for. The marker appearing proves the app was unblocked,
+//! and the reply is on the grid with ESC drawn as `E` and BEL as `G`.
 
 use std::time::Duration;
 
@@ -18,28 +13,31 @@ use termlens::{Error, Key, Terminal};
 
 mod common;
 
-fn sh(script: &str) -> termlens::Result<Terminal> {
-    Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .args(["-c", script])
-        .spawn("/bin/sh")
-}
-
 /// The `emit` fixture with the timeout the test names; steps are documented
 /// in `fixtures/emit/src/main.rs`.
 fn emit(timeout: Duration, steps: &[&str]) -> termlens::Result<Terminal> {
     common::spawn_emit(Terminal::builder().timeout(timeout), steps)
 }
 
+/// A program that asks and reads the answer, ten seconds to do it in.
+fn probe(steps: &[&str]) -> termlens::Result<Terminal> {
+    emit(Duration::from_secs(10), steps)
+}
+
 #[test]
 fn cursor_position_reports_the_position_at_the_query() -> termlens::Result<()> {
     // After printing "abc" the cursor sits at row 1, col 4 (1-based on the
     // wire); the CPR reply is exactly 6 bytes: ESC [ 1 ; 4 R.
-    let mut t = sh(concat!(
-        r"stty -icanon -echo; printf 'abc\033[6n'; ",
-        r#"reply=$(head -c 6 | tr '\033' 'E'); "#,
-        r#"printf '\nunblocked:%s' "$reply"; read guard"#
-    ))?;
+    let mut t = probe(&[
+        "--raw-mode",
+        "abc",
+        "--csi",
+        "6n",
+        "\nunblocked:",
+        "--read",
+        "6",
+        "--wait",
+    ])?;
     t.wait_until(|s| s.contains("unblocked:E[1;4R"))?;
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
@@ -51,11 +49,15 @@ fn device_attribute_probes_are_unblocked() -> termlens::Result<()> {
     // DA1 reply is ESC [ ? 6 2 ; 2 2 c = 9 bytes. This is also the exact
     // pattern kitty-protocol probes rely on: the DA1 answer arriving tells
     // the app "no kitty support", exactly like a real non-kitty terminal.
-    let mut t = sh(concat!(
-        r"stty -icanon -echo; printf '\033[c'; ",
-        r#"reply=$(head -c 9 | tr '\033' 'E'); "#,
-        r#"printf 'unblocked:%s' "$reply"; read guard"#
-    ))?;
+    let mut t = probe(&[
+        "--raw-mode",
+        "--csi",
+        "c",
+        "unblocked:",
+        "--read",
+        "9",
+        "--wait",
+    ])?;
     t.wait_until(|s| s.contains("unblocked:E[?62;22c"))?;
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
@@ -65,18 +67,20 @@ fn device_attribute_probes_are_unblocked() -> termlens::Result<()> {
 #[test]
 fn background_color_query_gets_the_configured_answer() -> termlens::Result<()> {
     // OSC 11 reply: ESC ] 1 1 ; rgb:1e1e/1e1e/2e2e BEL = 24 bytes.
-    let mut t = Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .background_rgb(0x1e, 0x1e, 0x2e)
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo; printf '\033]11;?\007'; ",
-                r#"reply=$(head -c 24 | tr '\033\007' 'EG'); "#,
-                r#"printf 'unblocked:%s' "$reply"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .timeout(Duration::from_secs(10))
+            .background_rgb(0x1e, 0x1e, 0x2e),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\e]11;?\a",
+            "unblocked:",
+            "--read",
+            "24",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("unblocked:E]11;rgb:1e1e/1e1e/2e2eG"))?;
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
@@ -86,18 +90,20 @@ fn background_color_query_gets_the_configured_answer() -> termlens::Result<()> {
 #[test]
 fn foreground_color_query_gets_the_configured_answer() -> termlens::Result<()> {
     // OSC 10 reply: ESC ] 1 0 ; rgb:cdcd/d6d6/f4f4 BEL = 24 bytes.
-    let mut t = Terminal::builder()
-        .timeout(Duration::from_secs(10))
-        .foreground_rgb(0xcd, 0xd6, 0xf4)
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo; printf '\033]10;?\007'; ",
-                r#"reply=$(head -c 24 | tr '\033\007' 'EG'); "#,
-                r#"printf 'unblocked:%s' "$reply"; read guard"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .timeout(Duration::from_secs(10))
+            .foreground_rgb(0xcd, 0xd6, 0xf4),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\e]10;?\a",
+            "unblocked:",
+            "--read",
+            "24",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("unblocked:E]10;rgb:cdcd/d6d6/f4f4G"))?;
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
@@ -107,11 +113,15 @@ fn foreground_color_query_gets_the_configured_answer() -> termlens::Result<()> {
 #[test]
 fn text_area_size_reports_the_real_grid() -> termlens::Result<()> {
     // XTWINOPS 18 reply: ESC [ 8 ; 24 ; 80 t = 10 bytes.
-    let mut t = sh(concat!(
-        r"stty -icanon -echo; printf '\033[18t'; ",
-        r#"reply=$(head -c 10 | tr '\033' 'E'); "#,
-        r#"printf 'unblocked:%s' "$reply"; read guard"#
-    ))?;
+    let mut t = probe(&[
+        "--raw-mode",
+        "--csi",
+        "18t",
+        "unblocked:",
+        "--read",
+        "10",
+        "--wait",
+    ])?;
     t.wait_until(|s| s.contains("unblocked:E[8;24;80t"))?;
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
@@ -222,17 +232,25 @@ fn wait_frame_timeouts_carry_the_query_note() {
 /// `wait_frame` works against a program nobody modified for us.
 #[test]
 fn an_app_that_probes_for_synchronized_output_gets_it() -> termlens::Result<()> {
-    let mut t = sh(concat!(
-        // Ask "is mode 2026 supported?" and read the DECRPM reply.
-        r"stty -icanon -echo; printf '\033[?2026$p'; ",
-        r#"reply=$(head -c 10 | tr '\033' 'E'); "#,
-        // A terminal that does not recognize the mode answers `;0$y`.
-        r#"case "$reply" in *';0$y') printf 'unsupported'; read guard; exit 0 ;; esac; "#,
-        // Recognized: bracket the repaint, exactly as a real app would.
-        r"printf '\033[?2026h\033[HPROBED FRAME\033[?2026l'; read guard"
-    ))?;
+    let mut t = probe(&[
+        // Ask "is mode 2026 supported?" and put the DECRPM reply on row 1,
+        // where the frame's `CSI H` will not paint over it.
+        "--raw-mode",
+        "--csi",
+        "?2026$p",
+        "\nreply:",
+        "--read",
+        "11",
+        // Then bracket the repaint, exactly as a real app would.
+        "--raw",
+        r"\e[?2026h\e[HPROBED FRAME\e[?2026l",
+        "--wait",
+    ])?;
 
-    t.wait_frame(|s| s.contains("PROBED FRAME"))?;
+    // A terminal that does not recognize the mode answers `;0$y`; the
+    // frame is asserted together with the reply that licensed it, so a
+    // regression to "unrecognized" fails here rather than passing quietly.
+    t.wait_frame(|s| s.contains("PROBED FRAME") && s.contains("reply:E[?2026;2$y"))?;
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
@@ -242,17 +260,23 @@ fn an_app_that_probes_for_synchronized_output_gets_it() -> termlens::Result<()> 
 /// track exactly is reported as "not recognized" rather than guessed.
 #[test]
 fn mode_reports_are_truthful() -> termlens::Result<()> {
-    let mut t = sh(concat!(
-        r"stty -icanon -echo; printf '\033[?2004h'; ",
+    let mut t = probe(&[
+        "--raw-mode",
+        "--csi",
+        "?2004h",
         // 2004 was just set -> `;1$y`; 1 (DECCKM) is untouched -> `;2$y`;
         // 12 (cursor blink) is not tracked at all -> `;0$y`.
-        r"printf '\033[?2004$p\033[?1$p\033[?12$p'; ",
+        "--raw",
+        r"\e[?2004$p\e[?1$p\e[?12$p",
         // The three replies are 11 + 8 + 9 = 28 bytes:
         // ESC[?2004;1$y  ESC[?1;2$y  ESC[?12;0$y
-        r#"reply=$(head -c 28 | tr '\033' 'E'); "#,
-        r#"printf 'got:%s' "$reply"; read guard"#
-    ))?;
-    t.wait_until(|s| s.contains("got:"))?;
+        "got:",
+        "--read",
+        "28",
+        " DONE",
+        "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("DONE"))?;
     let row = t.screen().row_text(0);
     assert!(row.contains("E[?2004;1$y"), "2004 should be set: {row}");
     assert!(row.contains("E[?1;2$y"), "DECCKM should be reset: {row}");
@@ -285,13 +309,19 @@ fn decrqss_and_palette_queries_are_named() {
 #[test]
 fn replies_are_not_echoed_into_the_screen() -> termlens::Result<()> {
     // The reply travels the input path; unless the app prints it, it must
-    // never appear in the grid. `stty -echo` keeps the line discipline
-    // from echoing what the "terminal" typed back.
-    let mut t = sh(concat!(
-        r"stty -icanon -echo; printf 'before\033[5n'; ",
-        r"head -c 4 >/dev/null; ",
-        r"printf ' after'; read guard"
-    ))?;
+    // never appear in the grid. Raw mode keeps the line discipline from
+    // echoing what the "terminal" typed back, and `--skip` reads the reply
+    // without printing it.
+    let mut t = probe(&[
+        "--raw-mode",
+        "before",
+        "--csi",
+        "5n",
+        "--skip",
+        "4",
+        " after",
+        "--wait",
+    ])?;
     t.wait_until(|s| s.contains("before after"))?;
     assert!(
         !t.screen().text().contains("[0n"),
@@ -310,17 +340,25 @@ fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
     // sends `CSI ?1000h` — and `click` then refuses, blaming the
     // application for a decision termlens caused.
     //
-    // The script is written to *prove* the decision: if the reply says the
-    // mode is unrecognized it prints REFUSED and never enables tracking,
-    // so a regression fails on the wait below rather than passing quietly.
-    let mut t = sh(concat!(
-        r"stty -icanon -echo; ",
-        r#"printf '\033[?1000$p'; "#,
-        r#"reply=$(head -c 11 | tr '\033' 'E'); "#,
-        r#"case "$reply" in *';0$y') printf 'REFUSED:%s' "$reply"; read g; exit 0;; esac; "#,
-        r#"printf '\033[?1000h\033[?1006h'; printf 'MOUSE-ON:%s|' "$reply"; "#,
-        r#"click=$(head -c 20 | tr '\033' 'E'); printf 'CLICK:%s' "$click"; read g"#
-    ))?;
+    // The program prints the reply it got before it enables tracking, and
+    // the wait below asserts the reply *and* the marker together: a
+    // regression to "unrecognized" shows up as `;0$y` on the grid and the
+    // wait fails, rather than passing quietly.
+    let mut t = probe(&[
+        "--raw-mode",
+        "--csi",
+        "?1000$p",
+        "MOUSE-ON:",
+        "--read",
+        "11",
+        "|",
+        "--raw",
+        r"\e[?1000h\e[?1006h",
+        "CLICK:",
+        "--read",
+        "20",
+        "--wait",
+    ])?;
     // `;2$y` = implemented and currently reset. The application proceeds.
     t.wait_until(|s| s.contains("MOUSE-ON:E[?1000;2$y|"))?;
 
@@ -341,43 +379,46 @@ fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
 fn decrqm_answers_each_mouse_tracking_mode_on_its_own() -> termlens::Result<()> {
     // Reply values: 1 = set, 2 = reset, 0 = not recognized. The reply is
     // `ESC [ ? <mode> ; <value> $ y`, so its length follows the mode's.
-    for (script, reply_len, expect, label) in [
+    for (sequence, reply_len, expect, label) in [
         (
-            r"printf '\033[?1000h\033[?1002h\033[?1003h\033[?1002$p'",
-            11,
+            r"\e[?1000h\e[?1002h\e[?1003h\e[?1002$p",
+            "11",
             "[?1002;1$y",
             "a member other than the last enabled is set",
         ),
         (
-            r"printf '\033[?1000h\033[?1002h\033[?1003h\033[?9$p'",
-            8,
+            r"\e[?1000h\e[?1002h\e[?1003h\e[?9$p",
+            "8",
             "[?9;2$y",
             "a member never asked for is reset, not unrecognized",
         ),
         (
-            r"printf '\033[?1000h\033[?1002h\033[?1003h\033[?1003l\033[?1003$p'",
-            11,
+            r"\e[?1000h\e[?1002h\e[?1003h\e[?1003l\e[?1003$p",
+            "11",
             "[?1003;2$y",
             "a released member is reset while the others stay",
         ),
         (
-            r"printf '\033[?1000h\033[?1002h\033[?1003h\033[?1003l\033[?1002$p'",
-            11,
+            r"\e[?1000h\e[?1002h\e[?1003h\e[?1003l\e[?1002$p",
+            "11",
             "[?1002;1$y",
             "and the others do stay set",
         ),
     ] {
-        let mut t = Terminal::builder()
-            .size(80, 6)
-            .timeout(Duration::from_secs(10))
-            .args([
-                "-c",
-                &format!(
-                    "stty -icanon -echo; {script}; \
-                     head -c {reply_len} | tr -d '\\033'; printf ' DONE'; read guard"
-                ),
-            ])
-            .spawn("/bin/sh")?;
+        let mut t = common::spawn_emit(
+            Terminal::builder()
+                .size(80, 6)
+                .timeout(Duration::from_secs(10)),
+            &[
+                "--raw-mode",
+                "--raw",
+                sequence,
+                "--read",
+                reply_len,
+                " DONE",
+                "--wait",
+            ],
+        )?;
         t.wait_until(|s| s.contains("DONE"))?;
         let row = t.screen().row_text(0);
         assert!(row.contains(expect), "{label}: got {row:?}");
@@ -393,34 +434,29 @@ fn decrqm_answers_each_mouse_tracking_mode_on_its_own() -> termlens::Result<()> 
 #[test]
 fn decrqm_answers_for_focus_reporting() -> termlens::Result<()> {
     // Reply values: 1 = set, 2 = reset, 0 = not recognized.
-    for (script, expect, label) in [
+    for (sequence, expect, label) in [
+        (r"\e[?1004$p", ";2$y", "reset before the app enables it"),
+        (r"\e[?1004h\e[?1004$p", ";1$y", "set after enabling"),
         (
-            r"printf '\033[?1004$p'",
-            ";2$y",
-            "reset before the app enables it",
-        ),
-        (
-            r"printf '\033[?1004h\033[?1004$p'",
-            ";1$y",
-            "set after enabling",
-        ),
-        (
-            r"printf '\033[?1004h\033[?1004l\033[?1004$p'",
+            r"\e[?1004h\e[?1004l\e[?1004$p",
             ";2$y",
             "reset again after disabling",
         ),
     ] {
-        let mut t = Terminal::builder()
-            .size(80, 6)
-            .timeout(Duration::from_secs(10))
-            .args([
-                "-c",
-                &format!(
-                    "stty -icanon -echo; {script}; \
-                     head -c 11 | tr -d '\\033'; printf ' DONE'; read guard"
-                ),
-            ])
-            .spawn("/bin/sh")?;
+        let mut t = common::spawn_emit(
+            Terminal::builder()
+                .size(80, 6)
+                .timeout(Duration::from_secs(10)),
+            &[
+                "--raw-mode",
+                "--raw",
+                sequence,
+                "--read",
+                "11",
+                " DONE",
+                "--wait",
+            ],
+        )?;
         t.wait_until(|s| s.contains("DONE"))?;
         let row = t.screen().row_text(0);
         assert!(row.contains(expect), "{label}: got {row:?}");
@@ -451,28 +487,34 @@ fn cell_size_answers_the_pixel_reports_and_the_ioctl() -> termlens::Result<()> {
     assert!(err.to_string().contains("^[[16t"), "named: {err}");
     mute.send(Key::Enter)?;
 
-    // Declared: both reports answer from it.
-    let mut t = Terminal::builder()
-        .size(80, 24)
-        .cell_size(10, 20)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                // `min 0 time 20` so a read returns on a 2s timer instead of
-                // blocking on a byte count guessed wrong.
-                r"stty -icanon -echo min 0 time 20; ",
-                r"printf '\033[16t'; a=$(dd bs=1 count=32 2>/dev/null | tr -d '\033'); ",
-                r"printf '\033[14t'; b=$(dd bs=1 count=32 2>/dev/null | tr -d '\033'); ",
-                r#"printf 'cell[%s] win[%s] DONE' "$a" "$b"; read g"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    // Declared: both reports answer from it. `--read-quiet` returns on a
+    // 2s timer instead of blocking on a byte count guessed wrong.
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .size(80, 24)
+            .cell_size(10, 20)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--csi",
+            "16t",
+            "cell[",
+            "--read-quiet",
+            "32",
+            "] win[",
+            "--csi",
+            "14t",
+            "--read-quiet",
+            "32",
+            "] DONE",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("DONE"))?;
     let row = t.screen().row_text(0);
     // CSI 6 ; height ; width t   and   CSI 4 ; rows*h ; cols*w t
-    assert!(row.contains("cell[[6;20;10t]"), "{row:?}");
-    assert!(row.contains("win[[4;480;800t]"), "{row:?}");
+    assert!(row.contains("cell[E[6;20;10t]"), "{row:?}");
+    assert!(row.contains("win[E[4;480;800t]"), "{row:?}");
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
@@ -483,15 +525,21 @@ fn cell_size_answers_the_pixel_reports_and_the_ioctl() -> termlens::Result<()> {
 /// question depending on how it asks.
 #[test]
 fn tiocgwinsz_agrees_with_the_declared_cell_size() -> termlens::Result<()> {
-    let read_winsize = r#"python3 -c 'import fcntl,struct,sys,termios; b=fcntl.ioctl(0,termios.TIOCGWINSZ,b"\0"*8); r,c,xp,yp=struct.unpack("HHHH",b); print(f"{c}x{r} px {xp}x{yp}", flush=True)'"#;
-    let script = format!("{read_winsize}; read a; {read_winsize}; printf DONE; read b");
-
-    let mut t = Terminal::builder()
-        .size(80, 24)
-        .cell_size(10, 20)
-        .timeout(Duration::from_secs(20))
-        .args(["-c", &script])
-        .spawn("/bin/sh")?;
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .size(80, 24)
+            .cell_size(10, 20)
+            .timeout(Duration::from_secs(20)),
+        &[
+            "--winsize",
+            "NL",
+            "--wait",
+            "--winsize",
+            "NL",
+            "DONE",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("px"))?;
     assert!(
         t.screen().contains("80x24 px 800x480"),
@@ -519,14 +567,12 @@ fn tiocgwinsz_agrees_with_the_declared_cell_size() -> termlens::Result<()> {
 #[test]
 fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
     // Default: DA1 has no `4`, and the kitty probe goes unanswered.
-    let mut plain = Terminal::builder()
-        .size(80, 6)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            r"stty -icanon -echo; printf '\033[c'; head -c 9 | tr -d '\033'; printf ' DONE'; read g",
-        ])
-        .spawn("/bin/sh")?;
+    let mut plain = common::spawn_emit(
+        Terminal::builder()
+            .size(80, 6)
+            .timeout(Duration::from_secs(10)),
+        &["--raw-mode", "--csi", "c", "--read", "9", " DONE", "--wait"],
+    )?;
     plain.wait_until(|s| s.contains("DONE"))?;
     let row = plain.screen().row_text(0);
     assert!(
@@ -537,15 +583,21 @@ fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
     plain.send(Key::Enter)?;
 
     // Sixel declared: DA1 gains `4`, so a probing application sees it.
-    let mut sixel = Terminal::builder()
-        .size(80, 6)
-        .graphics(termlens::Graphics::Sixel)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            r"stty -icanon -echo; printf '\033[c'; head -c 11 | tr -d '\033'; printf ' DONE'; read g",
-        ])
-        .spawn("/bin/sh")?;
+    let mut sixel = common::spawn_emit(
+        Terminal::builder()
+            .size(80, 6)
+            .graphics(termlens::Graphics::Sixel)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--csi",
+            "c",
+            "--read",
+            "11",
+            " DONE",
+            "--wait",
+        ],
+    )?;
     sixel.wait_until(|s| s.contains("DONE"))?;
     assert!(
         sixel.screen().row_text(0).contains("[?62;4;22c"),
@@ -555,15 +607,21 @@ fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
     sixel.send(Key::Enter)?;
 
     // Kitty declared: the a=q probe is answered OK, echoing the id.
-    let mut kitty = Terminal::builder()
-        .size(80, 6)
-        .graphics(termlens::Graphics::Kitty)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            r"stty -icanon -echo; printf '\033_Gi=7,a=q;\033\\'; head -c 9 | tr -d '\033'; printf ' DONE'; read g",
-        ])
-        .spawn("/bin/sh")?;
+    let mut kitty = common::spawn_emit(
+        Terminal::builder()
+            .size(80, 6)
+            .graphics(termlens::Graphics::Kitty)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\e_Gi=7,a=q;\e\\",
+            "--read",
+            "9",
+            " DONE",
+            "--wait",
+        ],
+    )?;
     kitty.wait_until(|s| s.contains("DONE"))?;
     assert!(
         kitty.screen().row_text(0).contains("_Gi=7;OK"),
@@ -580,19 +638,21 @@ fn declared_graphics_support_reaches_the_probe() -> termlens::Result<()> {
 #[test]
 fn xtgettcap_answers_what_it_knows_and_declines_the_rest() -> termlens::Result<()> {
     // TN=544e, colors=636f6c6f7273, and a made-up name that must be refused.
-    let mut t = Terminal::builder()
-        .size(120, 6)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo min 0 time 20; ",
-                r"printf '\033P+q544e;636f6c6f7273;7a7a7a7a\033\\'; ",
-                r"dd bs=1 count=200 2>/dev/null | tr -d '\033' | tr -s '\\' '|'; ",
-                r"printf ' DONE'; read g"
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    // Wide enough that the three replies stay on one row.
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .size(200, 6)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\eP+q544e;636f6c6f7273;7a7a7a7a\e\\",
+            "--read-quiet",
+            "200",
+            " DONE",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("DONE"))?;
     let text = t.screen().text();
 
@@ -621,20 +681,24 @@ fn xtgettcap_answers_what_it_knows_and_declines_the_rest() -> termlens::Result<(
 /// application cannot get two different answers to "which terminal is this?".
 #[test]
 fn xtgettcap_tn_follows_the_configured_term() -> termlens::Result<()> {
-    let mut t = Terminal::builder()
-        .size(120, 6)
-        .env("TERM", "xterm")
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo min 0 time 20; ",
-                r"printf '\033P+q544e\033\\'; ",
-                r"dd bs=1 count=80 2>/dev/null | tr -d '\033' | tr -s '\\' '|'; ",
-                r#"printf ' term=%s DONE' "$TERM"; read g"#
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .size(120, 6)
+            .env("TERM", "xterm")
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\eP+q544e\e\\",
+            "--read-quiet",
+            "80",
+            " term=",
+            "--env",
+            "TERM",
+            " DONE",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("DONE"))?;
     let text = t.screen().text();
     // "xterm" is hex 787465726d
@@ -651,19 +715,20 @@ fn xtgettcap_tn_follows_the_configured_term() -> termlens::Result<()> {
 #[test]
 fn xtgettcap_key_capabilities_match_what_send_emits() -> termlens::Result<()> {
     // kcuu1 = 6b63757531; the value must be ESC [ A = 1b5b41.
-    let mut t = Terminal::builder()
-        .size(120, 6)
-        .timeout(Duration::from_secs(10))
-        .args([
-            "-c",
-            concat!(
-                r"stty -icanon -echo min 0 time 20; ",
-                r"printf '\033P+q6b63757531\033\\'; ",
-                r"dd bs=1 count=80 2>/dev/null | tr -d '\033' | tr -s '\\' '|'; ",
-                r"printf ' DONE'; read g"
-            ),
-        ])
-        .spawn("/bin/sh")?;
+    let mut t = common::spawn_emit(
+        Terminal::builder()
+            .size(120, 6)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw-mode",
+            "--raw",
+            r"\eP+q6b63757531\e\\",
+            "--read-quiet",
+            "80",
+            " DONE",
+            "--wait",
+        ],
+    )?;
     t.wait_until(|s| s.contains("DONE"))?;
     let text = t.screen().text();
     assert!(text.contains("P1+r6b63757531=1b5b41"), "{text}");

--- a/crates/termlens/tests/state.rs
+++ b/crates/termlens/tests/state.rs
@@ -16,6 +16,10 @@ fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
 /// One program walks the whole state surface: set everything, assert, then
 /// unwind everything and assert the way back.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward the mode sets an application sends, so mouse and focus modes are never observed (#149)"
+)]
 fn screen_reports_title_alternate_screen_and_input_modes() -> termlens::Result<()> {
     let mut t = emit(&[
         "--raw",
@@ -111,6 +115,10 @@ fn screen_reports_the_cursor_shape_the_application_asked_for() -> termlens::Resu
 /// apart, so a test for "it linked the docs" passed against the one that
 /// emitted nothing.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY forwards an OSC 8 link with an id of its own choosing (#149)"
+)]
 fn an_osc8_hyperlink_is_observable_and_a_missing_one_is_not() -> termlens::Result<()> {
     fn run(steps: &[&str]) -> termlens::Result<Screen> {
         let mut t = emit(steps)?;
@@ -206,6 +214,7 @@ fn a_snapshot_keeps_its_own_view_of_the_links() -> termlens::Result<()> {
 /// keypad are not replayed — nothing observes them, so nothing could catch
 /// a wrong replay — and the alternate screen is left alone, as specified.
 #[test]
+#[cfg_attr(windows, ignore = "ConPTY does not forward DECSTR (#149)")]
 fn a_soft_reset_returns_the_modes_a_screen_can_observe() -> termlens::Result<()> {
     let mut t = emit(&[
         "--raw",
@@ -250,6 +259,10 @@ fn a_soft_reset_returns_the_modes_a_screen_can_observe() -> termlens::Result<()>
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward the mode sets an application sends, so mouse and focus modes are never observed (#149)"
+)]
 fn mouse_mode_reports_the_exact_tracking_mode() -> termlens::Result<()> {
     let mut t = emit(&[
         "--raw",
@@ -280,6 +293,10 @@ fn mouse_mode_reports_the_exact_tracking_mode() -> termlens::Result<()> {
 /// entirely — was indistinguishable from one that never had it (#151). The
 /// input path keeps the collapsed value; the set is reported beside it.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward the mode sets an application sends, so mouse and focus modes are never observed (#149)"
+)]
 fn mouse_modes_reports_the_set_the_application_asked_for() -> termlens::Result<()> {
     let mut t = emit(&[
         "--raw",

--- a/crates/termlens/tests/tabs.rs
+++ b/crates/termlens/tests/tabs.rs
@@ -167,6 +167,7 @@ fn a_hard_reset_restores_the_default_stops() -> termlens::Result<()> {
 /// `DECSTR` restores them too — the soft reset a well-behaved TUI sends on
 /// startup and teardown, which leaves the screen alone.
 #[test]
+#[cfg_attr(windows, ignore = "ConPTY does not forward DECSTR (#149)")]
 fn a_soft_reset_restores_the_default_stops() -> termlens::Result<()> {
     let mut t = emit(&[
         "--csi", "3g", "--csi", "4G", "--esc", "H", "--csi", "!p", "--csi", "1G", "\tx", " DONE",

--- a/crates/termlens/tests/timeouts.rs
+++ b/crates/termlens/tests/timeouts.rs
@@ -22,6 +22,10 @@ fn slow_app(steps: &[&str]) -> Terminal {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so no frame holds what was drawn (#149)"
+)]
 fn wait_frame_for_overrides_the_builder_default() -> termlens::Result<()> {
     let mut t = slow_app(&[
         "--sleep",

--- a/crates/termlens/tests/utf8.rs
+++ b/crates/termlens/tests/utf8.rs
@@ -14,6 +14,10 @@ fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "Rust's console stdio refuses to write bytes that are not UTF-8, so the fixture cannot send them on Windows (#149)"
+)]
 fn an_invalid_byte_is_a_replacement_character_and_the_columns_hold() -> termlens::Result<()> {
     // A Latin-1 `é` in a file name, a corrupted log line: the byte used to
     // be deleted from the grid, so `done` sat one column too far left and
@@ -52,6 +56,10 @@ fn a_character_split_across_two_writes_is_still_one_character() -> termlens::Res
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "Rust's console stdio refuses to write bytes that are not UTF-8, so the fixture cannot send them on Windows (#149)"
+)]
 fn wait_idle_does_not_call_a_half_written_character_silence() -> termlens::Result<()> {
     // The application stops for 600ms in the middle of a character. That is
     // not idleness — the stream ends mid-character — so `wait_idle` must

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -199,6 +199,40 @@ the terminal (`^[[14t`) and received no answer" — a hang becomes a
 diagnosis. `answer_queries(false)` mutes the responder for tests that
 need a silent terminal; the diagnosis still works.
 
+### Windows: ConPTY renders, and that decides what is claimed
+
+`portable-pty` gives the same four layers a ConPTY backend, and the crate
+builds and runs its suite on `windows-latest`. But ConPTY is a terminal
+emulator of its own standing between the child and layer 1: it renders the
+child's bytes into a screen and re-emits *its* rendering, and `portable-pty`
+creates it without `PSEUDOCONSOLE_PASSTHROUGH_MODE`. Measured with
+`tests/conpty_probe.rs` (twenty-one sequences in, six out verbatim):
+
+- **Eaten:** DA1, OSC 10/11, XTGETTCAP, DECRQM, mouse and focus mode sets,
+  kitty and sixel payloads, HTS/TBC. The responder never sees the question,
+  so the answers it is configured to give — `Graphics`, `background_rgb`,
+  `cell_size` — cannot reach the child.
+- **Reordered:** a DEC 2026 update arrives as `?2026h ?2026l` *then* the
+  content. A frame is the bracket, so `wait_frame` sees frames that never
+  contain what was drawn. Screen assertions yes, frame assertions no.
+- **Rewritten but equivalent:** SGR split and reordered, OSC 2 as OSC 0, DEC
+  Special Graphics already translated to UTF-8, a tab as `CUF`, an OSC 8
+  link with an id ConPTY chose.
+- **A preamble every child gets:** `CSI 6 n`, `?9001h`, `?1004h`, a title of
+  the executable path, `?25h`. Two of those bind the harness: the console
+  does **not start the child until the `6n` is answered** — the responder
+  answers it as it would any query, which is why the harness runs there at
+  all — and `?1004h` means `focus_events()` is true from the first byte.
+- **Child exit is not EOF.** The output pipe stays open until the console is
+  closed, whoever has exited. Every liveness decision reads EOF off the
+  master on Unix, so on Windows the reaped child plus the drain grace is the
+  signal instead (`EXIT_CLOSES_THE_TERMINAL`, `ExitWatch`).
+
+Each test a row above makes impossible is `#[cfg_attr(windows, ignore)]`
+with that row as its reason; the README carries the user-facing list. The
+`windows` workflow re-runs the probe and the whole suite on demand, and the
+`windows-check` gate keeps the build compiling from a Linux runner.
+
 ## 2. Wait semantics
 
 Every wait runs under the terminal's **default deadline** (builder

--- a/fixtures/emit/Cargo.toml
+++ b/fixtures/emit/Cargo.toml
@@ -9,8 +9,11 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
-# No dependencies, on purpose: see the crate-level doc.
+# Nothing but libc, and only on Unix: see the crate-level doc.
 [dependencies]
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/fixtures/emit/src/main.rs
+++ b/fixtures/emit/src/main.rs
@@ -1,6 +1,6 @@
 //! termlens fixture: writes exactly the bytes its arguments describe, in
-//! order, then waits, sleeps or exits as told — the program under test
-//! wherever the suite used to run `sh -c 'printf …; read _'` (#249).
+//! order, then waits, sleeps, reads or exits as told — the program under
+//! test wherever the suite used to run `sh -c 'printf …; read _'` (#249).
 //!
 //! A shell was a variable in every test that was not about the shell: which
 //! `sh` runs decides how `printf` reads `\033`, what `read` does at EOF, how
@@ -18,6 +18,7 @@
 //! --sleep DUR      pause for DUR: `250ms`, `1.5s`, `2s`
 //! --wait           read one line from stdin and discard it — "hold the
 //!                  terminal open until the test sends Enter"
+//! --wait-for WORD  read lines until one is exactly WORD
 //! --echo-line      read one line from stdin and write it back, without
 //!                  its newline
 //! --echo           copy stdin to stdout, line by line, until EOF
@@ -32,14 +33,39 @@
 //!                  forever
 //! ```
 //!
+//! And the steps that read what the terminal *typed back* — a query's reply,
+//! a mouse report, a paste — which need the line discipline out of the way:
+//!
+//! ```text
+//! --raw-mode       ICANON and ECHO off: bytes arrive as sent, unechoed
+//!                  (what `stty -icanon -echo` did); ICRNL is left on, so
+//!                  --wait still ends at Enter
+//! --no-icrnl       ICRNL off too, so a CR arrives as CR (what raw mode
+//!                  does in an application) — --wait then needs a LF
+//! --read N         read exactly N bytes and write them, ESC as `E` and
+//!                  BEL as `G` so a reply is legible on the grid
+//! --skip N         read exactly N bytes and write nothing
+//! --read-hex N     read exactly N bytes and write them as lowercase hex
+//! --read-quiet N   read up to N bytes, stopping after 2s without one,
+//!                  and write them as --read does
+//! --read-count N C read exactly N bytes and write how many were C
+//! --winsize        the tty's size as the kernel reports it:
+//!                  `COLSxROWS px WIDTHxHEIGHT`
+//! --kill-self      raise SIGTERM against this process
+//! --on-term TEXT CODE  on SIGTERM, write TEXT and exit CODE …
+//! --idle           … and sit here until that happens
+//! ```
+//!
 //! Every emitting step is one `write_all` and a flush, so a test that wants
 //! two writes says so with two steps. `--wait` at EOF exits 0: a harness that
 //! closed the terminal has finished with it.
 //!
-//! Fixture rules: **no timing but the explicit `--sleep`, and std only.** A
-//! dependency would make this a second thing the suite tests; a clock would
-//! make it a second source of flakiness. Nothing here reads the terminal's
-//! modes or sets them — a step that needs raw mode is a different fixture.
+//! Fixture rules: **no timing but the explicit `--sleep` and the 2s of
+//! `--read-quiet`; std, plus `libc` on Unix for the terminal-mode, ioctl and
+//! signal steps and nothing else.** A dependency with behaviour of its own
+//! would make this a second thing the suite tests; a clock would make it a
+//! second source of flakiness. Off Unix the terminal-mode steps are accepted
+//! and do nothing — the tests that need them are Unix-only for other reasons.
 
 use std::io::{self, BufRead, Write};
 use std::process;
@@ -50,6 +76,7 @@ enum Step {
     Write(Vec<u8>),
     Sleep(Duration),
     Wait,
+    WaitFor(String),
     EchoLine,
     Echo,
     Seq(u64),
@@ -58,6 +85,17 @@ enum Step {
     Env(String),
     Environ,
     Exit(i32),
+    RawMode,
+    NoIcrnl,
+    Read(usize),
+    Skip(usize),
+    ReadHex(usize),
+    ReadQuiet(usize),
+    ReadCount(usize, u8),
+    Winsize,
+    KillSelf,
+    OnTerm(Vec<u8>, i32),
+    Idle,
 }
 
 fn usage(reason: &str) -> ! {
@@ -114,6 +152,12 @@ fn duration(spec: &str) -> Duration {
     }
 }
 
+fn count(flag: &str, value: &str) -> usize {
+    value
+        .parse()
+        .unwrap_or_else(|_| usage(&format!("{flag} needs a byte count")))
+}
+
 /// The steps, and the index the forever-loop starts at, if there is one.
 fn parse(args: impl Iterator<Item = String>) -> (Vec<Step>, Option<usize>) {
     let mut steps = Vec::new();
@@ -141,6 +185,7 @@ fn parse(args: impl Iterator<Item = String>) -> (Vec<Step>, Option<usize>) {
             "--raw" => Step::Write(raw(&next("--raw"))),
             "--sleep" => Step::Sleep(duration(&next("--sleep"))),
             "--wait" => Step::Wait,
+            "--wait-for" => Step::WaitFor(next("--wait-for")),
             "--echo-line" => Step::EchoLine,
             "--echo" => Step::Echo,
             "--seq" => Step::Seq(
@@ -161,6 +206,30 @@ fn parse(args: impl Iterator<Item = String>) -> (Vec<Step>, Option<usize>) {
                 loop_from = Some(steps.len());
                 continue;
             }
+            "--raw-mode" => Step::RawMode,
+            "--no-icrnl" => Step::NoIcrnl,
+            "--read" => Step::Read(count("--read", &next("--read"))),
+            "--skip" => Step::Skip(count("--skip", &next("--skip"))),
+            "--read-hex" => Step::ReadHex(count("--read-hex", &next("--read-hex"))),
+            "--read-quiet" => Step::ReadQuiet(count("--read-quiet", &next("--read-quiet"))),
+            "--read-count" => {
+                let n = count("--read-count", &next("--read-count"));
+                let which = next("--read-count");
+                match which.as_bytes() {
+                    [b] => Step::ReadCount(n, *b),
+                    _ => usage("--read-count needs one byte to count"),
+                }
+            }
+            "--winsize" => Step::Winsize,
+            "--kill-self" => Step::KillSelf,
+            "--on-term" => {
+                let text = next("--on-term").into_bytes();
+                let code = next("--on-term")
+                    .parse()
+                    .unwrap_or_else(|_| usage("--on-term needs an exit code"));
+                Step::OnTerm(text, code)
+            }
+            "--idle" => Step::Idle,
             other if other.starts_with("--") => usage(&format!("unknown step `{other}`")),
             text => Step::Write(text.as_bytes().to_vec()),
         };
@@ -181,7 +250,40 @@ fn line(stdin: &mut impl BufRead) -> io::Result<Option<String>> {
     Ok(Some(s))
 }
 
-fn run(steps: &[Step], out: &mut impl Write, stdin: &mut impl BufRead) -> io::Result<()> {
+/// A reply as a grid can show it: ESC as `E`, BEL as `G`, the rest itself.
+fn legible(bytes: &[u8]) -> Vec<u8> {
+    bytes
+        .iter()
+        .map(|&b| match b {
+            0x1b => b'E',
+            0x07 => b'G',
+            other => other,
+        })
+        .collect()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn read_exact(stdin: &mut impl BufRead, n: usize) -> io::Result<Vec<u8>> {
+    let mut buf = vec![0u8; n];
+    stdin.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+/// What the `--on-term` handler is to do, once a SIGTERM has arrived.
+struct OnTerm {
+    text: Vec<u8>,
+    code: i32,
+}
+
+fn run(
+    steps: &[Step],
+    out: &mut impl Write,
+    stdin: &mut impl BufRead,
+    on_term: &mut Option<OnTerm>,
+) -> io::Result<()> {
     for step in steps {
         match step {
             Step::Write(bytes) => out.write_all(bytes)?,
@@ -191,6 +293,13 @@ fn run(steps: &[Step], out: &mut impl Write, stdin: &mut impl BufRead) -> io::Re
                     process::exit(0);
                 }
             }
+            Step::WaitFor(word) => loop {
+                match line(stdin)? {
+                    Some(l) if l == *word => break,
+                    Some(_) => {}
+                    None => process::exit(0),
+                }
+            },
             Step::EchoLine => match line(stdin)? {
                 Some(l) => out.write_all(l.as_bytes())?,
                 None => process::exit(0),
@@ -230,6 +339,41 @@ fn run(steps: &[Step], out: &mut impl Write, stdin: &mut impl BufRead) -> io::Re
                 out.flush()?;
                 process::exit(*code);
             }
+            Step::RawMode => tty::raw_mode(false)?,
+            Step::NoIcrnl => tty::raw_mode(true)?,
+            Step::Read(n) => out.write_all(&legible(&read_exact(stdin, *n)?))?,
+            Step::Skip(n) => {
+                read_exact(stdin, *n)?;
+            }
+            Step::ReadHex(n) => out.write_all(hex(&read_exact(stdin, *n)?).as_bytes())?,
+            Step::ReadQuiet(n) => out.write_all(&legible(&tty::read_quiet(stdin, *n)?))?,
+            Step::ReadCount(n, which) => {
+                let got = read_exact(stdin, *n)?;
+                write!(out, "{}", got.iter().filter(|b| *b == which).count())?;
+            }
+            Step::Winsize => out.write_all(tty::winsize()?.as_bytes())?,
+            Step::KillSelf => {
+                out.flush()?;
+                tty::kill_self();
+            }
+            Step::OnTerm(text, code) => {
+                tty::trap_term();
+                *on_term = Some(OnTerm {
+                    text: text.clone(),
+                    code: *code,
+                });
+            }
+            Step::Idle => loop {
+                if tty::term_received() {
+                    if let Some(OnTerm { text, code }) = on_term.take() {
+                        out.write_all(&text)?;
+                        out.flush()?;
+                        process::exit(code);
+                    }
+                    process::exit(0);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            },
         }
         out.flush()?;
     }
@@ -242,15 +386,162 @@ fn main() {
     let mut out = stdout.lock();
     let stdin = io::stdin();
     let mut stdin = stdin.lock();
+    let mut on_term = None;
     // A write that fails is the terminal going away under us — the harness
     // has torn down. Nothing to report to, so nothing to report.
     let result = match loop_from {
-        Some(from) => run(&steps[..from], &mut out, &mut stdin).and_then(|()| loop {
-            run(&steps[from..], &mut out, &mut stdin)?;
+        Some(from) => run(&steps[..from], &mut out, &mut stdin, &mut on_term).and_then(|()| loop {
+            run(&steps[from..], &mut out, &mut stdin, &mut on_term)?;
         }),
-        None => run(&steps, &mut out, &mut stdin),
+        None => run(&steps, &mut out, &mut stdin, &mut on_term),
     };
     if result.is_err() {
         process::exit(0);
+    }
+}
+
+/// The terminal-mode, ioctl and signal steps: one `tcsetattr`, one `ioctl`,
+/// one `raise`, one `signal`. Everything the shell scripts reached for
+/// `stty`, `python3 -c 'fcntl.ioctl…'`, `kill -TERM $$` and `trap` to do.
+#[cfg(unix)]
+mod tty {
+    use std::io::{self, BufRead};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static TERM_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+    fn termios() -> io::Result<libc::termios> {
+        // SAFETY: a zeroed termios is a valid value for tcgetattr to fill.
+        #[allow(unsafe_code)]
+        let mut t: libc::termios = unsafe { std::mem::zeroed() };
+        // SAFETY: fd 0 and a live, writable termios.
+        #[allow(unsafe_code)]
+        if unsafe { libc::tcgetattr(0, &mut t) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(t)
+    }
+
+    fn apply(t: &libc::termios) -> io::Result<()> {
+        // SAFETY: fd 0 and a termios tcgetattr filled.
+        #[allow(unsafe_code)]
+        if unsafe { libc::tcsetattr(0, libc::TCSANOW, t) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// `stty -icanon -echo`, and `-icrnl` when asked.
+    pub(super) fn raw_mode(no_icrnl: bool) -> io::Result<()> {
+        let mut t = termios()?;
+        t.c_lflag &= !(libc::ICANON | libc::ECHO);
+        if no_icrnl {
+            t.c_iflag &= !libc::ICRNL;
+        }
+        t.c_cc[libc::VMIN] = 1;
+        t.c_cc[libc::VTIME] = 0;
+        apply(&t)
+    }
+
+    /// Up to `max` bytes, ending after two seconds without one — `stty min
+    /// 0 time 20` for the duration of the read, then back to blocking.
+    pub(super) fn read_quiet(stdin: &mut impl BufRead, max: usize) -> io::Result<Vec<u8>> {
+        let mut t = termios()?;
+        let before = t;
+        t.c_cc[libc::VMIN] = 0;
+        t.c_cc[libc::VTIME] = 20;
+        apply(&t)?;
+        let mut out = Vec::new();
+        let mut buf = [0u8; 256];
+        while out.len() < max {
+            let want = buf.len().min(max - out.len());
+            match stdin.read(&mut buf[..want]) {
+                Ok(0) => break,
+                Ok(n) => out.extend_from_slice(&buf[..n]),
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => {
+                    apply(&before)?;
+                    return Err(e);
+                }
+            }
+        }
+        apply(&before)?;
+        Ok(out)
+    }
+
+    /// `TIOCGWINSZ`, as `COLSxROWS px WIDTHxHEIGHT`.
+    pub(super) fn winsize() -> io::Result<String> {
+        // SAFETY: a zeroed winsize is a valid value for the ioctl to fill.
+        #[allow(unsafe_code)]
+        let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+        // SAFETY: fd 0, the request the struct is for, and a live struct.
+        #[allow(unsafe_code)]
+        if unsafe { libc::ioctl(0, libc::TIOCGWINSZ, &mut ws) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(format!(
+            "{}x{} px {}x{}",
+            ws.ws_col, ws.ws_row, ws.ws_xpixel, ws.ws_ypixel
+        ))
+    }
+
+    pub(super) fn kill_self() -> ! {
+        // SAFETY: raise(3) touches no memory.
+        #[allow(unsafe_code)]
+        unsafe {
+            libc::raise(libc::SIGTERM);
+        }
+        // With the default disposition the line above did not return.
+        std::process::exit(0)
+    }
+
+    extern "C" fn on_term(_: libc::c_int) {
+        TERM_RECEIVED.store(true, Ordering::SeqCst);
+    }
+
+    pub(super) fn trap_term() {
+        // SAFETY: the handler only stores to an atomic, which is
+        // async-signal-safe; the function pointer outlives the process.
+        #[allow(unsafe_code)]
+        unsafe {
+            libc::signal(libc::SIGTERM, on_term as *const () as libc::sighandler_t);
+        }
+    }
+
+    pub(super) fn term_received() -> bool {
+        TERM_RECEIVED.load(Ordering::SeqCst)
+    }
+}
+
+/// Off Unix there is no line discipline to switch off and no signal to
+/// trap; the steps are accepted so a program reads the same everywhere,
+/// and the tests that depend on them are Unix-only for other reasons.
+#[cfg(not(unix))]
+mod tty {
+    use std::io::{self, BufRead};
+
+    pub(super) fn raw_mode(_no_icrnl: bool) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(super) fn read_quiet(stdin: &mut impl BufRead, max: usize) -> io::Result<Vec<u8>> {
+        let mut out = vec![0u8; max];
+        let n = stdin.read(&mut out)?;
+        out.truncate(n);
+        Ok(out)
+    }
+
+    pub(super) fn winsize() -> io::Result<String> {
+        Ok("unsupported".to_owned())
+    }
+
+    pub(super) fn kill_self() -> ! {
+        std::process::exit(143)
+    }
+
+    pub(super) fn trap_term() {}
+
+    pub(super) fn term_received() -> bool {
+        false
     }
 }


### PR DESCRIPTION
Refs #149 — everything that remained of step 4, plus the last of #249 and #278.

## What lands

**The fixture takes the last 27 shell sites.** `emit` gains the steps the reply readers needed — `--raw-mode`/`--no-icrnl` (one `tcsetattr`), `--read`/`--skip`/`--read-hex`/`--read-quiet`/`--read-count`, `--winsize`, `--kill-self`, `--on-term … --idle` — via `libc`, Unix only, and its header rule is rewritten to say exactly that: *std, plus libc for the terminal-mode, ioctl and signal steps and nothing else.* `grep -c 'spawn("/bin/sh")\|spawn("sh")' crates/termlens/tests/*.rs` is **zero**. Off Unix the steps are accepted and do nothing; the tests that depend on them are Unix-only for other reasons (below).

**79 tests are `#[cfg_attr(windows, ignore = "…")]`**, each with the row of the probe table it fails on:

| reason | tests |
|---|---|
| ConPTY closes a DEC 2026 bracket before the content it wrapped | 26 (`frames.rs`, form-echo-driven `input.rs`, one each in `observe.rs`/`timeouts.rs`) |
| ConPTY answers or eats the child's queries itself | 20 (`queries.rs`, `drain.rs`, `backpressure.rs`) |
| ConPTY does not forward kitty or sixel payloads | 12 (`graphics.rs`, `observe.rs`) |
| the wire is read in raw mode, a `tcsetattr` | 6 (`input.rs`) |
| ConPTY does not forward mode sets / DECSTR / turns 1004 on for itself / chooses OSC 8 ids | 3 + 2 + 1 + 1 (`state.rs`, `tabs.rs`, `input.rs`) |
| ConPTY translates charset designations itself | 3 (`charset.rs`) |
| Rust's console stdio refuses non-UTF-8 | 3 (`utf8.rs`, `fixtures.rs`) |
| Windows has no signals / TIOCGWINSZ is a Unix ioctl | 1 + 1 |

Two tests were wrong rather than impossible: they typed a bare LF to end a line, and ConPTY's cooked input ends one at CR. They send `Enter` now and pass on Windows. The two `wait_frame` doctests are Unix-only like the `Signal` one.

**The leg**: `windows (non-required)` in `ci.yml`, `continue-on-error: true`, outside `required-green`. Promoting it is two edits, written next to it. `windows.yml` stays as the dispatchable version with the probe and the report.

**The sentence**: README's "Unix only for now" becomes *Windows: screen assertions yes, frame assertions no*, with the list of what ConPTY renders away. DESIGN §1 gets the mechanics — the preamble, the `6n` handshake the child waits on, exit ≠ EOF. CHANGELOG gets the user-facing entry.

**#278**: `inspect.rs` builds the example once per test process (`OnceLock`), the guard `fixture_bin` already had.

## Verification

Unix: full suite, three feature configurations, both clippy targets, MSRV, docs, deny, gates-listed, zizmor. Windows: `windows.yml` dispatched against this branch after the ignore pass — the expected outcome is **0 failed**; result in a comment below, along with the new `windows (non-required)` job's own run on this PR.