### PR TITLE
feat: insert mode, the unsupported-sequence record, and the soft-wrap flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- **`Screen::unsupported()`: the sequences the emulator did not implement,
+  so a plausible-looking wrong grid can be told from a right one.** The
+  backend reports every escape it cannot render and termlens installed the
+  no-op callbacks and threw the list away. It is kept now — distinct shapes,
+  first seen first, in the timeout messages' form (`^[[20h`), 32 kept and
+  the rest counted in `unsupported_overflow()` — filtered to what *termlens*
+  did not honour, since the character sets, tab stops, insert mode and every
+  query the responder answers still reach the backend's callbacks. A request
+  to resize the window is listed rather than obeyed; `visual_bells()` counts
+  `ESC g` separately from `bells()`, since a flash is not a beep. (#266)
+
+- **`Screen::row_wrapped()` and `Screen::logical_text()`.** A line long
+  enough to wrap is two rows, and a needle spanning the wrap was found by
+  nobody although a reader plainly saw it. The backend has always recorded
+  which rows soft-wrapped and was never asked; each snapshot now carries the
+  bit, and `logical_text()` joins wrapped rows back together so
+  `logical_text().contains("brown fox jumps")` is true. `contains` and `find`
+  are unchanged and document the trap beside the scrollback one. The two
+  sentences that said history could not be reflowed *for lack of the
+  record* now give the true reason, cost. (#265)
+
 - **Windows.** The crate builds and the whole suite runs on `windows-latest`
   in CI, over ConPTY. Screen assertions work; the features ConPTY renders
   away — `wait_frame`, graphics, the responder's outbound claims, mouse
@@ -52,6 +73,16 @@ listed under a **Changed** or **Removed** heading.
   `--inherit-env` restores the previous behavior. (#263)
 
 ### Fixed
+
+- **Insert mode (`CSI 4 h`) is honoured.** `smir`/`rmir` are in the
+  terminfo entry every child is handed, and ncurses uses the mode for
+  `insch`; it was parsed and dropped, so an inserted character ate the rest
+  of the line and a snapshot could bless the eaten tail. The flag lives in
+  the sequence tracker beside the character sets; while it is set the
+  emulator reserves room for each printable run with the `ICH` the backend
+  does dispatch — in columns, so a wide character counts twice, and never
+  past the right margin. `RIS` and `DECSTR` clear it, and
+  `Screen::insert_mode()` reports an application that left it on. (#261)
 
 - **Custom tab stops are honoured: `HTS`, `TBC`, `CHT` and `CBT` do what
   they say.** Stops were fixed at every eighth column — the backend's

--- a/README.md
+++ b/README.md
@@ -270,6 +270,18 @@ design. termlens's position:
   ROMs, the other national sets — is acknowledged and reads as ASCII.
   `DECSC`/`DECRC` save and restore this state with the cursor. Locking
   shifts remain G0/G1 only (`LS2`/`LS3` are not modelled).
+- **Insert mode (`IRM`, `CSI 4 h`) pushes the rest of the row right**, as
+  ncurses's `insch` expects on a terminal advertising `smir`; `RIS` and
+  `DECSTR` clear it, and `Screen::insert_mode()` reports an application
+  that left it on. Other ANSI modes the backend drops (`LNM` and the rest)
+  are not modelled — and *say so*: `Screen::unsupported()` lists every
+  sequence the emulator did not implement, in the form `^[[20h`, so a test
+  can tell a plausible-looking wrong grid from a right one.
+- **A soft-wrapped line is two rows.** `contains` and `find` read the grid
+  row by row and do not span the wrap; `Screen::row_wrapped(row)` reports
+  the backend's record of where a line wrapped, and
+  `Screen::logical_text()` joins wrapped rows back together for the
+  assertion that spans one.
 - **Tab stops are the application's to set.** `HTS` (`ESC H`), `TBC`
   (`CSI g`, `CSI 3 g`), `CHT` (`CSI I`) and `CBT` (`CSI Z`) all work, and a
   plain `\t` honours whatever stops are set rather than a fixed eight.

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -32,6 +32,10 @@ portable-pty.workspace = true
 vt100.workspace = true
 thiserror.workspace = true
 unicode-normalization.workspace = true
+# Insert mode reserves room for a printable run with `ICH`, sized in columns;
+# a wide character counts twice, and this is what says so (#261). Already in
+# the tree through vt100.
+unicode-width.workspace = true
 insta = { workspace = true, optional = true }
 miniz_oxide = { workspace = true, optional = true }
 
@@ -39,9 +43,6 @@ miniz_oxide = { workspace = true, optional = true }
 libc.workspace = true
 
 [dev-dependencies]
-# vt100 reports wide cells itself; unicode-width is only needed by our own
-# tests to construct wide-character fixtures.
-unicode-width.workspace = true
 insta.workspace = true
 anyhow.workspace = true
 

--- a/crates/termlens/src/emu/mod.rs
+++ b/crates/termlens/src/emu/mod.rs
@@ -9,6 +9,7 @@
 
 mod seq;
 mod shadow;
+mod unhandled;
 mod vt100;
 
 #[cfg(feature = "decode")]

--- a/crates/termlens/src/emu/seq.rs
+++ b/crates/termlens/src/emu/seq.rs
@@ -537,6 +537,9 @@ pub(crate) struct SeqTracker {
     /// anywhere in a multi-mode list, so scanning for it beats assuming it
     /// is the only parameter.
     csi_saw_1004: bool,
+    /// Whether a completed parameter of the current CSI was `4`: insert
+    /// mode, when the final byte turns out to be a plain `h` or `l`.
+    csi_saw_irm: bool,
     /// The mouse tracking modes (`9`, `1000`, `1002`, `1003`) named in the
     /// current CSI's parameter list, as [`mouse_bit`]s — the same scan as
     /// `csi_saw_1004`, for a group rather than one mode.
@@ -661,6 +664,8 @@ pub(crate) struct SeqTracker {
     /// Where the tab stops are. Sized to the grid, so `set_cols` follows
     /// every resize.
     tabs: TabStops,
+    /// `IRM` (`CSI 4 h`) is set — see [`insert_mode`](Self::insert_mode).
+    insert_mode: bool,
 }
 
 impl SeqTracker {
@@ -680,6 +685,7 @@ impl SeqTracker {
             csi_param_count: 0,
             csi_saw_2026: false,
             csi_saw_1004: false,
+            csi_saw_irm: false,
             csi_saw_mouse: 0,
             seq_buf: [0; 24],
             seq_len: 0,
@@ -716,6 +722,7 @@ impl SeqTracker {
             dcs_body: Vec::new(),
             dcs_body_full: true,
             tabs: TabStops::new(cols),
+            insert_mode: false,
         }
     }
 
@@ -919,7 +926,16 @@ impl SeqTracker {
         self.cursor_style = None;
         self.focus_events = false;
         self.mouse_tracking = 0;
+        self.insert_mode = false;
         self.tabs.reset();
+    }
+
+    /// Whether `IRM` (`CSI 4 h`) is set: a printable byte pushes the rest
+    /// of the row right instead of overwriting the cell under the cursor.
+    /// vt100 does not model the mode, so the emulator reserves the room
+    /// with an `ICH` it does dispatch (#261).
+    pub(crate) fn insert_mode(&self) -> bool {
+        self.insert_mode
     }
 
     /// Apply the final byte of an `ESC ( ) * + Ps` designation.
@@ -966,6 +982,7 @@ impl SeqTracker {
         self.csi_param_count = 0;
         self.csi_saw_2026 = false;
         self.csi_saw_1004 = false;
+        self.csi_saw_irm = false;
         self.csi_saw_mouse = 0;
     }
 
@@ -995,6 +1012,9 @@ impl SeqTracker {
         }
         if self.csi_param == 1004 {
             self.csi_saw_1004 = true;
+        }
+        if self.csi_param == 4 {
+            self.csi_saw_irm = true;
         }
         self.csi_saw_mouse |= mouse_bit(self.csi_param);
         if self.csi_param_count == 0 {
@@ -1140,6 +1160,19 @@ impl SeqTracker {
                     self.sync_update = false;
                     return SeqEvent::SyncEnd;
                 }
+                _ => {}
+            }
+        }
+
+        // Insert mode (`IRM`, ANSI mode 4): `smir`/`rmir` in the terminfo
+        // entry every child is handed, and the mode ncurses uses for
+        // `insch`. vt100 dispatches no ANSI mode at all, so the flag lives
+        // here and the emulator acts on it (#261). Any mode list naming 4
+        // counts, as it does for the private modes above.
+        if self.csi_prefix == 0 && self.csi_saw_irm {
+            match b {
+                b'h' => self.insert_mode = true,
+                b'l' => self.insert_mode = false,
                 _ => {}
             }
         }
@@ -1606,6 +1639,7 @@ impl SeqTracker {
                     self.reset_charsets();
                     self.saved_charsets = None;
                     self.mouse_tracking = 0;
+                    self.insert_mode = false;
                     self.tabs.reset();
                     self.close_link();
                     State::Ground

--- a/crates/termlens/src/emu/unhandled.rs
+++ b/crates/termlens/src/emu/unhandled.rs
@@ -1,0 +1,268 @@
+//! What the backend could not render, kept so a screen can say so.
+//!
+//! `vt100` calls a [`Callbacks`] method for every escape sequence outside
+//! its dispatch table, and termlens used to install the no-op set and throw
+//! the list away — so an application that asked for something the emulator
+//! does not implement got a plausible-looking wrong grid and nothing
+//! anywhere said why (#266). This is the collection half: distinct shapes,
+//! first seen first, bounded with an overflow count, rendered the way the
+//! unanswered-query record renders a sequence (`^[[20h`), and read back by
+//! every snapshot through [`Screen::unsupported`](crate::Screen::unsupported).
+//!
+//! Not everything vt100 declines is unsupported. The sequence tracker
+//! (`emu/seq.rs`) handles a set of them before or beside the backend — the
+//! character sets, tab stops, insert mode, DECSTR, DECSCUSR, the modes it
+//! tracks, every query the responder answers or names — and those still
+//! reach vt100's callbacks, because the bytes are fed through. They are
+//! filtered here by shape, so the list means what its name says: sequences
+//! **termlens** did not honour.
+
+use std::sync::Arc;
+
+use vt100::Callbacks;
+
+/// Distinct shapes kept before the record only counts.
+pub(super) const MAX_UNSUPPORTED: usize = 32;
+
+/// The callback set the primary parser is built with.
+#[derive(Debug)]
+pub(super) struct Unhandled {
+    seen: Vec<Arc<str>>,
+    /// The same shapes as one shared slice, rebuilt when a shape is added —
+    /// at most 32 times in a terminal's life — so a snapshot pays one
+    /// refcount rather than a copy.
+    shared: Arc<[Arc<str>]>,
+    overflow: u64,
+    visual_bells: u64,
+}
+
+impl Default for Unhandled {
+    fn default() -> Self {
+        Self {
+            seen: Vec::new(),
+            shared: Arc::from([] as [Arc<str>; 0]),
+            overflow: 0,
+            visual_bells: 0,
+        }
+    }
+}
+
+impl Unhandled {
+    /// The distinct shapes, first seen first.
+    pub(super) fn shapes(&self) -> Arc<[Arc<str>]> {
+        Arc::clone(&self.shared)
+    }
+
+    /// Distinct shapes beyond [`MAX_UNSUPPORTED`], counted only.
+    pub(super) fn overflow(&self) -> u64 {
+        self.overflow
+    }
+
+    /// `ESC g` seen.
+    pub(super) fn visual_bells(&self) -> u64 {
+        self.visual_bells
+    }
+
+    fn record(&mut self, shape: String) {
+        if self.seen.iter().any(|s| **s == *shape) {
+            return;
+        }
+        if self.seen.len() >= MAX_UNSUPPORTED {
+            self.overflow = self.overflow.saturating_add(1);
+            return;
+        }
+        self.seen.push(Arc::from(shape));
+        self.shared = self.seen.iter().cloned().collect();
+    }
+}
+
+/// `params` as they were written: `;` between parameters, `:` between the
+/// sub-parameters of one.
+fn params_text(params: &[&[u16]]) -> String {
+    params
+        .iter()
+        .map(|p| p.iter().map(u16::to_string).collect::<Vec<_>>().join(":"))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+/// DEC private modes the sequence tracker keeps itself, so a set or reset
+/// of one is termlens's business even though vt100 declines it — plus 9001,
+/// win32-input-mode, which is not the application's at all: on Windows the
+/// console asks its host for it in the preamble every child gets, and
+/// termlens's answer is to keep sending VT. Recording it would put the
+/// console's handshake in every Windows snapshot's list (#149).
+const TRACKED_PRIVATE_MODES: &[u16] = &[9, 1000, 1002, 1003, 1005, 1006, 1015, 1004, 2026, 9001];
+
+impl Callbacks for Unhandled {
+    fn visual_bell(&mut self, _: &mut vt100::Screen) {
+        self.visual_bells = self.visual_bells.saturating_add(1);
+    }
+
+    fn resize(&mut self, _: &mut vt100::Screen, (rows, cols): (u16, u16)) {
+        // The grid's size is the test's to set, so the request is not
+        // honoured — and that is exactly what makes it worth recording.
+        self.record(format!("^[[8;{rows};{cols}t"));
+    }
+
+    fn unhandled_control(&mut self, _: &mut vt100::Screen, b: u8) {
+        // SO and SI are the locking shifts the tracker handles.
+        if matches!(b, 0x0e | 0x0f) {
+            return;
+        }
+        self.record(match b {
+            0x7f => "^?".to_owned(),
+            0..=0x1f => format!("^{}", (b + 0x40) as char),
+            other => format!("\\x{other:02x}"),
+        });
+    }
+
+    fn unhandled_escape(&mut self, _: &mut vt100::Screen, i1: Option<u8>, i2: Option<u8>, b: u8) {
+        // Designations (`ESC ( 0` …), HTS, SS2/SS3: the tracker's. And ST
+        // (`ESC \`), which is not a sequence of its own but the terminator
+        // of the OSC, DCS or APC string that came before it — the string
+        // parser hands the ESC back and the backslash arrives here.
+        let designation = matches!(i1, Some(b'(' | b')' | b'*' | b'+')) && i2.is_none();
+        if designation || (i1.is_none() && matches!(b, b'H' | b'N' | b'O' | b'\\')) {
+            return;
+        }
+        let mut shape = String::from("^[");
+        shape.extend(i1.map(char::from));
+        shape.extend(i2.map(char::from));
+        shape.push(char::from(b));
+        self.record(shape);
+    }
+
+    fn unhandled_csi(
+        &mut self,
+        _: &mut vt100::Screen,
+        i1: Option<u8>,
+        i2: Option<u8>,
+        params: &[&[u16]],
+        c: char,
+    ) {
+        // vte hands the private marker (`?`, `>`, `=`) over as the first
+        // intermediate; a real intermediate (`$`, `!`, `SP`) follows it or
+        // stands alone.
+        let (prefix, intermediate) = match (i1, i2) {
+            (Some(p @ (b'?' | b'>' | b'=')), other) => (Some(p), other),
+            (other, None) => (None, other),
+            (a, b) => (a, b),
+        };
+        let first = params.first().and_then(|p| p.first()).copied();
+        let handled = match (prefix, intermediate, c) {
+            // Tab stops, insert mode, the queries the responder answers or
+            // names, and the window reports it answers or names.
+            (None, None, 'g' | 'I' | 'Z' | 'c' | 'n' | 't') => true,
+            (None, None, 'h' | 'l') => first == Some(4),
+            // DECSTR, DECSCUSR, DECRQM and the mode reports.
+            (None, Some(b'!'), 'p') | (None, Some(b' '), 'q') => true,
+            (_, Some(b'$'), 'p' | 'y') => true,
+            // DA2, and the kitty keyboard probe the responder names.
+            (Some(b'>'), None, 'c') | (Some(b'?'), None, 'u') => true,
+            // The private modes the tracker keeps; any other private mode
+            // vt100 declined is one nobody honoured.
+            (Some(b'?'), None, 'h' | 'l') => params
+                .iter()
+                .flat_map(|p| p.iter())
+                .all(|m| TRACKED_PRIVATE_MODES.contains(m)),
+            _ => false,
+        };
+        if handled {
+            return;
+        }
+        let mut shape = String::from("^[[");
+        shape.extend(prefix.map(char::from));
+        shape.push_str(&params_text(params));
+        shape.extend(intermediate.map(char::from));
+        shape.push(c);
+        self.record(shape);
+    }
+
+    fn unhandled_osc(&mut self, _: &mut vt100::Screen, params: &[&[u8]]) {
+        // Links, the clipboard, the colour and palette queries: the
+        // tracker's, answered or named by the responder.
+        if matches!(
+            params.first(),
+            Some(&b"8" | &b"52" | &b"10" | &b"11" | &b"4")
+        ) {
+            return;
+        }
+        let mut shape = String::from("^[]");
+        for (i, p) in params.iter().enumerate() {
+            if i > 0 {
+                shape.push(';');
+            }
+            shape.push_str(&String::from_utf8_lossy(p));
+        }
+        self.record(shape);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fed(bytes: &[u8]) -> vt100::Parser<Unhandled> {
+        let mut parser = vt100::Parser::new_with_callbacks(4, 20, 0, Unhandled::default());
+        parser.process(bytes);
+        parser
+    }
+
+    fn shapes(bytes: &[u8]) -> Vec<String> {
+        fed(bytes)
+            .callbacks()
+            .shapes()
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn a_sequence_nobody_honours_is_recorded_once_in_its_written_form() {
+        assert_eq!(
+            shapes(b"\x1b[20h\x1b[20h\x1bD\x1b]9;hi\x07\x05\x1b[?69h"),
+            ["^[[20h", "^[D", "^[]9;hi", "^E", "^[[?69h"]
+        );
+    }
+
+    #[test]
+    fn what_the_tracker_handles_is_not_reported() {
+        let ours = b"\x1bH\x1b[3g\x1b[2I\x1b[1Z\x1b[4h\x1b[4l\x1b[6n\x1b[c\x1b[>c\x1b[18t\
+                     \x1b(0\x1b)0\x1bN\x1bO\x1b[!p\x1b[2 q\x1b[?2026$p\x1b[?1004h\x1b[?2026h\
+                     \x1b[?2026l\x1b[?1000h\x1b[?u\x1b]8;;http://x\x1b\\\x1b]52;c;aGk=\x07\
+                     \x1b]11;?\x07\x0e\x0f";
+        assert_eq!(shapes(ours), Vec::<String>::new());
+    }
+
+    #[test]
+    fn the_record_is_bounded_and_counts_the_rest() {
+        let mut stream = Vec::new();
+        for mode in 20..(20 + MAX_UNSUPPORTED as u16 + 5) {
+            stream.extend_from_slice(format!("\x1b[{mode}h").as_bytes());
+        }
+        let parser = fed(&stream);
+        assert_eq!(parser.callbacks().shapes().len(), MAX_UNSUPPORTED);
+        assert_eq!(parser.callbacks().overflow(), 5);
+    }
+
+    #[test]
+    fn a_visual_bell_and_a_resize_request_are_seen() {
+        let parser = fed(b"\x1bg\x1b[8;10;40t");
+        assert_eq!(parser.callbacks().visual_bells(), 1);
+        assert_eq!(
+            parser
+                .callbacks()
+                .shapes()
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
+            ["^[[8;10;40t"]
+        );
+        assert_eq!(
+            parser.screen().size(),
+            (4, 20),
+            "the request is recorded, not honoured"
+        );
+    }
+}

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -6,14 +6,19 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use unicode_width::UnicodeWidthStr;
+
 use super::seq::{SeqEvent, SeqTracker, TabOp};
 use super::shadow::{AttrShadow, ColorNormalizer};
+use super::unhandled::Unhandled;
 use super::{Emulator, FrameSpan, InputModes, ModeState, MouseEncoding, Processed, Stop};
 use crate::graphics::{GraphicsPayload, GraphicsSeen, HISTORY};
 use crate::screen::{Cell, Color, MouseMode, Screen, Style, TermState};
 
 pub(crate) struct Vt100Emulator {
-    parser: ::vt100::Parser,
+    /// Built with the callback set that records what vt100 could not
+    /// render, so a snapshot can say so (`emu/unhandled.rs`).
+    parser: ::vt100::Parser<Unhandled>,
     tracker: SeqTracker,
     /// Carries blink, conceal and strikethrough, which vt100 drops. See
     /// `emu/shadow.rs` for why this is a second parser rather than
@@ -68,7 +73,12 @@ impl Vt100Emulator {
 
     pub(crate) fn new(rows: u16, cols: u16, scrollback_len: usize, capture: usize) -> Self {
         Self {
-            parser: ::vt100::Parser::new(rows, cols, scrollback_len),
+            parser: ::vt100::Parser::new_with_callbacks(
+                rows,
+                cols,
+                scrollback_len,
+                Unhandled::default(),
+            ),
             tracker: SeqTracker::new(capture, cols),
             shadow: AttrShadow::new(rows, cols),
             colors: ColorNormalizer::new(),
@@ -253,7 +263,37 @@ impl Emulator for Vt100Emulator {
         // it draws instead of being sliced through, and everything else is
         // fed in one go, exactly as before.
         let mut fed = 0;
+        // Where the current run of printable bytes ends while insert mode is
+        // on, so the room is reserved once per run rather than per byte.
+        let mut run_until = 0;
         for (i, &byte) in bytes.iter().enumerate() {
+            // Insert mode: a printable run pushes the rest of the row right
+            // instead of overwriting it. vt100 does not model IRM, so the
+            // room is reserved with the `ICH` it does dispatch, sized in
+            // columns — a wide character counts twice — and never past the
+            // right margin (#261). The bytes owed to the grid go first, so
+            // the cursor column the reservation is made at is current.
+            if i >= run_until
+                && self.tracker.insert_mode()
+                && !self.tracker.mid_sequence()
+                && is_printable(byte)
+            {
+                let end = bytes[i..]
+                    .iter()
+                    .position(|&b| !is_printable(b))
+                    .map_or(bytes.len(), |p| i + p);
+                run_until = end;
+                let width = String::from_utf8_lossy(&bytes[i..end]).width();
+                self.feed_staged(&bytes[fed..i]);
+                fed = i;
+                let screen = self.parser.screen();
+                let (_, col) = screen.cursor_position();
+                let room = usize::from(screen.size().1.saturating_sub(col));
+                let reserve = width.min(room);
+                if reserve > 0 {
+                    self.feed(format!("\x1b[{reserve}@").as_bytes());
+                }
+            }
             // Asked before the step, because whether this byte is a character
             // at all depends on the state the tracker is in before it — and
             // a designation's own final byte must not be drawn.
@@ -313,6 +353,9 @@ impl Emulator for Vt100Emulator {
     }
 
     fn snapshot(&self) -> Screen {
+        let unsupported = self.parser.callbacks().shapes();
+        let unsupported_overflow = self.parser.callbacks().overflow();
+        let visual_bells = self.parser.callbacks().visual_bells();
         let screen = self.parser.screen();
         let (rows, cols) = screen.size();
         let mut cells: Vec<Cell> = Vec::with_capacity(usize::from(rows) * usize::from(cols));
@@ -363,6 +406,12 @@ impl Emulator for Vt100Emulator {
             // Filled in by the terminal, which owns the frame count.
             repaints: 0,
             scrollback: self.history.iter().cloned().collect(),
+            // The backend's own record of a soft wrap, per row (#265).
+            wrapped: (0..rows).map(|row| screen.row_wrapped(row)).collect(),
+            insert_mode: self.tracker.insert_mode(),
+            unsupported,
+            unsupported_overflow,
+            visual_bells,
         };
         Screen::from_parts(
             cols,
@@ -502,6 +551,12 @@ fn convert_cell(cell: &::vt100::Cell, shadow: Option<&::vt100::Cell>) -> Cell {
         cell.is_wide(),
         cell.is_wide_continuation(),
     )
+}
+
+/// A byte that draws: not a C0 control, not DEL, not ESC. Continuation
+/// bytes of a multi-byte character count, so a run is measured whole.
+fn is_printable(b: u8) -> bool {
+    b >= 0x20 && b != 0x7f
 }
 
 /// What the reader substitutes for a byte it could not decode (`utf8.rs`).

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -406,6 +406,17 @@ pub(crate) struct TermState {
     /// history is asserted on for its content. The rows are shared, so a
     /// snapshot pays one `Arc` clone each.
     pub(crate) scrollback: Arc<[Arc<str>]>,
+    /// Per row, whether it ended in a soft wrap rather than a line end —
+    /// the backend's own record, never asked for before #265.
+    pub(crate) wrapped: Arc<[bool]>,
+    /// `IRM` is set: the application left the terminal in insert mode.
+    pub(crate) insert_mode: bool,
+    /// Escape sequences nobody honoured, distinct, first seen first (#266).
+    pub(crate) unsupported: Arc<[Arc<str>]>,
+    /// Distinct unsupported shapes beyond the bound, counted only.
+    pub(crate) unsupported_overflow: u64,
+    /// `ESC g` seen: a flash rather than a beep.
+    pub(crate) visual_bells: u64,
 }
 
 impl Default for TermState {
@@ -425,6 +436,11 @@ impl Default for TermState {
             graphics: GraphicsSeen::default(),
             repaints: 0,
             scrollback: Arc::from([] as [Arc<str>; 0]),
+            wrapped: Arc::from([] as [bool; 0]),
+            insert_mode: false,
+            unsupported: Arc::from([] as [Arc<str>; 0]),
+            unsupported_overflow: 0,
+            visual_bells: 0,
         }
     }
 }
@@ -848,6 +864,105 @@ impl Screen {
         self.state.graphics.clone()
     }
 
+    /// Escape sequences the emulator did not implement, so the grid below
+    /// them is not what a terminal would show. Distinct shapes, first seen
+    /// first, in the form the timeout messages use (`^[[20h` for
+    /// `CSI 20 h`), at most 32 — [`unsupported_overflow`](Self::unsupported_overflow)
+    /// counts the rest.
+    ///
+    /// Empty for an application that uses only what the emulator renders,
+    /// which is what makes it worth asserting: the failure this catches is
+    /// the one where a test passes against a plausible-looking wrong screen
+    /// because the sequence that would have made it right was dropped.
+    /// Sequences termlens handles itself — the character sets, tab stops,
+    /// insert mode, the queries it answers or names, the modes it tracks —
+    /// are not listed, since the screen does show their effect. A request to
+    /// resize the window (`CSI 8 ; rows ; cols t`) *is* listed: the grid's
+    /// size is the test's to set, so the request is recorded rather than
+    /// honoured.
+    #[must_use]
+    pub fn unsupported(&self) -> &[Arc<str>] {
+        &self.state.unsupported
+    }
+
+    /// Distinct unsupported sequences beyond the 32 that
+    /// [`unsupported`](Self::unsupported) keeps, counted so a stream that
+    /// emits thousands cannot grow a snapshot.
+    #[must_use]
+    pub fn unsupported_overflow(&self) -> u64 {
+        self.state.unsupported_overflow
+    }
+
+    /// Visual bells (`ESC g`) the application requested — a flash rather
+    /// than a beep, and a different event from [`bells`](Self::bells), so an
+    /// application that flashes on an invalid key is assertable as such.
+    #[must_use]
+    pub fn visual_bells(&self) -> u64 {
+        self.state.visual_bells
+    }
+
+    /// Whether the application has the terminal in insert mode (`IRM`,
+    /// `CSI 4 h`): a printed character pushes the rest of its row right
+    /// rather than overwriting. The same shape of assertion as
+    /// [`alternate_screen`](Self::alternate_screen) — "the application set
+    /// a mode and left it there" — and cleared by `RIS` and `DECSTR`.
+    #[must_use]
+    pub fn insert_mode(&self) -> bool {
+        self.state.insert_mode
+    }
+
+    /// Whether `row` ended in a **soft wrap** — the application wrote past
+    /// the right margin and the terminal continued on the next row — rather
+    /// than in a line end. The backend's own record; `false` for a row
+    /// outside the screen.
+    ///
+    /// This is the fact [`logical_text`](Self::logical_text) joins rows on.
+    #[must_use]
+    pub fn row_wrapped(&self, row: u16) -> bool {
+        self.state
+            .wrapped
+            .get(usize::from(row))
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// The grid as the application wrote it: soft-wrapped rows joined with
+    /// nothing, every other row ending in `\n`, trailing whitespace stripped
+    /// per logical line — [`text`](Self::text) with the wraps undone, blank
+    /// rows below the content included as blank lines just as there.
+    ///
+    /// A line long enough to wrap is two rows on the grid, and a needle
+    /// spanning the wrap is not found by [`contains`](Self::contains) or
+    /// [`find`](Self::find), which read the grid row by row. This is the
+    /// accessor for that assertion: on a 20-column screen showing
+    /// `the quick brown fox` over `jumps`,
+    /// `logical_text().contains("brown fox jumps")` is true. It is `str`
+    /// matching from here on — byte-exact, no NFC fold — like
+    /// [`full_text`](Self::full_text).
+    #[must_use]
+    pub fn logical_text(&self) -> String {
+        let mut out = String::new();
+        let mut line = String::new();
+        for row in 0..self.rows {
+            line.push_str(&self.row_text(row));
+            if self.row_wrapped(row) {
+                continue;
+            }
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(line.trim_end());
+            line.clear();
+        }
+        if !line.is_empty() {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(line.trim_end());
+        }
+        out
+    }
+
     /// The cell at `(row, col)`, or `None` when out of bounds.
     #[must_use]
     pub fn cell(&self, row: u16, col: u16) -> Option<&Cell> {
@@ -981,6 +1096,12 @@ impl Screen {
     /// timeout therefore says how many rows have scrolled off whenever any
     /// have.
     ///
+    /// The same trap one row lower: a line long enough to **wrap** is two
+    /// rows here, and a needle spanning the wrap is not found even though a
+    /// reader plainly sees it. [`logical_text`](Self::logical_text) joins
+    /// soft-wrapped rows back together, using the wrap record the backend
+    /// keeps ([`row_wrapped`](Self::row_wrapped)).
+    ///
     /// # Normalization
     ///
     /// Both sides are folded to **NFC** before comparing, so a needle finds
@@ -1029,6 +1150,9 @@ impl Screen {
     /// needle that has scrolled into history is not found here, however
     /// recently it left. [`full_text`](Self::full_text) spans history and
     /// screen, [`scrollback_text`](Self::scrollback_text) the history alone.
+    /// A needle spanning a soft wrap is not found either — a match across a
+    /// wrap has no single row and column to report — and
+    /// [`logical_text`](Self::logical_text) is the accessor for that.
     ///
     /// Needles containing `\n` match across consecutive rows with exactly
     /// the semantics of [`Screen::contains`] (trailing whitespace stripped
@@ -1913,6 +2037,7 @@ mod tests {
             graphics: GraphicsSeen::for_test(1, 1, 2, 160),
             repaints: 9,
             scrollback: Arc::from([Arc::from("scrolled away")]),
+            ..TermState::default()
         };
         let cells = vec![Cell::new("x".into(), Style::default(), false, false)];
         let s = Screen::from_parts(1, 1, 0, 0, true, cells, state);

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -3683,13 +3683,15 @@ impl Terminal {
     /// Rows already in scrollback keep the width they were captured at, and
     /// rows that scroll off after the resize are captured at the new width,
     /// so [`full_text`](Screen::full_text) after a narrowing resize can hold
-    /// both geometries. That is a decision rather than an omission. History
-    /// is text, with no record of which rows were soft-wrapped, so there is
-    /// nothing to reflow *from*; and discarding it on resize — the other
-    /// honest option — would make a suite that exercises a responsive layout
-    /// lose everything it had already asserted on. The visible grid is not
-    /// reflowed either: the backend clips or pads each row to the new width,
-    /// which is the stale-frame trap above.
+    /// both geometries. That is a decision rather than an omission, and the
+    /// reason is cost: the backend does record which rows soft-wrapped
+    /// ([`Screen::row_wrapped`]), so reflowing is possible, but history is
+    /// captured as text without that bit and re-laying a thousand rows out
+    /// on every resize is a price no assertion has asked for. Discarding
+    /// history on resize — the other honest option — would make a suite that
+    /// exercises a responsive layout lose everything it had already asserted
+    /// on. The visible grid is not reflowed either: the backend clips or pads
+    /// each row to the new width, which is the stale-frame trap above.
     ///
     /// # After the child exits
     ///

--- a/crates/termlens/tests/insert_mode.rs
+++ b/crates/termlens/tests/insert_mode.rs
@@ -1,0 +1,134 @@
+//! Insert mode (`IRM`, `CSI 4 h` / `CSI 4 l`): a printed character pushes
+//! the rest of its row right instead of overwriting the cell under the
+//! cursor. `smir`/`rmir` are in the terminfo entry every child is handed,
+//! and ncurses uses the mode for `insch`; before this the mode was parsed
+//! and dropped, so an inserted character ate the tail of the line (#261).
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+
+/// The `emit` fixture on the 20x2 terminal the issue's reproductions use.
+fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
+    common::spawn_emit(
+        Terminal::builder()
+            .size(20, 2)
+            .timeout(Duration::from_secs(10)),
+        steps,
+    )
+}
+
+/// The reproduction from the issue.
+#[test]
+fn an_insert_pushes_the_rest_of_the_row_right() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "abcd", "--csi", "1G", "--csi", "4h", "ZZ", "\nDONE", "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "ZZabcd", "{s}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The mode itself is observable: "the application put the terminal in
+/// insert mode and left it there" is the same shape of assertion as
+/// `alternate_screen()`.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY does not forward the mode sets an application sends, so insert mode is never observed — it performs the insert itself (#149)"
+)]
+fn the_mode_is_reported_on_the_screen() -> termlens::Result<()> {
+    let mut t = emit(&["--csi", "4h", "DONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert!(s.insert_mode(), "the application left insert mode on: {s}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn csi_4_l_returns_to_overwriting() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "abcd", "--csi", "1G", "--csi", "4h", "ZZ", "--csi", "4l", "--csi", "1G", "YY", "\nDONE",
+        "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "YYabcd", "{s}");
+    assert!(!s.insert_mode(), "{s}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Both resets clear the mode: `RIS` (which also clears the screen) and
+/// `DECSTR` (which clears nothing).
+#[test]
+fn ris_and_decstr_clear_the_mode() -> termlens::Result<()> {
+    for reset in [&["--esc", "c"][..], &["--csi", "!p"]] {
+        let mut steps = vec!["--csi", "4h"];
+        steps.extend_from_slice(reset);
+        steps.extend(["abcd", "--csi", "1G", "XX", "\nDONE", "--wait"]);
+        let mut t = emit(&steps)?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let s = t.screen();
+        assert_eq!(
+            s.row_text(0).trim_end(),
+            "XXcd",
+            "the mode must not survive {reset:?}:\n{s}"
+        );
+        assert!(!s.insert_mode(), "{s}");
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+    }
+    Ok(())
+}
+
+/// A run that reaches the right margin reserves no room past it: the
+/// characters pushed off the end are gone, and nothing wraps.
+#[test]
+fn an_insert_at_the_right_margin_does_not_reserve_past_it() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "12345678901234567890",
+        "--csi",
+        "19G",
+        "--csi",
+        "4h",
+        "ab",
+        "\nDONE",
+        "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0), "123456789012345678ab", "{s}");
+    assert_eq!(s.find("DONE"), Some((1, 0)), "nothing wrapped: {s}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The run length is in columns: a wide character reserves two.
+#[test]
+fn a_wide_character_reserves_two_columns() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "abcd", "--csi", "1G", "--csi", "4h", "汉", "\nDONE", "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0).trim_end(), "汉abcd", "{s}");
+    assert_eq!(
+        s.find("abcd"),
+        Some((0, 2)),
+        "the tail moved by two columns: {s}"
+    );
+    assert!(s.cell(0, 0).unwrap().is_wide());
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/crates/termlens/tests/queries.rs
+++ b/crates/termlens/tests/queries.rs
@@ -399,8 +399,12 @@ fn a_probe_then_enable_application_gets_its_mouse() -> termlens::Result<()> {
         "20",
         "--wait",
     ])?;
-    // `;2$y` = implemented and currently reset. The application proceeds.
-    t.wait_until(|s| s.contains("MOUSE-ON:E[?1000;2$y|"))?;
+    // `;2$y` = implemented and currently reset. The application proceeds —
+    // and the wait covers the enable that follows the marker, since the
+    // click below is refused until the terminal has seen `CSI ?1000 h`.
+    t.wait_until(|s| {
+        s.contains("MOUSE-ON:E[?1000;2$y|") && s.mouse_mode() != termlens::MouseMode::None
+    })?;
 
     t.click(9, 4)?;
     // Press and release, SGR-encoded, 1-based on the wire.

--- a/crates/termlens/tests/unsupported.rs
+++ b/crates/termlens/tests/unsupported.rs
@@ -1,0 +1,110 @@
+//! `Screen::unsupported`: the sequences the emulator did not implement, so
+//! a test can tell a plausible-looking wrong grid from a right one (#266).
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+
+fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
+    common::spawn_emit(
+        Terminal::builder()
+            .size(40, 4)
+            .timeout(Duration::from_secs(10)),
+        steps,
+    )
+}
+
+fn shapes(t: &Terminal) -> Vec<String> {
+    t.screen()
+        .unsupported()
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// A sequence nobody honours is named, in the form the timeout messages
+/// use, once however often it is sent.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY renders what it implements and drops the rest before termlens sees a byte, so the record there is the console's, not the application's (#149)"
+)]
+fn an_unimplemented_sequence_is_listed_once() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "--csi", "20h", "--csi", "20h", "--esc", "D", "text", "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("text"))?;
+    assert_eq!(shapes(&t), ["^[[20h", "^[D"]);
+    assert_eq!(t.screen().unsupported_overflow(), 0);
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Everything termlens renders or answers itself is not "unsupported",
+/// even though the backend declines it: the list means what its name says.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY renders what it implements and drops the rest before termlens sees a byte, so the record there is the console's, not the application's (#149)"
+)]
+fn an_application_using_only_what_is_implemented_reports_nothing() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "--raw",
+        r"\e(0lqk\e(B\eH\e[3g\e[4h\e[4l\e[!p\e[2 q\e[?1004h\e[?2026h\e[?2026l\e[?1000h",
+        "--raw",
+        r"\e]8;;http://a/\e\\link\e]8;;\e\\\e[31mred\e[0m",
+        " DONE",
+        "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    assert_eq!(shapes(&t), Vec::<String>::new(), "{}", t.screen());
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// A visual bell is a different event from an audible one, and a request to
+/// resize the window is recorded rather than honoured.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY renders what it implements and drops the rest before termlens sees a byte, so the record there is the console's, not the application's (#149)"
+)]
+fn a_visual_bell_and_a_resize_request_are_observable() -> termlens::Result<()> {
+    let mut t = emit(&["--esc", "g", "--csi", "8;10;60t", "DONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.visual_bells(), 1, "{s}");
+    assert_eq!(s.bells(), 0, "a flash is not a beep: {s}");
+    assert_eq!(shapes(&t), ["^[[8;10;60t"]);
+    assert_eq!(s.size(), (40, 4), "the grid is the test's to size: {s}");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The record keeps 32 distinct shapes and counts the rest, so a stream
+/// that invents thousands cannot grow a snapshot.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY renders what it implements and drops the rest before termlens sees a byte, so the record there is the console's, not the application's (#149)"
+)]
+fn the_record_is_bounded() -> termlens::Result<()> {
+    let mut stream = String::new();
+    for mode in 20..60u16 {
+        stream.push_str(&format!(r"\e[{mode}h"));
+    }
+    let mut t = emit(&["--raw", &stream, "DONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.unsupported().len(), 32, "{s}");
+    assert_eq!(s.unsupported_overflow(), 8, "{s}");
+    assert_eq!(&*s.unsupported()[0], "^[[20h");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/crates/termlens/tests/wrap.rs
+++ b/crates/termlens/tests/wrap.rs
@@ -1,0 +1,65 @@
+//! Soft wraps: a line long enough to wrap is two rows on the grid, and the
+//! backend records which rows wrapped. `contains` and `find` read the grid
+//! row by row and say so; `logical_text` joins the rows back (#265).
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+
+fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
+    common::spawn_emit(
+        Terminal::builder()
+            .size(20, 4)
+            .timeout(Duration::from_secs(10)),
+        steps,
+    )
+}
+
+/// The reproduction from the issue: `brown fox jumps` is plainly on the
+/// screen, straddling the wrap.
+#[test]
+fn a_needle_spanning_a_wrap_is_found_in_the_logical_text() -> termlens::Result<()> {
+    let mut t = emit(&["the quick brown fox jumps\nDONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.row_text(0), "the quick brown fox ", "{s}");
+    assert_eq!(s.row_text(1).trim_end(), "jumps", "{s}");
+    assert!(s.row_wrapped(0), "row 0 ended in a soft wrap: {s}");
+    assert!(!s.row_wrapped(1), "row 1 ended in a line end: {s}");
+    assert!(!s.row_wrapped(99), "off the screen is not wrapped");
+
+    // The grid-shaped searches do not span the wrap, by contract…
+    assert!(!s.contains("brown fox jumps"), "{s}");
+    assert_eq!(s.find("brown fox jumps"), None, "{s}");
+    // …and the accessor for that assertion does. Blank rows below stay
+    // blank lines, exactly as in `text()`.
+    assert_eq!(
+        s.logical_text().trim_end(),
+        "the quick brown fox jumps\nDONE",
+        "{s}"
+    );
+    assert!(s.logical_text().contains("brown fox jumps"));
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// A row that merely reaches the margin without spilling over is not a
+/// wrap, and a hard line end never is.
+#[test]
+fn a_full_row_ended_by_a_newline_is_not_a_wrap() -> termlens::Result<()> {
+    let mut t = emit(&["12345678901234567890\nnext\nDONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert!(!s.row_wrapped(0), "{s}");
+    assert_eq!(
+        s.logical_text().trim_end(),
+        "12345678901234567890\nnext\nDONE",
+        "{s}"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -481,10 +481,13 @@ bound (free, within noise), 639ms on the re-read path.
 Two limits are documented rather than papered over: history is bounded, so
 a longer run drops its oldest rows; and resize does not reflow, so rows
 keep the width they were captured at — a decision, recorded on
-`Terminal::resize`, not an omission. History is text with no record of
-which rows were soft-wrapped, so there is nothing to reflow from, and the
-other honest option, discarding history on resize, would cost a suite that
-exercises a responsive layout everything it had asserted on. Rows captured
+`Terminal::resize`, not an omission. The record needed to reflow exists —
+the backend reports which rows soft-wrapped, and `Screen::row_wrapped` and
+`Screen::logical_text` read it for the visible grid — but history is
+captured as text without it, and re-laying a thousand rows out on every
+resize is a cost no assertion has asked for; the other honest option,
+discarding history on resize, would cost a suite that exercises a
+responsive layout everything it had asserted on. Rows captured
 after a resize have the new width, so `full_text()` can hold both
 geometries, and says so where a caller meets it. The alternate screen
 accumulates no history at all (vt100 gives the alternate grid none), which


### PR DESCRIPTION
Closes #261, #265, #266 — the three emulator-layer issues in v0.10, in one PR because they share `screen.rs`/`vt100.rs` and each is small.

**#261 insert mode** — `IRM` flag in the sequence tracker (`CSI 4 h`/`l`, cleared by `RIS` and `DECSTR`); while set, `Vt100Emulator::process` reserves room for each printable run with `CSI n @` before the run reaches the grid, `n` in columns (a wide character counts twice) and never past the right margin. `Screen::insert_mode()` exposes the flag — the "left the terminal in a mode" assertion, like `alternate_screen()`. Tests: the issue's reproduction, `CSI 4 l`, both resets, the right margin, a wide character.

**#266 the unsupported record** — `emu/unhandled.rs` implements `vt100::Callbacks`: distinct shapes, first seen first, 32 kept + overflow count, rendered as `^[[20h`. Filtered by shape to what *termlens* did not honour (the tracker's sequences — designations, HTS/TBC/CHT/CBT, IRM, DECSTR, DECSCUSR, DECRQM, the answered queries, the tracked private modes, OSC 8/52/10/11/4, SO/SI, and ST as a terminator — still reach the backend's callbacks). Decisions asked for in the issue: `visual_bells()` is its own counter (a flash is not a beep); a resize request is recorded, not honoured. Tests at both layers, including the bound.

**#265 soft wraps** — `row_wrapped` read per row into the snapshot; `Screen::row_wrapped(row)`, `Screen::logical_text()`; `contains`/`find` unchanged with the trap documented beside the scrollback one; the `resize` rustdoc and DESIGN §2 now give cost as the reason history is not reflowed, since the record exists.

`unicode-width` moves from dev-dependency to dependency (already in the tree via vt100) to size the ICH reservation. All local gates green; Windows leg will show the new tests — the wrap and insert tests go through the grid, which ConPTY renders faithfully, so they should pass there too.