### PR TITLE
feat: find_all, a regex feature, and grid-aware masks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --no-default-features
       - run: cargo test --workspace --no-default-features --features decode
+      - run: cargo test --workspace --no-default-features --features regex
       - run: cargo test --workspace
       - run: cargo clippy --workspace --all-targets -- -D warnings
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -78,7 +78,7 @@ jobs:
           WANTED: ${{ inputs.version }}
           # Only the leg that asks for `decode` demands the registry advertise
           # it; the other leg proves the crate stands with no feature at all.
-          WANTED_FEATURES: ${{ matrix.features == 'decode' && 'decode insta' || '' }}
+          WANTED_FEATURES: ${{ matrix.features == 'decode' && 'decode insta regex' || '' }}
         run: |
           api="https://crates.io/api/v1/crates/termlens"
           agent="termlens-install-check (github actions)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- **`Screen::find_all`.** Every occurrence of a needle in reading order,
+  from the same scan `find` is the first element of — NFC-folded, trimmed
+  per row, real columns across wide characters — so the two cannot drift.
+  Non-overlapping, multi-row needles supported, a `Vec`; the reasons for each
+  are in the rustdoc. "This warning appears exactly once" and "click the
+  second item" are writable without opting out of normalisation. (#264)
+
+- **A `regex` feature** (off by default): `Screen::matches`, `find_match`,
+  `find_all_matches`, `mask_matches`, and `Terminal::wait_until_matches` /
+  `_for`, which returns the screen it matched on. Matching is per row over
+  the row's text as `contains` sees it, and the column reported is a cell
+  column — the expect-style wait, pointed at a row of the rendered screen
+  rather than at the byte stream. (#245)
+
+- **Grid-aware masks: `Screen::mask_rect`, `mask_matching`, `mask_cells`.**
+  Each returns a new `Screen` with cell *contents* replaced and the size,
+  cursor, styles and wide-character structure kept, so a clock or a PID can
+  be redacted without moving a column — which is what insta's text filters
+  cannot do for a grid. A masked screen snapshots, `find`s and compares like
+  any other, and its `styles:` block is unchanged, so a colour regression
+  stays visible through the redaction. (#250)
+
 - **`Screen::unsupported()`: the sequences the emulator did not implement,
   so a plausible-looking wrong grid can be told from a right one.** The
   backend reports every escape it cannot render and termlens installed the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ cargo clippy --workspace --all-targets --no-default-features --features decode -
 cargo clippy --workspace --all-targets -- -D warnings    # default features: what `cargo add termlens --dev` gives you
 cargo test --workspace --no-default-features
 cargo test --workspace --no-default-features --features decode
+cargo test --workspace --no-default-features --features regex
 cargo test --workspace                                   # default features
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +390,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "resize-echo"
 version = "0.9.0"
 dependencies = [
@@ -535,6 +573,7 @@ dependencies = [
  "libc",
  "miniz_oxide",
  "portable-pty",
+ "regex",
  "thiserror 2.0.20",
  "unicode-normalization",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ libc = "0.2"
 # zlib, for the `decode` feature: kitty transmits `o=z` compressed, so an
 # image cannot be read back off the wire without inflating it first.
 miniz_oxide = "0.9"
+# The `regex` feature: a pattern over a row of the screen, for the
+# expect-style wait and for masking volatile content by shape.
+regex = "1"
 
 # Dev / fixture dependencies.
 insta = "1.48"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ fn quits_from_the_main_screen() -> termlens::Result<()> {
 When a wait times out, the error embeds the screen — your CI log shows
 exactly what the app was displaying, not "assertion failed: false".
 
+A clock in the title bar, a PID in the status line — anything volatile —
+would break that snapshot on every run, and a text filter over the rendering
+shifts every column after it. Mask the **grid** instead, which keeps the
+width, the styles and the cursor:
+
+```rust,ignore
+let s = t.snapshot_after(|s| s.contains("Ready"))?;
+insta::assert_snapshot!(s.mask_matching("12:34:56", '▒'));   // a literal…
+insta::assert_snapshot!(s.mask_rect(70.., ..1));              // …a rectangle…
+// …or a pattern, with the `regex` feature:
+insta::assert_snapshot!(s.mask_matches(&regex::Regex::new(r"\d\d:\d\d:\d\d")?, '▒'));
+```
+
 The builder chain above is what every test of a package's own binary
 starts from, so it has a name: `termlens::bin!("myapp")` spawns
 `CARGO_BIN_EXE_myapp` at 80x24 with a cleared environment and a
@@ -194,7 +207,7 @@ so the backend can be swapped; details in [docs/DESIGN.md](docs/DESIGN.md).
 | Tool                  | Real PTY | Screen grid | Snapshots | Notes                                   |
 | --------------------- | :------: | :---------: | :-------: | --------------------------------------- |
 | **termlens**          |    ✔     |      ✔      |     ✔     | this crate                              |
-| [rexpect] / [expectrl] |   ✔     |      ✗      |     ✗     | stream matching, no rendered screen     |
+| [rexpect] / [expectrl] |   ✔     |      ✗      |     ✗     | stream matching, no rendered screen; termlens's `regex` feature gives the same `wait_until_matches(pattern)` over a *row of the screen* |
 | [term-transcript]     |    ✗     |      ~      |   SVG     | transcripts for docs, not assertions    |
 | ratatui `TestBackend` |    ✗     |      ✔      |     ~     | in-process only: your real binary, PTY layer, and non-ratatui output stay untested |
 | [teatest] (Go)        |    ✔     |      ✔      |     ✔     | same idea, Bubble Tea / Go ecosystem    |

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -26,6 +26,12 @@ insta = ["dep:insta"]
 # whether an image went out should not pay for it. Every other fact about a
 # payload — placement, declared size, format, id — is free and always on.
 decode = ["dep:miniz_oxide"]
+# Pattern matching over the rows of a screen: `Screen::matches`,
+# `find_match`, `find_all_matches`, `mask_matches` and
+# `Terminal::wait_until_matches`. Off by default like `decode`, for the same
+# reason: a suite that matches literal text should not pay for a regex
+# engine.
+regex = ["dep:regex"]
 
 [dependencies]
 portable-pty.workspace = true
@@ -38,6 +44,7 @@ unicode-normalization.workspace = true
 unicode-width.workspace = true
 insta = { workspace = true, optional = true }
 miniz_oxide = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -1177,8 +1177,68 @@ impl Screen {
     /// searches agree; [`cell`](Self::cell) still reports the character.
     #[must_use]
     pub fn find(&self, needle: &str) -> Option<(u16, u16)> {
+        let mut first = None;
+        self.for_each_match(needle, |at| {
+            first = Some(at);
+            false
+        });
+        first
+    }
+
+    /// Every occurrence of `needle`, in reading order — the `(row, col)` of
+    /// each match's first character. Matching is identical to
+    /// [`find`](Self::find), which is the first element of this same scan:
+    /// NFC on both sides, trailing whitespace trimmed per row, real columns
+    /// across double-width characters, the visible screen only.
+    ///
+    /// Two decisions, written down so they need not be discovered:
+    ///
+    /// - **Matches do not overlap.** `find_all("aa")` on a row reading
+    ///   `aaaa` is two matches, not three — each match advances past its
+    ///   own end, as `str::matches` does.
+    /// - **Multi-row needles are supported**, with exactly the semantics of
+    ///   `find`: a needle containing `\n` matches across consecutive rows,
+    ///   and the scan resumes below the rows a match consumed.
+    ///
+    /// A `Vec` rather than an iterator: a screen holds at most a few
+    /// thousand cells, so allocation is not the concern, and a `Vec` is what
+    /// `.len()` — "this warning appears exactly once" — and indexing —
+    /// "click the second item" — want. There is deliberately no count
+    /// method; `find_all(x).len()` reads fine and one scan is easier to keep
+    /// honest than two.
+    ///
+    /// ```
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder()
+    /// #     .args(["-c", r"printf 'item\nitem\nitem'; read q"]).spawn("sh")?;
+    /// # t.wait_until(|s| s.find_all("item").len() == 3)?;
+    /// let s = t.screen();
+    /// assert_eq!(s.find_all("item"), [(0, 0), (1, 0), (2, 0)]);
+    /// let (row, col) = s.find_all("item")[1];   // the second one, for a click
+    /// # assert_eq!((row, col), (1, 0));
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn find_all(&self, needle: &str) -> Vec<(u16, u16)> {
+        let mut all = Vec::new();
+        self.for_each_match(needle, |at| {
+            all.push(at);
+            true
+        });
+        all
+    }
+
+    /// The one scan behind [`find`](Self::find) and [`find_all`](Self::find_all):
+    /// every non-overlapping match of `needle` in reading order, handed to
+    /// `visit` until it returns `false`. One implementation, so the two can
+    /// never disagree about what matches — `find`'s rustdoc promises it
+    /// agrees with `contains`, and a second scan would be a second thing to
+    /// keep in agreement.
+    fn for_each_match(&self, needle: &str, mut visit: impl FnMut((u16, u16)) -> bool) {
         if needle.is_empty() {
-            return Some((0, 0));
+            visit((0, 0));
+            return;
         }
         let needle = &self.fold(needle);
         if !needle.contains('\n') {
@@ -1188,49 +1248,224 @@ impl Screen {
                 // trimmed — not the grid padded out to `cols`. The trimmed
                 // string is a prefix, so the byte-to-column map is unchanged
                 // and an interior space still matches (#212).
-                if let Some(byte_off) = text.trim_end().find(needle.as_str()) {
-                    return Some((row, cols.get(byte_off).copied()?));
+                for (byte_off, _) in text.trim_end().match_indices(needle.as_str()) {
+                    let Some(&col) = cols.get(byte_off) else {
+                        return;
+                    };
+                    if !visit((row, col)) {
+                        return;
+                    }
                 }
             }
-            return None;
+            return;
         }
 
         // Multi-row: the needle is a substring of `text()` — its first
         // segment ends a row (after the trailing-whitespace trim), the
         // middle segments equal whole rows, the last starts one.
         let segments: Vec<&str> = needle.split('\n').collect();
-        let extra = u16::try_from(segments.len() - 1).ok()?;
-        for row in 0..self.rows.checked_sub(extra)? {
+        let Ok(extra) = u16::try_from(segments.len() - 1) else {
+            return;
+        };
+        let Some(last_start) = self.rows.checked_sub(extra) else {
+            return;
+        };
+        let mut row = 0;
+        while row < last_start {
             let (first_line, cols) = self.searchable_row(row);
             let first = first_line.trim_end();
-            if !first.ends_with(segments[0]) {
-                continue;
-            }
-            let tail_matches = segments[1..].iter().enumerate().all(|(i, seg)| {
-                let (line, _) = self.searchable_row(row + 1 + i as u16);
-                let line = line.trim_end();
-                if i as u16 == extra - 1 {
-                    line.starts_with(seg) // last segment: prefix
-                } else {
-                    line == *seg // middle segments: whole rows
-                }
-            });
-            if !tail_matches {
+            let tail_matches = || {
+                segments[1..].iter().enumerate().all(|(i, seg)| {
+                    let (line, _) = self.searchable_row(row + 1 + i as u16);
+                    let line = line.trim_end();
+                    if i as u16 == extra - 1 {
+                        line.starts_with(seg) // last segment: prefix
+                    } else {
+                        line == *seg // middle segments: whole rows
+                    }
+                })
+            };
+            if !first.ends_with(segments[0]) || !tail_matches() {
+                row += 1;
                 continue;
             }
             // The needle's first character: on this row for a non-empty
             // first segment, else the first character after the leading
             // newlines (start of a following row).
-            return match segments.iter().position(|s| !s.is_empty()) {
+            let at = match segments.iter().position(|s| !s.is_empty()) {
                 Some(0) => {
                     let byte_off = first.len() - segments[0].len();
-                    Some((row, cols.get(byte_off).copied()?))
+                    match cols.get(byte_off) {
+                        Some(&col) => (row, col),
+                        None => return,
+                    }
                 }
-                Some(k) => Some((row + u16::try_from(k).ok()?, 0)),
-                None => Some((row + extra, 0)),
+                Some(k) => match u16::try_from(k) {
+                    Ok(k) => (row + k, 0),
+                    Err(_) => return,
+                },
+                None => (row + extra, 0),
             };
+            if !visit(at) {
+                return;
+            }
+            // Non-overlapping: the rows this match spanned are spent.
+            row += extra;
         }
-        None
+    }
+
+    /// A copy of this screen with every cell in the rectangle blanked —
+    /// the given columns of the given rows, the same range arguments and
+    /// clamping as [`rect_text`](Self::rect_text), **columns first**.
+    ///
+    /// # Masks change contents and nothing else
+    ///
+    /// Mask the grid, not the text, because width is meaning in a terminal.
+    /// A snapshot of a screen with a clock in the title bar fails on every
+    /// run, and a text filter over the rendering — insta's — turns an
+    /// eight-column `12:34:56` into a six-column `[time]` and moves every
+    /// cell after it, while the `styles:` block still names the original
+    /// columns. These three methods replace cell *contents* and keep the
+    /// size, the cursor, every style and the wide-character structure, so
+    /// the masked screen is an ordinary [`Screen`]: it snapshots, `find`s
+    /// and compares like any other, and a colour regression stays visible
+    /// through the redaction. A masked cell renders as its fill.
+    ///
+    /// # Panics
+    ///
+    /// If either range runs backwards, as [`rect_text`](Self::rect_text)
+    /// does and for the same reason.
+    #[must_use]
+    pub fn mask_rect(&self, cols: impl RangeBounds<u16>, rows: impl RangeBounds<u16>) -> Screen {
+        let (col_start, col_end) = clamp_range(&cols, self.cols, "column");
+        let (row_start, row_end) = clamp_range(&rows, self.rows, "row");
+        self.masked(
+            |row, col, _| {
+                (row_start..row_end).contains(&row) && (col_start..col_end).contains(&col)
+            },
+            None,
+        )
+    }
+
+    /// A copy of this screen with the cells covered by every match of
+    /// `pattern` — a literal, matched the way [`find_all`](Self::find_all)
+    /// matches — replaced by `fill`, one per column, so an eight-column
+    /// time stays eight columns of `▒`. A wide character under a match
+    /// becomes two fill cells. See [`mask_rect`](Self::mask_rect) for what
+    /// a mask keeps.
+    ///
+    /// With the `regex` feature, `mask_matches` takes a pattern instead; the
+    /// two share one engine.
+    ///
+    /// # Panics
+    ///
+    /// If `fill` is not one column wide: a wide fill would change the
+    /// row's width, which is the one thing a mask exists not to do.
+    #[must_use]
+    pub fn mask_matching(&self, pattern: &str, fill: char) -> Screen {
+        let pattern = self.fold(pattern);
+        self.masked_spans(
+            |hay| {
+                hay.match_indices(pattern.as_str())
+                    .map(|(start, _)| (start, start + pattern.len()))
+                    .collect()
+            },
+            fill,
+        )
+    }
+
+    /// A copy of this screen with every cell for which `predicate` holds
+    /// blanked — everything dim, say, or everything in a given colour. See
+    /// [`mask_rect`](Self::mask_rect) for what a mask keeps.
+    #[must_use]
+    pub fn mask_cells(&self, mut predicate: impl FnMut(&Cell) -> bool) -> Screen {
+        self.masked(|_, _, cell| predicate(cell), None)
+    }
+
+    /// The masks' shared core: `hit(row, col, cell)` decides, `fill` is the
+    /// replacement (`None` for a blank cell).
+    fn masked(&self, mut hit: impl FnMut(u16, u16, &Cell) -> bool, fill: Option<char>) -> Screen {
+        let width = usize::from(self.cols);
+        let hits: Vec<bool> = self
+            .cells
+            .iter()
+            .enumerate()
+            .map(|(i, cell)| {
+                let row = u16::try_from(i / width).unwrap_or(u16::MAX);
+                let col = u16::try_from(i % width).unwrap_or(u16::MAX);
+                hit(row, col, cell)
+            })
+            .collect();
+        self.apply_mask(hits, fill)
+    }
+
+    /// Mask by byte ranges of each row's searchable text — what a literal
+    /// or a pattern match produces — mapped back to columns through the
+    /// same map `find` reports columns with.
+    fn masked_spans(
+        &self,
+        mut spans: impl FnMut(&str) -> Vec<(usize, usize)>,
+        fill: char,
+    ) -> Screen {
+        let width = usize::from(self.cols);
+        let mut hits = vec![false; self.cells.len()];
+        for row in 0..self.rows {
+            let (text, cols) = self.searchable_row(row);
+            for (start, end) in spans(text.trim_end()) {
+                for byte in start..end {
+                    if let Some(&col) = cols.get(byte) {
+                        hits[usize::from(row) * width + usize::from(col)] = true;
+                    }
+                }
+            }
+        }
+        self.apply_mask(hits, Some(fill))
+    }
+
+    fn apply_mask(&self, mut hits: Vec<bool>, fill: Option<char>) -> Screen {
+        if let Some(fill) = fill {
+            assert_eq!(
+                unicode_width::UnicodeWidthChar::width(fill),
+                Some(1),
+                "a mask fill must be one column wide, and {fill:?} is not"
+            );
+        }
+        // A masked wide character masks both of its columns, whichever of
+        // the two was hit, so the row keeps its width.
+        let width = usize::from(self.cols);
+        for i in 0..hits.len() {
+            if !hits[i] {
+                continue;
+            }
+            if self.cells[i].is_wide() && (i + 1) % width != 0 && i + 1 < hits.len() {
+                hits[i + 1] = true;
+            }
+            if self.cells[i].is_wide_continuation() && i % width != 0 {
+                hits[i - 1] = true;
+            }
+        }
+        let contents = fill.map_or_else(String::new, String::from);
+        let cells: Vec<Cell> = self
+            .cells
+            .iter()
+            .zip(&hits)
+            .map(|(cell, &hit)| {
+                if hit {
+                    Cell::new(contents.clone(), *cell.style(), false, false)
+                } else {
+                    cell.clone()
+                }
+            })
+            .collect();
+        Screen {
+            cols: self.cols,
+            rows: self.rows,
+            cursor_row: self.cursor_row,
+            cursor_col: self.cursor_col,
+            cursor_visible: self.cursor_visible,
+            cells: cells.into(),
+            state: Arc::clone(&self.state),
+        }
     }
 
     /// The text within a rectangle: the given columns of the given rows,
@@ -1424,6 +1659,98 @@ impl Screen {
     #[must_use]
     pub fn with_styles(&self) -> ScreenWithStyles<'_> {
         ScreenWithStyles { screen: self }
+    }
+}
+
+/// Pattern matching over the rows of the screen (feature `regex`).
+///
+/// The crate's position — assert on the rendered screen, not the byte
+/// stream — is not weakened by matching a pattern against a *row of that
+/// screen*: the match still lands on cells with coordinates. Matching is
+/// per row over the row's text as [`contains`](Self::contains) sees it —
+/// NFC-folded, trailing whitespace trimmed — so a pattern never spans rows
+/// (a terminal has no row boundary a user reads across), and the column
+/// reported is a cell column, mapped back through wide characters exactly
+/// as [`find`](Self::find) does.
+#[cfg(feature = "regex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
+impl Screen {
+    /// The first match of `re` in reading order: `(row, col, matched text)`,
+    /// the column being that of the match's first character.
+    ///
+    /// ```
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder()
+    /// #     .args(["-c", r"printf 'myapp v1.42.0 ready'; read q"]).spawn("sh")?;
+    /// # t.wait_until(|s| s.contains("ready"))?;
+    /// let version = regex::Regex::new(r"v\d+\.\d+\.\d+").unwrap();
+    /// let (row, col, text) = t.screen().find_match(&version).expect("a version");
+    /// assert_eq!((row, col, text.as_str()), (0, 6, "v1.42.0"));
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn find_match(&self, re: &regex::Regex) -> Option<(u16, u16, String)> {
+        let mut first = None;
+        self.for_each_regex_match(re, |m| {
+            first = Some(m);
+            false
+        });
+        first
+    }
+
+    /// Every match of `re`, in reading order, non-overlapping within a row
+    /// as [`regex::Regex::find_iter`] is: `(row, col, matched text)` each.
+    #[must_use]
+    pub fn find_all_matches(&self, re: &regex::Regex) -> Vec<(u16, u16, String)> {
+        let mut all = Vec::new();
+        self.for_each_regex_match(re, |m| {
+            all.push(m);
+            true
+        });
+        all
+    }
+
+    /// True if some row matches `re` — the pattern-shaped
+    /// [`contains`](Self::contains), and what
+    /// [`Terminal::wait_until_matches`](crate::Terminal::wait_until_matches)
+    /// waits on.
+    #[must_use]
+    pub fn matches(&self, re: &regex::Regex) -> bool {
+        self.find_match(re).is_some()
+    }
+
+    /// [`mask_matching`](Self::mask_matching) with a pattern: the cells
+    /// covered by every match of `re` in every row become `fill`, one per
+    /// column, so a `\d{2}:\d{2}:\d{2}` clock stays eight columns wide.
+    ///
+    /// # Panics
+    ///
+    /// If `fill` is not one column wide, as `mask_matching` does.
+    #[must_use]
+    pub fn mask_matches(&self, re: &regex::Regex, fill: char) -> Screen {
+        self.masked_spans(
+            |hay| re.find_iter(hay).map(|m| (m.start(), m.end())).collect(),
+            fill,
+        )
+    }
+
+    fn for_each_regex_match(
+        &self,
+        re: &regex::Regex,
+        mut visit: impl FnMut((u16, u16, String)) -> bool,
+    ) {
+        for row in 0..self.rows {
+            let (text, cols) = self.searchable_row(row);
+            for m in re.find_iter(text.trim_end()) {
+                let Some(&col) = cols.get(m.start()) else {
+                    return;
+                };
+                if !visit((row, col, m.as_str().to_owned())) {
+                    return;
+                }
+            }
+        }
     }
 }
 

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -3762,6 +3762,57 @@ impl fmt::Debug for Terminal {
     }
 }
 
+/// Waiting on a pattern (feature `regex`).
+#[cfg(feature = "regex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "regex")))]
+impl Terminal {
+    /// Block until some row of the screen matches `re`, and return the
+    /// screen it matched on — the instant the pattern was seen, like
+    /// [`wait_frame`](Self::wait_frame) and
+    /// [`snapshot_after`](Self::snapshot_after), so the assertion lands on
+    /// that screen rather than on a later one that may have moved on.
+    /// Matching is [`Screen::matches`]: per row, NFC-folded, cell columns.
+    ///
+    /// This is the expect-style wait — "the prompt ends in a digit", "the
+    /// status line shows a version" — pointed at a row of the rendered
+    /// screen instead of at the byte stream. Everything
+    /// [`wait_until`](Self::wait_until)'s rustdoc says about race-free
+    /// waits applies unchanged; a pattern is a predicate.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Timeout`] / [`Error::Eof`], each carrying the screen.
+    pub fn wait_until_matches(&mut self, re: &regex::Regex) -> Result<Screen> {
+        self.wait_until_matches_for(re, self.default_timeout)
+    }
+
+    /// [`wait_until_matches`](Self::wait_until_matches) with a per-call
+    /// timeout.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Timeout`] / [`Error::Eof`], each carrying the screen.
+    pub fn wait_until_matches_for(
+        &mut self,
+        re: &regex::Regex,
+        timeout: Duration,
+    ) -> Result<Screen> {
+        let mut matched = None;
+        self.wait_until_deadline(
+            |screen| {
+                if screen.matches(re) {
+                    matched = Some(screen.clone());
+                    true
+                } else {
+                    false
+                }
+            },
+            timeout,
+        )?;
+        Ok(matched.expect("the wait returned Ok, so the predicate held on a screen"))
+    }
+}
+
 impl Drop for Terminal {
     /// Kill and reap the child. No zombies, even when a test panics before
     /// `wait_exit`. The reader thread ends on its own at EOF and is never

--- a/crates/termlens/tests/search.rs
+++ b/crates/termlens/tests/search.rs
@@ -1,0 +1,224 @@
+//! `find_all`, the `regex` feature's matches and waits, and the grid-aware
+//! masks (#264, #245, #250).
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+
+fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
+    common::spawn_emit(
+        Terminal::builder()
+            .size(40, 6)
+            .timeout(Duration::from_secs(10)),
+        steps,
+    )
+}
+
+#[test]
+fn find_all_returns_every_match_in_reading_order() -> termlens::Result<()> {
+    let mut t = emit(&["item one\nitem two\n  item three\nDONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.find_all("item"), [(0, 0), (1, 0), (2, 2)], "{s}");
+    assert_eq!(
+        s.find("item"),
+        Some((0, 0)),
+        "find is the first of the same scan"
+    );
+    assert_eq!(s.find_all("item").len(), 3);
+    assert!(s.find_all("nowhere").is_empty());
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Matches do not overlap, a match after a wide character reports the real
+/// column, and a multi-row needle is found wherever `contains` is true.
+#[test]
+fn find_all_does_not_overlap_and_keeps_real_columns() -> termlens::Result<()> {
+    let mut t = emit(&["aaaa 汉ab ab\nx\nab\nx\nDONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    assert_eq!(s.find_all("aa"), [(0, 0), (0, 2)], "non-overlapping: {s}");
+    // `ab` twice on row 0 — the first straight after the two-column 汉 —
+    // then once on row 2.
+    assert_eq!(s.find_all("ab"), [(0, 7), (0, 10), (2, 0)], "{s}");
+    assert_eq!(
+        s.find_all("ab\nx"),
+        [(0, 10), (2, 0)],
+        "multi-row, twice: {s}"
+    );
+    assert!(s.contains("ab\nx"));
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn mask_rect_blanks_the_rectangle_and_keeps_everything_else() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "--raw",
+        r"\e[1mmyapp\e[0m         12:34:56\nrow two\nDONE",
+        "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    let masked = s.mask_rect(14.., ..1);
+    assert_eq!(masked.row_text(0).trim_end(), "myapp", "{masked}");
+    assert_eq!(
+        masked.row_text(1).trim_end(),
+        "row two",
+        "the other rows are untouched: {masked}"
+    );
+    assert_eq!(masked.size(), s.size());
+    assert_eq!(masked.cursor(), s.cursor());
+    assert!(
+        masked.cell(0, 0).unwrap().style().bold,
+        "styles survive: {}",
+        masked.with_styles()
+    );
+    assert_eq!(masked.title(), s.title(), "out-of-band state is shared");
+    assert!(s.contains("12:34:56"), "the original is not mutated");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// The point of a grid-aware mask: the width never changes.
+#[test]
+fn mask_matching_keeps_the_width_and_masks_both_columns_of_a_wide_character() -> termlens::Result<()>
+{
+    let mut t = emit(&["--raw", r"at 12:34:56 in 汉字 town\nDONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    let masked = s.mask_matching("12:34:56", '▒');
+    assert_eq!(
+        masked.row_text(0).trim_end(),
+        "at ▒▒▒▒▒▒▒▒ in 汉字 town",
+        "{masked}"
+    );
+    assert_eq!(
+        masked.row_text(0).chars().count(),
+        s.row_text(0).chars().count(),
+        "same width"
+    );
+    assert_eq!(
+        masked.find("in"),
+        s.find("in"),
+        "nothing after the field moved"
+    );
+
+    let wide = s.mask_matching("汉", '#');
+    assert_eq!(
+        wide.row_text(0).trim_end(),
+        "at 12:34:56 in ##字 town",
+        "{wide}"
+    );
+    assert!(
+        !wide.cell(0, 15).unwrap().is_wide(),
+        "two narrow fill cells now"
+    );
+    assert_eq!(wide.find("town"), s.find("town"), "the tail did not move");
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn mask_cells_blanks_by_predicate() -> termlens::Result<()> {
+    let mut t = emit(&["--raw", r"keep \e[2mfaint\e[0m keep\nDONE", "--wait"])?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    let masked = s.mask_cells(|c| c.style().dim);
+    assert_eq!(masked.row_text(0).trim_end(), "keep       keep", "{masked}");
+    assert!(
+        masked.with_styles().to_string().contains("0: 5-9 dim"),
+        "the style run is kept so a dim field stays visibly a field:\n{}",
+        masked.with_styles()
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[cfg(feature = "regex")]
+mod patterns {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn a_pattern_matches_within_a_row_and_reports_cell_columns() -> termlens::Result<()> {
+        let mut t = emit(&["--raw", r"汉 myapp v1.42.0 ready\nbuild 7\nDONE", "--wait"])?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let s = t.screen();
+        let version = Regex::new(r"v\d+\.\d+\.\d+").unwrap();
+        assert_eq!(
+            s.find_match(&version),
+            Some((0, 9, "v1.42.0".to_owned())),
+            "the column is a cell column, after the two-column 汉: {s}"
+        );
+        assert!(s.matches(&version));
+        let digits = Regex::new(r"\d+").unwrap();
+        assert_eq!(
+            s.find_all_matches(&digits),
+            [
+                (0, 10, "1".to_owned()),
+                (0, 12, "42".to_owned()),
+                (0, 15, "0".to_owned()),
+                (1, 6, "7".to_owned()),
+            ],
+            "{s}"
+        );
+        // A pattern never spans rows.
+        assert!(!s.matches(&Regex::new(r"ready\nbuild").unwrap()));
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+        Ok(())
+    }
+
+    #[test]
+    fn wait_until_matches_returns_the_screen_it_matched() -> termlens::Result<()> {
+        let mut t = emit(&["counting: ", "--sleep", "200ms", "42", "--wait"])?;
+        let prompt = Regex::new(r"counting: \d+$").unwrap();
+        let matched = t.wait_until_matches(&prompt)?;
+        assert!(matched.matches(&prompt), "{matched}");
+        assert_eq!(matched.find_match(&prompt).unwrap().2, "counting: 42");
+        // And a pattern that never appears is the ordinary timeout.
+        let never = Regex::new(r"never \d+").unwrap();
+        let err = t
+            .wait_until_matches_for(&never, Duration::from_millis(200))
+            .unwrap_err();
+        assert!(matches!(err, termlens::Error::Timeout { .. }), "{err}");
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+        Ok(())
+    }
+
+    /// A volatile field — this process's id — masked by shape, then
+    /// snapshotted: the snapshot is stable across runs because the mask
+    /// keeps the width whatever the number was.
+    #[test]
+    fn a_masked_volatile_field_snapshots_stably() -> termlens::Result<()> {
+        let mut t = emit(&["pid ", "--pid", " running\nDONE", "--wait"])?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let s = t.screen();
+        let digits = Regex::new(r"\d+").unwrap();
+        let masked = s.mask_matches(&digits, '#');
+        assert!(
+            masked.find("running").is_some(),
+            "the word after the field is still there: {masked}"
+        );
+        // The width follows the pid, so the stable assertion is about
+        // shape, not about the exact string.
+        let row = masked.row_text(0);
+        let field: String = row.chars().filter(|&c| c == '#').collect();
+        assert!(!field.is_empty(), "{masked}");
+        assert!(row.trim_end().starts_with("pid #"), "{masked}");
+        assert!(row.trim_end().ends_with("# running"), "{masked}");
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+        Ok(())
+    }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -674,6 +674,19 @@ The `insta` feature (default) re-exports `insta` and ships
 `assert_screen_snapshot!` so the snapshotting insta version can't drift
 from the one the macro targets.
 
+### Masks
+
+`Screen::mask_rect`, `mask_matching`, `mask_cells` (and `mask_matches` with
+the `regex` feature) return a *new* `Screen` with cell contents replaced and
+nothing else changed: the size, the cursor, every style, and the two columns
+of a wide character (both become the fill) are preserved, so the masked
+screen renders in this same format — a masked cell renders as its fill, a
+blank fill as the blank a cell renders as anyway — and its `styles:` block
+is the original's. That is the whole reason the masks exist in the crate
+rather than as a text filter in the snapshot tool: a filter over the
+rendering changes a field's width and moves every column after it while the
+style runs still name the original columns; a mask over the grid cannot.
+
 ## 4. Emulator abstraction — why
 
 `vt100` is the first backend: small, pure, battle-tested by its own suite.


### PR DESCRIPTION
Closes #264, #245, #250 — the three search-and-redaction issues in v0.10, one PR because they share one scan.

**#264 `Screen::find_all`** — every occurrence in reading order, from the one scan `find` is now the first element of (`for_each_match`), so the two cannot drift. The three decisions the issue asked for, written into the rustdoc: non-overlapping (like `str::matches`), multi-row needles supported with `find`'s semantics and the scan resuming below the rows a match consumed, and a `Vec` because a screen holds a few thousand cells and `.len()`/indexing are what the two motivating assertions want. No count method.

**#245 the `regex` feature** (off by default) — `Screen::matches`, `find_match` → `(row, col, String)`, `find_all_matches`, `mask_matches`, and `Terminal::wait_until_matches` / `_for`, which return the screen the pattern was seen on. Per row over the searchable row text (NFC-folded, trailing whitespace trimmed), cell columns mapped through wide characters exactly as `find` does. The `features` job and CONTRIBUTING §1 gain the `--features regex` leg; `install.yml` asks the registry to advertise it; the README's rexpect/expectrl row names it.

**#250 masks** — `mask_rect`, `mask_matching`, `mask_cells` (and `mask_matches`) return a new `Screen` with cell *contents* replaced and size, cursor, styles and the two columns of a wide character kept, so a masked screen is an ordinary `Screen`. A fill that is not one column wide panics, for the same reason a backwards range does. DESIGN §3 records that a masked cell renders as its fill; the README shows a title-bar clock masked.

Tests in `tests/search.rs`: several rows, overlap, a match after a wide character, a needle nowhere, multi-row twice; rect/literal/predicate masks keeping width, styles and the wide-character structure; with `regex`, cell columns after a wide character, a pattern that never spans rows, `wait_until_matches` returning the matched screen and timing out, and a PID masked by shape. Every local gate green across all six feature configurations.