### PR TITLE
feat: Screen::diff, the ANSI/SVG/HTML renderings, and a serde feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       - run: cargo test --workspace --no-default-features
       - run: cargo test --workspace --no-default-features --features decode
       - run: cargo test --workspace --no-default-features --features regex
+      - run: cargo test --workspace --no-default-features --features serde
       - run: cargo test --workspace
       - run: cargo clippy --workspace --all-targets -- -D warnings
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -78,7 +78,7 @@ jobs:
           WANTED: ${{ inputs.version }}
           # Only the leg that asks for `decode` demands the registry advertise
           # it; the other leg proves the crate stands with no feature at all.
-          WANTED_FEATURES: ${{ matrix.features == 'decode' && 'decode insta regex' || '' }}
+          WANTED_FEATURES: ${{ matrix.features == 'decode' && 'decode insta regex serde' || '' }}
         run: |
           api="https://crates.io/api/v1/crates/termlens"
           agent="termlens-install-check (github actions)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- **`Screen::diff`.** Two screens that differed printed as two whole grids;
+  `a.diff(&b)` renders only the rows that changed, side by side over a
+  marker line under the changed columns, the size and cursor deltas, a count
+  of unchanged rows and the style runs before → after. `is_empty()` and
+  `cells()` for assertions; `assert!(a.diff(&b).is_empty(), "{}", a.diff(&b))`
+  is the documented way to compare two screens outside insta. A `wait_frame`
+  timeout now shows the diff from the frame it last returned to the live
+  screen. Plain text, so CI logs stay readable. (#246)
+
+- **`Screen::to_ansi`, `to_svg`, `to_html`.** Three renderings a person can
+  see — paste the ANSI into a terminal and the failure is on screen in
+  colour; the SVG is self-contained for a bug report or a README; the HTML
+  is a `<pre>` of `<span style>`s for a step summary or a PR comment. Pure
+  functions of the cells and styles, no dependency, a wide character one
+  glyph over two columns. (#248)
+
+- **A `serde` feature** (off by default): `Serialize`/`Deserialize` on
+  `Screen`, `Cell`, `Style`, `Color`, `CursorShape`, `MouseMode`,
+  `MouseModes`, `Link`, `Clipboard` and the graphics types. A `Screen` is
+  rows of cells, so a JSON snapshot diffs by row; `Color` is a tagged enum
+  (`{"indexed": 1}`, `{"rgb": [30, 30, 46]}`) so nothing needs a parser on
+  the way back; deserializing re-checks that every row holds exactly `cols`
+  cells. `insta::assert_json_snapshot!(t.screen())` works. (#247)
+
 - **`Screen::find_all`.** Every occurrence of a needle in reading order,
   from the same scan `find` is the first element of — NFC-folded, trimmed
   per row, real columns across wide characters — so the two cannot drift.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ cargo clippy --workspace --all-targets -- -D warnings    # default features: wha
 cargo test --workspace --no-default-features
 cargo test --workspace --no-default-features --features decode
 cargo test --workspace --no-default-features --features regex
+cargo test --workspace --no-default-features --features serde
 cargo test --workspace                                   # default features
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
+ "serde",
  "similar",
  "tempfile",
 ]
@@ -460,6 +461,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +618,8 @@ dependencies = [
  "miniz_oxide",
  "portable-pty",
  "regex",
+ "serde",
+ "serde_json",
  "thiserror 2.0.20",
  "unicode-normalization",
  "unicode-width",
@@ -738,3 +784,9 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,13 @@ miniz_oxide = "0.9"
 # The `regex` feature: a pattern over a row of the screen, for the
 # expect-style wait and for masking volatile content by shape.
 regex = "1"
+# The `serde` feature: a Screen as JSON, and back. `rc` because the grid and
+# the out-of-band state live behind `Arc`s so a snapshot stays cheap.
+serde = { version = "1", features = ["derive", "rc"] }
+serde_json = "1"
 
 # Dev / fixture dependencies.
-insta = "1.48"
+insta = { version = "1.48", features = ["json"] }
 anyhow = "1"
 crossterm = "0.29"
 

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -32,6 +32,13 @@ decode = ["dep:miniz_oxide"]
 # reason: a suite that matches literal text should not pay for a regex
 # engine.
 regex = ["dep:regex"]
+# `Serialize`/`Deserialize` for `Screen`, `Cell`, `Style`, `Color` and the
+# out-of-band state, so a screen can leave a test as JSON — for
+# `insta::assert_json_snapshot!` with structured redactions, a CI step that
+# renders the failing screen, or a consumer in another language — and come
+# back as an equal `Screen`. Off by default; `serde` is already in most
+# consumers' trees, so the cost when on is a set of derives.
+serde = ["dep:serde"]
 
 [dependencies]
 portable-pty.workspace = true
@@ -45,12 +52,14 @@ unicode-width.workspace = true
 insta = { workspace = true, optional = true }
 miniz_oxide = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+serde_json.workspace = true
 anyhow.workspace = true
 
 [lints]

--- a/crates/termlens/examples/inspect.rs
+++ b/crates/termlens/examples/inspect.rs
@@ -35,7 +35,7 @@ use termlens::Terminal;
 /// 0, a missing program prints it to stderr and exits 1 (#229).
 const USAGE: &str = "\
 usage: inspect [--size COLSxROWS] [--timeout SECONDS] [--idle MILLIS]
-               [--inherit-env] [--env KEY=VALUE]... <program> [args…]
+               [--inherit-env] [--ansi] [--env KEY=VALUE]... <program> [args…]
 
 Runs <program> in an 80x24 pseudo-terminal (or --size), waits for it to
 exit or for the deadline (--timeout, default 5 seconds), and prints the
@@ -69,6 +69,17 @@ fn take<T>(
     parse(&raw).ok_or_else(|| format!("bad {flag} {raw:?}, expected e.g. {example}"))
 }
 
+/// The text rendering, or with `--ansi` the header over the screen in colour.
+fn render(screen: &termlens::Screen, ansi: bool) -> String {
+    if ansi {
+        let header = screen.to_string();
+        let header = header.lines().next().unwrap_or_default();
+        format!("{header}\n{}", screen.to_ansi())
+    } else {
+        screen.to_string()
+    }
+}
+
 fn main() -> ExitCode {
     let mut args = std::env::args().skip(1).peekable();
 
@@ -76,6 +87,7 @@ fn main() -> ExitCode {
     let mut timeout = Duration::from_secs(5);
     let mut idle = Duration::from_millis(300);
     let mut inherit_env = false;
+    let mut ansi = false;
     let mut env = Vec::new();
 
     // Options come before the program; everything after it is the
@@ -103,6 +115,13 @@ fn main() -> ExitCode {
                 .map(|millis| idle = Duration::from_millis(millis)),
             "--inherit-env" => {
                 inherit_env = true;
+                Ok(())
+            }
+            // The screen in colour, for a person: every cell painted through
+            // the SGR its style derives to, so what the program showed is
+            // shown rather than described by a `styles:` block.
+            "--ansi" => {
+                ansi = true;
                 Ok(())
             }
             "--env" => take(&mut args, "--env", "KEY=VALUE", "NO_COLOR=1", |s| {
@@ -148,7 +167,7 @@ fn main() -> ExitCode {
     let mut out = String::new();
     match t.wait_exit() {
         Ok(status) => {
-            out.push_str(&t.screen().to_string());
+            out.push_str(&render(&t.screen(), ansi));
             out.push_str(&format!("\n--- exited: {status} ---\n"));
         }
         Err(termlens::Error::Timeout { .. }) => {
@@ -156,13 +175,13 @@ fn main() -> ExitCode {
             // instead. The settle is bounded by the deadline too, unless the
             // silence window asked for is itself longer than that.
             let _ = t.wait_idle_for(idle, timeout.max(idle));
-            out.push_str(&t.screen().to_string());
+            out.push_str(&render(&t.screen(), ansi));
             out.push_str("\n--- still running at the deadline (killed on exit) ---\n");
         }
         Err(e) => {
             // Not "still running": the OS wait itself failed, and saying so
             // is the difference between a slow program and a broken harness.
-            out.push_str(&t.screen().to_string());
+            out.push_str(&render(&t.screen(), ansi));
             out.push_str(&format!("\n--- waiting for the program failed: {e} ---\n"));
         }
     }

--- a/crates/termlens/src/graphics.rs
+++ b/crates/termlens/src/graphics.rs
@@ -51,6 +51,11 @@ pub(crate) const HISTORY: usize = 512;
 /// Which protocol carried a payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum GraphicsProtocol {
     /// The kitty graphics protocol: `APC G <control> ; <base64> ST`.
     Kitty,
@@ -77,6 +82,11 @@ impl fmt::Display for GraphicsProtocol {
 /// answer with the number of *escapes* instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum GraphicsAction {
     /// `a=t`: transmit the data, place it later.
     Transmit,
@@ -108,6 +118,11 @@ impl GraphicsAction {
 /// How the pixels in a payload are encoded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum GraphicsFormat {
     /// kitty `f=24`: three bytes a pixel.
     Rgb,
@@ -141,6 +156,7 @@ impl fmt::Display for GraphicsFormat {
 /// application stated or the wire carried — nothing here is inferred from a
 /// rendering, because there is no rendering.
 #[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GraphicsPayload {
     protocol: GraphicsProtocol,
     action: GraphicsAction,
@@ -753,6 +769,7 @@ fn decode_sixel(data: &[u8]) -> Result<Bitmap, DecodeError> {
 /// than resetting a gauge; [`payloads`](Self::payloads) is the bounded tail
 /// of what was captured.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GraphicsSeen {
     pub(crate) counts: GraphicsCounts,
     pub(crate) payloads: Arc<Vec<GraphicsPayload>>,
@@ -766,6 +783,7 @@ impl GraphicsSeen {
 
 /// The cumulative counters, kept by the sequence tracker as bytes arrive.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct GraphicsCounts {
     pub(crate) kitty: u32,
     pub(crate) sixel: u32,

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -124,7 +124,9 @@ pub use graphics::{
     GraphicsAction, GraphicsFormat, GraphicsPayload, GraphicsProtocol, GraphicsSeen,
 };
 pub use keys::{Chord, Input, Key};
-pub use screen::{Cell, Clipboard, Color, CursorShape, Link, MouseMode, MouseModes, Screen, Style};
+pub use screen::{
+    Cell, Clipboard, Color, CursorShape, Link, MouseMode, MouseModes, Screen, ScreenDiff, Style,
+};
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -12,6 +12,13 @@ use unicode_normalization::UnicodeNormalization;
 
 use crate::graphics::GraphicsSeen;
 
+mod diff;
+mod render;
+#[cfg(feature = "serde")]
+mod serde_impl;
+
+pub use diff::ScreenDiff;
+
 /// A terminal color, as reported by the emulator.
 ///
 /// Deliberately *not* `#[non_exhaustive]`, unlike [`Key`](crate::Key) and
@@ -23,6 +30,11 @@ use crate::graphics::GraphicsSeen;
 /// equality (`cell.style().fg == Color::Indexed(1)`) is unaffected either
 /// way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum Color {
     /// The terminal's default foreground/background.
     #[default]
@@ -42,6 +54,7 @@ pub enum Color {
 /// relevant to the assertion rather than using a struct literal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Style {
     /// Foreground color.
     pub fg: Color,
@@ -87,6 +100,11 @@ pub struct Style {
 /// encode exactly what the application expects.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum MouseMode {
     /// No mouse tracking enabled.
     #[default]
@@ -150,6 +168,7 @@ impl MouseMode {
 /// # }
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MouseModes(u8);
 
 impl MouseModes {
@@ -213,6 +232,11 @@ impl fmt::Debug for MouseModes {
 /// [`Screen::alternate_screen`] already catches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum CursorShape {
     /// The application never sent `DECSCUSR`, so the cursor is whatever the
     /// terminal draws by default.
@@ -237,6 +261,7 @@ pub enum CursorShape {
 /// proves the copy path ran; this proves the payload, which is usually the
 /// behaviour actually under test.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Clipboard {
     targets: Arc<str>,
     text: Option<Arc<str>>,
@@ -285,6 +310,7 @@ impl Clipboard {
 /// or linked the wrong URL**. That is the failure
 /// [`Screen::clipboard`] exists to prevent for `OSC 52`, in the same shape.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Link {
     uri: Arc<str>,
     id: Option<Arc<str>>,
@@ -368,6 +394,7 @@ impl Link {
 /// bumps one refcount instead of copying every field, which matters because
 /// a clone happens on each wait evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct TermState {
     pub(crate) title: Arc<str>,
     pub(crate) alternate_screen: bool,
@@ -447,6 +474,7 @@ impl Default for TermState {
 
 /// One cell of the screen grid.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cell {
     contents: String,
     style: Style,
@@ -1788,12 +1816,12 @@ fn clamp_range(range: &impl RangeBounds<u16>, len: u16, axis: &str) -> (u16, u16
 
 impl Style {
     /// True when every attribute is at its default.
-    fn is_default(&self) -> bool {
+    pub(crate) fn is_default(&self) -> bool {
         *self == Style::default()
     }
 
     /// Fixed-order tokens for the `styles:` block (see `docs/DESIGN.md` §3).
-    fn tokens(&self) -> String {
+    pub(crate) fn tokens(&self) -> String {
         fn color(prefix: &str, color: Color, out: &mut Vec<String>) {
             match color {
                 Color::Default => {}

--- a/crates/termlens/src/screen/diff.rs
+++ b/crates/termlens/src/screen/diff.rs
@@ -1,0 +1,226 @@
+//! [`Screen::diff`]: what changed between two screens, rendered as only
+//! the rows that changed with the changed columns marked (#246). A 24-row
+//! grid printed twice hides exactly the failure a TUI test produces — one
+//! cell moved, one colour changed — and the derived `Debug` of a `Screen`
+//! is deliberately the compact `Display`, right for one screen and
+//! unhelpful for two. This is the other half of the "readable failures"
+//! promise the embedded screens started.
+
+use std::fmt;
+
+use super::{Cell, Screen, Style};
+
+/// The difference between two screens. Built by [`Screen::diff`]; render it
+/// with `{}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreenDiff {
+    before_size: (u16, u16),
+    after_size: (u16, u16),
+    before_cursor: (u16, u16, bool),
+    after_cursor: (u16, u16, bool),
+    /// `(row, col, before, after)` for every cell — within the overlap of
+    /// the two grids — whose contents or style differ, in reading order.
+    cells: Vec<(u16, u16, Cell, Cell)>,
+    /// Rows within the overlap with no changed cell.
+    unchanged_rows: u16,
+    /// The `styles:` runs of each changed row, before and after, where
+    /// they differ.
+    style_changes: Vec<(u16, String, String)>,
+    /// The rows of the taller screen whose text is in the diff.
+    rows: Vec<(u16, String, String, Vec<u16>)>,
+}
+
+impl Screen {
+    /// What changed from `self` to `other`: every cell whose contents or
+    /// style differ, the cursor and size deltas, and the style runs of the
+    /// rows that changed. Empty when the two screens show the same picture
+    /// — size, cursor and every cell — which is narrower than `==`, since
+    /// the out-of-band state (bells, repaints, title) is not a picture.
+    ///
+    /// The documented way to compare two screens outside insta:
+    ///
+    /// ```
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().args(["-c", "printf 'Counter: 1'; read q"]).spawn("sh")?;
+    /// # t.wait_until(|s| s.contains("Counter: 1"))?;
+    /// let a = t.screen();
+    /// let b = t.screen();
+    /// assert!(a.diff(&b).is_empty(), "{}", a.diff(&b));
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Sizes that differ diff what overlaps, and the rendering says what was
+    /// clipped. The rendering is plain text — no colour, so CI logs stay
+    /// readable — and shows only the rows that changed, with a marker line
+    /// under the changed columns and the style runs before and after.
+    #[must_use]
+    pub fn diff(&self, other: &Screen) -> ScreenDiff {
+        let cols = self.cols().min(other.cols());
+        let rows = self.rows().min(other.rows());
+        let mut cells = Vec::new();
+        let mut rows_out = Vec::new();
+        let mut style_changes = Vec::new();
+        let mut unchanged_rows = 0;
+        for row in 0..rows {
+            let mut changed_cols = Vec::new();
+            for col in 0..cols {
+                let (Some(a), Some(b)) = (self.cell(row, col), other.cell(row, col)) else {
+                    continue;
+                };
+                if a != b {
+                    changed_cols.push(col);
+                    cells.push((row, col, a.clone(), b.clone()));
+                }
+            }
+            if changed_cols.is_empty() {
+                unchanged_rows += 1;
+                continue;
+            }
+            rows_out.push((
+                row,
+                self.row_text(row).trim_end().to_owned(),
+                other.row_text(row).trim_end().to_owned(),
+                changed_cols,
+            ));
+            let before = row_styles(self, row);
+            let after = row_styles(other, row);
+            if before != after {
+                style_changes.push((row, before, after));
+            }
+        }
+        ScreenDiff {
+            before_size: self.size(),
+            after_size: other.size(),
+            before_cursor: self.cursor(),
+            after_cursor: other.cursor(),
+            cells,
+            unchanged_rows,
+            style_changes,
+            rows: rows_out,
+        }
+    }
+}
+
+/// One row's `styles:` runs, `(none)` for an all-default row — the same
+/// tokens `with_styles` renders, so a diff and a snapshot agree.
+pub(super) fn row_styles(screen: &Screen, row: u16) -> String {
+    let mut spans: Vec<String> = Vec::new();
+    let mut run: Option<(u16, u16, Style)> = None;
+    let flush = |run: Option<(u16, u16, Style)>, spans: &mut Vec<String>| {
+        if let Some((start, end, style)) = run {
+            if !style.is_default() {
+                let range = if start == end {
+                    format!("{start}")
+                } else {
+                    format!("{start}-{end}")
+                };
+                spans.push(format!("{range} {}", style.tokens()));
+            }
+        }
+    };
+    for col in 0..screen.cols() {
+        let style = screen
+            .cell(row, col)
+            .map_or_else(Style::default, |cell| *cell.style());
+        match &mut run {
+            Some((_, end, current)) if *current == style => *end = col,
+            _ => {
+                flush(run.take(), &mut spans);
+                run = Some((col, col, style));
+            }
+        }
+    }
+    flush(run, &mut spans);
+    if spans.is_empty() {
+        "(none)".to_owned()
+    } else {
+        spans.join("; ")
+    }
+}
+
+impl ScreenDiff {
+    /// True when the two screens show the same picture: same size, same
+    /// cursor, every cell equal.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.cells.is_empty()
+            && self.before_size == self.after_size
+            && self.before_cursor == self.after_cursor
+    }
+
+    /// Every changed cell as `(row, col, before, after)`, in reading order,
+    /// within the overlap of the two grids.
+    pub fn cells(&self) -> impl Iterator<Item = (u16, u16, &Cell, &Cell)> {
+        self.cells.iter().map(|(r, c, a, b)| (*r, *c, a, b))
+    }
+}
+
+/// `a → b` when they differ, `a` alone when they do not.
+fn arrow<T: PartialEq + fmt::Display>(a: T, b: T) -> String {
+    if a == b {
+        a.to_string()
+    } else {
+        format!("{a} → {b}")
+    }
+}
+
+fn cursor_text((row, col, visible): (u16, u16, bool)) -> String {
+    if visible {
+        format!("{row},{col}")
+    } else {
+        "hidden".to_owned()
+    }
+}
+
+impl fmt::Display for ScreenDiff {
+    /// Header with the size and cursor deltas; then, for each changed row,
+    /// the row before and after side by side over a marker line with `^`
+    /// under every changed column; a count of unchanged rows; and the
+    /// style runs of the changed rows before and after, where they differ.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return write!(f, "no difference");
+        }
+        writeln!(
+            f,
+            "size: {}   cursor: {}",
+            arrow(
+                format!("{}x{}", self.before_size.0, self.before_size.1),
+                format!("{}x{}", self.after_size.0, self.after_size.1)
+            ),
+            arrow(
+                cursor_text(self.before_cursor),
+                cursor_text(self.after_cursor)
+            )
+        )?;
+        if self.before_size != self.after_size {
+            let cols = self.before_size.0.min(self.after_size.0);
+            let rows = self.before_size.1.min(self.after_size.1);
+            writeln!(
+                f,
+                "compared over the {cols}x{rows} overlap; the rest is clipped"
+            )?;
+        }
+        let width = usize::from(self.before_size.0.min(self.after_size.0));
+        for (row, before, after, changed) in &self.rows {
+            writeln!(f, "{row:>3} │{before:<width$}│{after}")?;
+            let mut marks = vec![' '; width];
+            for &col in changed {
+                if let Some(mark) = marks.get_mut(usize::from(col)) {
+                    *mark = '^';
+                }
+            }
+            let marks: String = marks.into_iter().collect();
+            let marks = marks.trim_end();
+            writeln!(f, "    │{marks:<width$}│{marks}")?;
+        }
+        if self.unchanged_rows > 0 {
+            writeln!(f, "… {} rows unchanged", self.unchanged_rows)?;
+        }
+        for (row, before, after) in &self.style_changes {
+            writeln!(f, "styles: {row}: {before} → {after}")?;
+        }
+        Ok(())
+    }
+}

--- a/crates/termlens/src/screen/render.rs
+++ b/crates/termlens/src/screen/render.rs
@@ -1,0 +1,326 @@
+//! Renderings of a [`Screen`] a person can *see*: ANSI for a terminal, SVG
+//! for a bug report or a README, HTML for a pull request or a step summary
+//! (#248). All three are pure functions of the screen, derived straight
+//! from its cells and styles, treat a wide character as one glyph over two
+//! columns, and need no dependency.
+
+use std::fmt::Write as _;
+
+use super::{Cell, Color, Screen, Style};
+
+/// The colour a default foreground renders as where a real colour is
+/// needed (SVG, HTML); the ANSI rendering leaves the terminal's own.
+const DEFAULT_FG: &str = "#d4d4d4";
+/// Same for the background.
+const DEFAULT_BG: &str = "#1e1e1e";
+
+/// The xterm 256-colour palette as `#rrggbb`.
+fn palette(index: u8) -> String {
+    const ANSI: [&str; 16] = [
+        "#000000", "#cd3131", "#0dbc79", "#e5e510", "#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5",
+        "#666666", "#f14c4c", "#23d18b", "#f5f543", "#3b8eea", "#d670d6", "#29b8db", "#ffffff",
+    ];
+    match index {
+        0..=15 => ANSI[usize::from(index)].to_owned(),
+        16..=231 => {
+            let i = index - 16;
+            let level = |v: u8| if v == 0 { 0 } else { 55 + 40 * u32::from(v) };
+            format!(
+                "#{:02x}{:02x}{:02x}",
+                level(i / 36),
+                level((i / 6) % 6),
+                level(i % 6)
+            )
+        }
+        232..=255 => {
+            let grey = 8 + 10 * u32::from(index - 232);
+            format!("#{grey:02x}{grey:02x}{grey:02x}")
+        }
+    }
+}
+
+fn css_color(color: Color, default: &str) -> String {
+    match color {
+        Color::Default => default.to_owned(),
+        Color::Indexed(i) => palette(i),
+        Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
+    }
+}
+
+/// The foreground and background a cell is *painted* with, reverse video
+/// applied, as CSS colours.
+fn painted(style: &Style) -> (String, String) {
+    let fg = css_color(style.fg, DEFAULT_FG);
+    let bg = css_color(style.bg, DEFAULT_BG);
+    if style.reverse {
+        (bg, fg)
+    } else {
+        (fg, bg)
+    }
+}
+
+/// The SGR parameters that set `style` from a reset terminal.
+fn sgr(style: &Style) -> String {
+    let mut params = vec!["0".to_owned()];
+    for (on, code) in [
+        (style.bold, "1"),
+        (style.dim, "2"),
+        (style.italic, "3"),
+        (style.underline, "4"),
+        (style.blink, "5"),
+        (style.reverse, "7"),
+        (style.conceal, "8"),
+        (style.strikethrough, "9"),
+    ] {
+        if on {
+            params.push(code.to_owned());
+        }
+    }
+    match style.fg {
+        Color::Default => {}
+        Color::Indexed(i @ 0..=7) => params.push((30 + u16::from(i)).to_string()),
+        Color::Indexed(i @ 8..=15) => params.push((82 + u16::from(i)).to_string()),
+        Color::Indexed(i) => params.push(format!("38;5;{i}")),
+        Color::Rgb(r, g, b) => params.push(format!("38;2;{r};{g};{b}")),
+    }
+    match style.bg {
+        Color::Default => {}
+        Color::Indexed(i @ 0..=7) => params.push((40 + u16::from(i)).to_string()),
+        Color::Indexed(i @ 8..=15) => params.push((92 + u16::from(i)).to_string()),
+        Color::Indexed(i) => params.push(format!("48;5;{i}")),
+        Color::Rgb(r, g, b) => params.push(format!("48;2;{r};{g};{b}")),
+    }
+    format!("\x1b[{}m", params.join(";"))
+}
+
+/// What a cell shows: its text, or a space for a blank.
+fn glyph(cell: &Cell) -> &str {
+    if cell.contents().is_empty() {
+        " "
+    } else {
+        cell.contents()
+    }
+}
+
+fn escape_xml(text: &str, out: &mut String) {
+    for c in text.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            other => out.push(other),
+        }
+    }
+}
+
+/// One row as runs of consecutive cells sharing a style, wide
+/// continuations folded into the cell before them: `(start col, width
+/// in columns, style, text)`.
+fn runs(screen: &Screen, row: u16) -> Vec<(u16, u16, Style, String)> {
+    let mut runs: Vec<(u16, u16, Style, String)> = Vec::new();
+    for col in 0..screen.cols() {
+        let Some(cell) = screen.cell(row, col) else {
+            break;
+        };
+        if cell.is_wide_continuation() {
+            if let Some(last) = runs.last_mut() {
+                last.1 += 1;
+            }
+            continue;
+        }
+        let style = *cell.style();
+        match runs.last_mut() {
+            Some(last) if last.2 == style => {
+                last.1 += 1;
+                last.3.push_str(glyph(cell));
+            }
+            _ => runs.push((col, 1, style, glyph(cell).to_owned())),
+        }
+    }
+    runs
+}
+
+impl Screen {
+    /// The screen as ANSI: one line per row, every cell painted through SGR
+    /// sequences derived from its [`Style`], a reset at each row's end, a
+    /// newline after every row. Paste it into a terminal and the failure is
+    /// on screen, in colour, in the shape the user saw. The cursor is not
+    /// encoded; it is in the header of the text rendering.
+    ///
+    /// Concealed text is emitted as `SGR 8` and left to the terminal, as a
+    /// real one would; default colours are left to the terminal too.
+    #[must_use]
+    pub fn to_ansi(&self) -> String {
+        let mut out = String::new();
+        for row in 0..self.rows() {
+            for (_, _, style, text) in runs(self, row) {
+                if !style.is_default() {
+                    out.push_str(&sgr(&style));
+                }
+                out.push_str(&text);
+                if !style.is_default() {
+                    out.push_str("\x1b[0m");
+                }
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    /// The screen as a self-contained SVG: a `<rect>` per background run, a
+    /// `<text>` per foreground run, fixed cell metrics (9×18 px), a
+    /// monospace fallback font stack and no font embedding — enough for a
+    /// bug report or a README, not a typeset transcript. Concealed text is
+    /// drawn as blanks, as a terminal shows it; dim is opacity.
+    #[must_use]
+    pub fn to_svg(&self) -> String {
+        const CELL_W: u32 = 9;
+        const CELL_H: u32 = 18;
+        let width = u32::from(self.cols()) * CELL_W;
+        let height = u32::from(self.rows()) * CELL_H;
+        let mut out = String::new();
+        let _ = writeln!(
+            out,
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width}\" height=\"{height}\" \
+             viewBox=\"0 0 {width} {height}\" font-family=\"'JetBrains Mono', 'Fira Code', \
+             Menlo, Consolas, 'DejaVu Sans Mono', monospace\" font-size=\"14\">"
+        );
+        let _ = writeln!(
+            out,
+            "<rect width=\"{width}\" height=\"{height}\" fill=\"{DEFAULT_BG}\"/>"
+        );
+        for row in 0..self.rows() {
+            let y = u32::from(row) * CELL_H;
+            for (col, cols, style, text) in runs(self, row) {
+                let (fg, bg) = painted(&style);
+                let x = u32::from(col) * CELL_W;
+                if bg != DEFAULT_BG {
+                    let _ = writeln!(
+                        out,
+                        "<rect x=\"{x}\" y=\"{y}\" width=\"{}\" height=\"{CELL_H}\" fill=\"{bg}\"/>",
+                        u32::from(cols) * CELL_W
+                    );
+                }
+                // Trailing blanks draw nothing as text — the background run
+                // above is what paints them — so the element carries only
+                // the glyphs. Concealed text is blanks, as a terminal shows it.
+                let shown = if style.conceal { "" } else { text.trim_end() };
+                if shown.is_empty() {
+                    continue;
+                }
+                let _ = write!(
+                    out,
+                    "<text x=\"{x}\" y=\"{}\" fill=\"{fg}\" xml:space=\"preserve\"",
+                    y + 14
+                );
+                if style.bold {
+                    out.push_str(" font-weight=\"bold\"");
+                }
+                if style.italic {
+                    out.push_str(" font-style=\"italic\"");
+                }
+                if style.dim {
+                    out.push_str(" opacity=\"0.6\"");
+                }
+                let mut decoration = Vec::new();
+                if style.underline {
+                    decoration.push("underline");
+                }
+                if style.strikethrough {
+                    decoration.push("line-through");
+                }
+                if !decoration.is_empty() {
+                    let _ = write!(out, " text-decoration=\"{}\"", decoration.join(" "));
+                }
+                out.push('>');
+                escape_xml(shown, &mut out);
+                out.push_str("</text>\n");
+            }
+        }
+        out.push_str("</svg>\n");
+        out
+    }
+
+    /// The screen as HTML: a `<pre>` with one `<span style>` per run, so it
+    /// pastes into a GitHub step summary or a pull-request comment. The
+    /// same run model as [`to_svg`](Self::to_svg); concealed text is shown
+    /// as blanks.
+    #[must_use]
+    pub fn to_html(&self) -> String {
+        let mut out = format!(
+            "<pre style=\"background:{DEFAULT_BG};color:{DEFAULT_FG};font-family:monospace;\
+             line-height:1.2;padding:8px\">"
+        );
+        for row in 0..self.rows() {
+            for (_, cols, style, text) in runs(self, row) {
+                let shown: String = if style.conceal {
+                    " ".repeat(usize::from(cols))
+                } else {
+                    text
+                };
+                if style.is_default() {
+                    escape_xml(&shown, &mut out);
+                    continue;
+                }
+                let (fg, bg) = painted(&style);
+                let mut css = format!("color:{fg};background:{bg}");
+                if style.bold {
+                    css.push_str(";font-weight:bold");
+                }
+                if style.italic {
+                    css.push_str(";font-style:italic");
+                }
+                if style.dim {
+                    css.push_str(";opacity:0.6");
+                }
+                let mut decoration = Vec::new();
+                if style.underline {
+                    decoration.push("underline");
+                }
+                if style.strikethrough {
+                    decoration.push("line-through");
+                }
+                if !decoration.is_empty() {
+                    let _ = write!(css, ";text-decoration:{}", decoration.join(" "));
+                }
+                let _ = write!(out, "<span style=\"{css}\">");
+                escape_xml(&shown, &mut out);
+                out.push_str("</span>");
+            }
+            out.push('\n');
+        }
+        out.push_str("</pre>\n");
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_palette_is_xterms() {
+        assert_eq!(palette(1), "#cd3131");
+        assert_eq!(palette(16), "#000000");
+        assert_eq!(palette(21), "#0000ff");
+        assert_eq!(palette(196), "#ff0000");
+        assert_eq!(palette(232), "#080808");
+        assert_eq!(palette(255), "#eeeeee");
+    }
+
+    #[test]
+    fn sgr_sets_the_style_from_a_reset() {
+        let mut style = Style {
+            bold: true,
+            fg: Color::Indexed(1),
+            bg: Color::Rgb(30, 30, 46),
+            ..Style::default()
+        };
+        assert_eq!(sgr(&style), "\x1b[0;1;31;48;2;30;30;46m");
+        style.fg = Color::Indexed(9);
+        assert_eq!(sgr(&style), "\x1b[0;1;91;48;2;30;30;46m");
+        style.fg = Color::Indexed(200);
+        assert_eq!(sgr(&style), "\x1b[0;1;38;5;200;48;2;30;30;46m");
+    }
+}

--- a/crates/termlens/src/screen/serde_impl.rs
+++ b/crates/termlens/src/screen/serde_impl.rs
@@ -1,0 +1,101 @@
+//! `Serialize`/`Deserialize` for [`Screen`] (feature `serde`).
+//!
+//! The shape is **rows of cells**, not a flat vector, so a JSON snapshot
+//! diffs by row; the header fields and the out-of-band state ride beside
+//! the grid. Reading a screen back re-establishes the one invariant
+//! `from_parts` only debug-asserts — every row holds exactly `cols` cells
+//! and there are exactly `rows` of them — through a validating constructor
+//! rather than a bare derive, so a hand-edited or truncated file is an
+//! error and never a screen that panics on its first `cell()`.
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::{Cell, Screen, TermState};
+
+/// The cursor as three named fields rather than a tuple, so the JSON reads.
+#[derive(Serialize, Deserialize)]
+struct Cursor {
+    row: u16,
+    col: u16,
+    visible: bool,
+}
+
+/// What a [`Screen`] is on the wire.
+#[derive(Serialize)]
+struct Wire<'a> {
+    cols: u16,
+    rows: u16,
+    cursor: Cursor,
+    cells: Vec<&'a [Cell]>,
+    state: &'a TermState,
+}
+
+#[derive(Deserialize)]
+struct OwnedWire {
+    cols: u16,
+    rows: u16,
+    cursor: Cursor,
+    cells: Vec<Vec<Cell>>,
+    state: TermState,
+}
+
+impl Serialize for Screen {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let width = usize::from(self.cols).max(1);
+        Wire {
+            cols: self.cols,
+            rows: self.rows,
+            cursor: Cursor {
+                row: self.cursor_row,
+                col: self.cursor_col,
+                visible: self.cursor_visible,
+            },
+            cells: self.cells.chunks(width).collect(),
+            state: &self.state,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Screen {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let wire = OwnedWire::deserialize(deserializer)?;
+        if wire.cells.len() != usize::from(wire.rows) {
+            return Err(D::Error::custom(format!(
+                "a {}x{} screen needs {} rows of cells, not {}",
+                wire.cols,
+                wire.rows,
+                wire.rows,
+                wire.cells.len()
+            )));
+        }
+        if let Some((row, cells)) = wire
+            .cells
+            .iter()
+            .enumerate()
+            .find(|(_, row)| row.len() != usize::from(wire.cols))
+        {
+            return Err(D::Error::custom(format!(
+                "row {row} of a {}-column screen holds {} cells",
+                wire.cols,
+                cells.len()
+            )));
+        }
+        if wire.cursor.row >= wire.rows.max(1) || wire.cursor.col > wire.cols {
+            return Err(D::Error::custom(format!(
+                "cursor {},{} is outside a {}x{} screen",
+                wire.cursor.row, wire.cursor.col, wire.cols, wire.rows
+            )));
+        }
+        Ok(Screen::from_parts(
+            wire.cols,
+            wire.rows,
+            wire.cursor.row,
+            wire.cursor.col,
+            wire.cursor.visible,
+            wire.cells.into_iter().flatten().collect(),
+            wire.state,
+        ))
+    }
+}

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1762,6 +1762,7 @@ impl TerminalBuilder {
             exit_status: None,
             command_desc,
             frame_cursor: 0,
+            last_frame: None,
             cell_size: self.cell_size,
         })
     }
@@ -2246,6 +2247,9 @@ pub struct Terminal {
     /// satisfy two waits. Advanced by a resize too: a frame drawn at the
     /// old size is not the repaint that answers the new one.
     frame_cursor: u64,
+    /// The frame `wait_frame` last returned, so a timeout can show what
+    /// changed since rather than the live grid alone (#246).
+    last_frame: Option<Screen>,
     /// Declared pixels per cell, kept so a resize can recompute the PTY's
     /// pixel geometry rather than silently dropping it.
     cell_size: Option<(u16, u16)>,
@@ -3142,6 +3146,7 @@ impl Terminal {
         match outcome {
             Ok(Ok((index, frame))) => {
                 self.frame_cursor = index;
+                self.last_frame = Some(frame.clone());
                 Ok(frame)
             }
             Ok(Err(e)) => Err(e),
@@ -3151,7 +3156,9 @@ impl Terminal {
                 // the only evidence there is. The last completed frame
                 // can be arbitrarily old — it is named in `waiting_for`
                 // instead, where it reads as a count rather than a
-                // picture that claims to be current.
+                // picture that claims to be current — and what changed
+                // between that frame and the live grid is shown as a diff,
+                // which is the question a stuck wait actually asks.
                 let (frames, screen, note) = {
                     let mut guard = self.shared.lock();
                     let screen = guard.snapshot();
@@ -3188,6 +3195,13 @@ impl Terminal {
                         "{WHAT} ({} since the last one returned, {frames} in total){note}",
                         frames_phrase(frames - cursor)
                     )
+                };
+                let waiting_for = match &self.last_frame {
+                    Some(last) if !last.diff(&screen).is_empty() => format!(
+                        "{waiting_for}\n--- last returned frame → live screen ---\n{}",
+                        last.diff(&screen)
+                    ),
+                    _ => waiting_for,
                 };
                 Err(Error::Timeout {
                     waiting_for,

--- a/crates/termlens/tests/export.rs
+++ b/crates/termlens/tests/export.rs
@@ -1,0 +1,185 @@
+//! Leaving a test: `Screen::diff` (#246), the ANSI/SVG/HTML renderings
+//! (#248) and, with the `serde` feature, a `Screen` as JSON and back (#247).
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+
+fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
+    common::spawn_emit(
+        Terminal::builder()
+            .size(30, 4)
+            .timeout(Duration::from_secs(10)),
+        steps,
+    )
+}
+
+/// A small styled screen every rendering below is made from: a bold cyan
+/// title, a reverse-video highlight, a dim note, a concealed field, a wide
+/// character and an RGB background.
+fn styled() -> termlens::Result<Terminal> {
+    emit(&[
+        "--raw",
+        r"\e[1;36mmyapp\e[0m  \e[7m> Alpha\e[0m  汉字\n",
+        "--raw",
+        r"\e[2mnote\e[0m pw: \e[8msecret\e[28m \e[48;2;30;30;46m  \e[0m\nDONE",
+        "--wait",
+    ])
+}
+
+#[test]
+fn a_diff_shows_only_what_changed_and_where() -> termlens::Result<()> {
+    let mut t = emit(&[
+        "--raw",
+        r"Counter: 1\n\e[7m> Quit\e[0m\nrow three\nrow four",
+        "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("row four"))?;
+    let a = t.screen();
+    t.send(Key::Enter)?;
+    t.wait_exit()?;
+    let mut t = emit(&[
+        "--raw",
+        r"Counter: 2\n  Quit\nrow three\nrow four",
+        "--wait",
+    ])?;
+    t.wait_until(|s| s.contains("row four"))?;
+    let b = t.screen();
+
+    let diff = a.diff(&b);
+    assert!(!diff.is_empty());
+    let changed: Vec<(u16, u16)> = diff.cells().map(|(r, c, _, _)| (r, c)).collect();
+    // The digit, and every cell of the highlighted word plus the marker.
+    assert_eq!(changed[0], (0, 9), "{diff}");
+    assert!(
+        changed.iter().all(|&(r, _)| r <= 1),
+        "rows 2 and 3 are unchanged: {diff}"
+    );
+    assert!(a.diff(&a).is_empty());
+    assert_eq!(a.diff(&a).to_string(), "no difference");
+    insta::assert_snapshot!("diff_rendering", diff.to_string());
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn sizes_that_differ_diff_the_overlap_and_say_so() -> termlens::Result<()> {
+    let mut a = emit(&["same\nDONE", "--wait"])?;
+    a.wait_until(|s| s.contains("DONE"))?;
+    let mut b = common::spawn_emit(
+        Terminal::builder()
+            .size(20, 6)
+            .timeout(Duration::from_secs(10)),
+        &["same\nDONE", "--wait"],
+    )?;
+    b.wait_until(|s| s.contains("DONE"))?;
+    let diff = a.screen().diff(&b.screen());
+    assert!(!diff.is_empty(), "a size change is a change");
+    assert_eq!(diff.cells().count(), 0, "the overlap is identical: {diff}");
+    let text = diff.to_string();
+    assert!(text.contains("size: 30x4 → 20x6"), "{text}");
+    assert!(text.contains("compared over the 20x4 overlap"), "{text}");
+    a.send(Key::Enter)?;
+    b.send(Key::Enter)?;
+    Ok(())
+}
+
+#[test]
+fn the_three_renderings_are_pure_functions_of_the_screen() -> termlens::Result<()> {
+    let mut t = styled()?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    let ansi = s.to_ansi();
+    assert_eq!(ansi.lines().count(), 4, "one line per row");
+    assert!(ansi.contains("\x1b[0;1;36mmyapp\x1b[0m"), "{ansi:?}");
+    assert!(ansi.contains("\x1b[0;7m> Alpha\x1b[0m"), "{ansi:?}");
+    assert!(
+        ansi.contains("\x1b[0;8msecret\x1b[0m"),
+        "concealed is the terminal's to hide: {ansi:?}"
+    );
+    let svg = s.to_svg();
+    assert!(
+        svg.starts_with("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"270\" height=\"72\""),
+        "{svg}"
+    );
+    assert!(
+        svg.contains("汉字</text>"),
+        "a wide character is one glyph: {svg}"
+    );
+    assert!(
+        !svg.contains("secret"),
+        "concealed text is drawn as blanks: {svg}"
+    );
+    assert!(
+        svg.contains("fill=\"#1e1e2e\""),
+        "the RGB background run: {svg}"
+    );
+    let html = s.to_html();
+    assert!(html.starts_with("<pre style="), "{html}");
+    assert!(html.contains("font-weight:bold\">myapp</span>"), "{html}");
+    assert!(!html.contains("secret"), "{html}");
+    insta::assert_snapshot!("styled_ansi", ansi);
+    insta::assert_snapshot!("styled_svg", svg);
+    insta::assert_snapshot!("styled_html", html);
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[cfg(feature = "serde")]
+mod json {
+    use super::*;
+
+    #[test]
+    #[cfg_attr(
+        windows,
+        ignore = "the JSON snapshot carries the out-of-band state, and ConPTY sets some of it itself — focus reporting on, the console's title — so it differs from the Unix recording (#149)"
+    )]
+    fn a_screen_round_trips_through_json_as_an_equal_screen() -> termlens::Result<()> {
+        let mut t = styled()?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let s = t.screen();
+        let json = serde_json::to_string(&s).expect("serializes");
+        let back: termlens::Screen = serde_json::from_str(&json).expect("deserializes");
+        assert_eq!(back, s, "an equal Screen, out-of-band state included");
+        assert!(back.diff(&s).is_empty());
+        // Rows of cells, and a tagged colour with no parser needed.
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["rows"], 4);
+        assert_eq!(value["cells"].as_array().unwrap().len(), 4);
+        assert_eq!(value["cells"][0].as_array().unwrap().len(), 30);
+        assert_eq!(
+            value["cells"][0][0]["style"]["fg"],
+            serde_json::json!({"indexed": 6})
+        );
+        assert_eq!(
+            value["cells"][1][17]["style"]["bg"],
+            serde_json::json!({"rgb": [30, 30, 46]})
+        );
+        insta::assert_json_snapshot!("styled_json", s);
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+        Ok(())
+    }
+
+    #[test]
+    fn a_screen_that_does_not_hold_together_is_refused() -> termlens::Result<()> {
+        let mut t = emit(&["ab\nDONE", "--wait"])?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let mut value: serde_json::Value = serde_json::to_value(t.screen()).unwrap();
+        // Drop one cell from the first row: the file no longer holds together.
+        value["cells"][0].as_array_mut().unwrap().pop();
+        let err = serde_json::from_value::<termlens::Screen>(value).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("row 0 of a 30-column screen holds 29 cells"),
+            "refused with a reason: {err}"
+        );
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+        Ok(())
+    }
+}

--- a/crates/termlens/tests/snapshots/export__diff_rendering.snap
+++ b/crates/termlens/tests/snapshots/export__diff_rendering.snap
@@ -1,0 +1,11 @@
+---
+source: crates/termlens/tests/export.rs
+expression: diff.to_string()
+---
+size: 30x4   cursor: 3,8
+  0 │Counter: 1                    │Counter: 2
+    │         ^                    │         ^
+  1 │> Quit                        │  Quit
+    │^^^^^^                        │^^^^^^
+… 2 rows unchanged
+styles: 1: 0-5 reverse → (none)

--- a/crates/termlens/tests/snapshots/export__json__styled_json.snap
+++ b/crates/termlens/tests/snapshots/export__json__styled_json.snap
@@ -1,0 +1,2122 @@
+---
+source: crates/termlens/tests/export.rs
+expression: s
+---
+{
+  "cols": 30,
+  "rows": 4,
+  "cursor": {
+    "row": 2,
+    "col": 4,
+    "visible": true
+  },
+  "cells": [
+    [
+      {
+        "contents": "m",
+        "style": {
+          "fg": {
+            "indexed": 6
+          },
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "y",
+        "style": {
+          "fg": {
+            "indexed": 6
+          },
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "a",
+        "style": {
+          "fg": {
+            "indexed": 6
+          },
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "p",
+        "style": {
+          "fg": {
+            "indexed": 6
+          },
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "p",
+        "style": {
+          "fg": {
+            "indexed": 6
+          },
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": ">",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": true,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": true,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "A",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": true,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "l",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": true,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "p",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": true,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "h",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": true,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "a",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": true,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "汉",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": true,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": true
+      },
+      {
+        "contents": "字",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": true,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": true
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "n",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": true,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "o",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": true,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "t",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": true,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "e",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": true,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "p",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "w",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": ":",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "s",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "e",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "c",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "r",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "e",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "t",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "D",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "O",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "N",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "E",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ]
+  ],
+  "state": {
+    "title": "",
+    "alternate_screen": false,
+    "bracketed_paste": false,
+    "application_cursor": false,
+    "mouse": "none",
+    "mouse_modes": 0,
+    "clipboard": null,
+    "bells": 0,
+    "focus_events": false,
+    "cursor_style": null,
+    "links": [],
+    "graphics": {
+      "counts": {
+        "kitty": 0,
+        "sixel": 0,
+        "deletes": 0,
+        "bytes": 0
+      },
+      "payloads": []
+    },
+    "repaints": 0,
+    "scrollback": [],
+    "wrapped": [
+      false,
+      false,
+      false,
+      false
+    ],
+    "insert_mode": false,
+    "unsupported": [
+      "^[[8m",
+      "^[[28m"
+    ],
+    "unsupported_overflow": 0,
+    "visual_bells": 0
+  }
+}

--- a/crates/termlens/tests/snapshots/export__styled_ansi.snap
+++ b/crates/termlens/tests/snapshots/export__styled_ansi.snap
@@ -1,0 +1,7 @@
+---
+source: crates/termlens/tests/export.rs
+expression: ansi
+---
+[0;1;36mmyapp[0m  [0;7m> Alpha[0m  汉字          
+[0;2mnote[0m pw: [0;8msecret[0m [0;48;2;30;30;46m  [0m            
+DONE

--- a/crates/termlens/tests/snapshots/export__styled_html.snap
+++ b/crates/termlens/tests/snapshots/export__styled_html.snap
@@ -1,0 +1,9 @@
+---
+source: crates/termlens/tests/export.rs
+expression: html
+---
+<pre style="background:#1e1e1e;color:#d4d4d4;font-family:monospace;line-height:1.2;padding:8px"><span style="color:#11a8cd;background:#1e1e1e;font-weight:bold">myapp</span>  <span style="color:#1e1e1e;background:#d4d4d4">&gt; Alpha</span>  汉字          
+<span style="color:#d4d4d4;background:#1e1e1e;opacity:0.6">note</span> pw: <span style="color:#d4d4d4;background:#1e1e1e">      </span> <span style="color:#d4d4d4;background:#1e1e2e">  </span>            
+DONE                          
+                              
+</pre>

--- a/crates/termlens/tests/snapshots/export__styled_svg.snap
+++ b/crates/termlens/tests/snapshots/export__styled_svg.snap
@@ -1,0 +1,15 @@
+---
+source: crates/termlens/tests/export.rs
+expression: svg
+---
+<svg xmlns="http://www.w3.org/2000/svg" width="270" height="72" viewBox="0 0 270 72" font-family="'JetBrains Mono', 'Fira Code', Menlo, Consolas, 'DejaVu Sans Mono', monospace" font-size="14">
+<rect width="270" height="72" fill="#1e1e1e"/>
+<text x="0" y="14" fill="#11a8cd" xml:space="preserve" font-weight="bold">myapp</text>
+<rect x="63" y="0" width="63" height="18" fill="#d4d4d4"/>
+<text x="63" y="14" fill="#1e1e1e" xml:space="preserve">&gt; Alpha</text>
+<text x="126" y="14" fill="#d4d4d4" xml:space="preserve">  汉字</text>
+<text x="0" y="32" fill="#d4d4d4" xml:space="preserve" opacity="0.6">note</text>
+<text x="36" y="32" fill="#d4d4d4" xml:space="preserve"> pw:</text>
+<rect x="144" y="18" width="18" height="18" fill="#1e1e2e"/>
+<text x="0" y="50" fill="#d4d4d4" xml:space="preserve">DONE</text>
+</svg>


### PR DESCRIPTION
Closes #246, #248, #247 — the three "a screen leaves the test" issues in v0.10.

**#246 `Screen::diff`** — `ScreenDiff` with `is_empty()`, `cells()` and a `Display` that renders only the rows that changed, side by side over a marker line with `^` under every changed column, the size and cursor deltas, `… N rows unchanged`, and `styles: row: before → after` for changed rows whose runs differ. Sizes that differ diff the overlap and say what was clipped. Plain text — no colour — so CI logs stay readable; a snapshot test pins the rendering. A `wait_frame` timeout now appends `--- last returned frame → live screen ---` with the diff, when there is a last frame and it differs.

**#248 renderers** — `to_ansi` (SGR per run, reset per row), `to_svg` (self-contained, `<rect>` per background run, `<text>` per foreground run, 9×18 metrics, fallback font stack, concealed text drawn as blanks, dim as opacity), `to_html` (`<pre>` of `<span style>`s). Pure functions of cells and styles, no dependency; snapshot tests for all three against one styled screen. `inspect` gains `--ansi`.

**#247 `serde` feature** — derives on `Cell`, `Style`, `Color` (`{"indexed": 6}`, `{"rgb": [30,30,46]}`), `CursorShape`, `MouseMode`, `MouseModes`, `Link`, `Clipboard` and the graphics types, `rc` for the `Arc`s; `Screen` is rows of cells with a hand-written `Deserialize` that re-checks every row holds exactly `cols` cells and refuses otherwise with a reason. Round-trip test, `insta::assert_json_snapshot!` test, refusal test. `features` job, CONTRIBUTING §1 and `install.yml` know the feature.

Every local gate green across all six feature configurations, both `cargo doc` shapes, and the MSRV check.