### PR TITLE
feat: assert_screen_snapshot! settles and keeps styles; Terminal::record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- **`Terminal::record()`.** Every complete frame from that moment on,
+  timestamped, until `stop()`: `Recording::frames()` for asserting on the
+  sequence of repaints an animation went through, and `write_asciicast()`
+  for a file `asciinema` plays and `agg` turns into a GIF — each frame a full
+  repaint through `to_ansi`. Bounded by `TerminalBuilder::record_budget`
+  (cells; default about a thousand 80x24 frames), oldest frames dropped and
+  the drop reported; refuses, with `wait_frame`'s diagnosis, an application
+  that never emits synchronized updates, because a sampled recording is the
+  torn-frame problem in a new hat. (#254)
+
 - **`Screen::diff`.** Two screens that differed printed as two whole grids;
   `a.diff(&b)` renders only the rows that changed, side by side over a
   marker line under the changed columns, the size and cursor deltas, a count
@@ -100,6 +110,17 @@ listed under a **Changed** or **Removed** heading.
   crate in CI, and the README shows the one-line install for Claude Code.
 
 ### Changed
+
+- **`assert_screen_snapshot!` earns its name.** It was `insta::assert_snapshot!`
+  under another name. Given a `Terminal` it now settles the picture
+  (`wait_stable(100ms)`, or `snapshot_after(pred)` with `after = pred`) and
+  snapshots **with styles** by default; `styles = false` is text-only, the
+  inline `@""` form still works, and a `Screen` argument still records the
+  screen as it is. Built on `snapshot_after`/`wait_stable`, so it adds no
+  waiting logic of its own; its rustdoc is now the home of the race rules.
+  The README's first example uses it and drops the rule-2 paragraph it no
+  longer needs. The macro uses `?`, so the test returns `Result` — which
+  every test should. (#253)
 
 - **`Screen::row_text` rejects an out-of-bounds row instead of returning an
   ambiguous empty string.** Callers with a potentially invalid index should

--- a/README.md
+++ b/README.md
@@ -34,11 +34,9 @@ fn quits_from_the_main_screen() -> termlens::Result<()> {
         .timeout(Duration::from_secs(5))   // every wait_* has this deadline
         .spawn(env!("CARGO_BIN_EXE_myapp"))?;
 
-    // Wait on the LAST thing the app paints before snapshotting the whole
-    // screen; an early marker races the rest of the frame (DESIGN.md §2, rule 2).
-    t.wait_until(|screen| screen.contains("Ready") && screen.contains("╯"))?;
-    insta::assert_snapshot!(t.screen());   // snapshot the rendered grid
-    // …or t.screen().with_styles() to catch style-only regressions too
+    // Wait for the app's ready marker, let the picture settle, then snapshot
+    // it with its styles — the three decisions every TUI snapshot needs.
+    termlens::assert_screen_snapshot!(t, after = |s| s.contains("Ready"));
 
     t.send(Key::Char('q'))?;
     assert!(t.wait_exit()?.success());

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -130,9 +130,42 @@ pub use screen::{
 #[cfg(unix)]
 pub use terminal::Signal;
 pub use terminal::{
-    ExitStatus, FrameTiming, Graphics, MouseButton, MouseChord, Scroll, ScrollChord, Terminal,
-    TerminalBuilder,
+    ExitStatus, FrameTiming, Graphics, MouseButton, MouseChord, Recorder, Recording, Scroll,
+    ScrollChord, Terminal, TerminalBuilder,
 };
+
+/// What [`assert_screen_snapshot!`] snapshots: a [`Terminal`], settled, or a
+/// [`Screen`] as it is. Implemented for `&mut Terminal` and `&Screen`, so the
+/// macro's method-call syntax borrows a `Terminal` mutably and a `Screen`
+/// immutably — whichever it was handed.
+#[doc(hidden)]
+pub trait SnapshotSource {
+    /// The screen to snapshot. `after` is the predicate to wait for first;
+    /// a [`Screen`] is already one instant, so it refuses one.
+    fn screen_for_snapshot(self, after: Option<&mut dyn FnMut(&Screen) -> bool>) -> Result<Screen>;
+}
+
+impl SnapshotSource for &mut Terminal {
+    fn screen_for_snapshot(self, after: Option<&mut dyn FnMut(&Screen) -> bool>) -> Result<Screen> {
+        match after {
+            Some(predicate) => self.snapshot_after(|screen| predicate(screen)),
+            None => self.wait_stable(std::time::Duration::from_millis(100)),
+        }
+    }
+}
+
+impl SnapshotSource for &Screen {
+    fn screen_for_snapshot(self, after: Option<&mut dyn FnMut(&Screen) -> bool>) -> Result<Screen> {
+        if after.is_some() {
+            return Err(Error::Input(
+                "assert_screen_snapshot!(screen, after = …): a Screen is already one instant, \
+                 so there is nothing to wait for — pass the Terminal instead"
+                    .to_owned(),
+            ));
+        }
+        Ok(self.clone())
+    }
+}
 
 /// Re-export of [`insta`](https://insta.rs) (feature `insta`, on by
 /// default), so [`assert_screen_snapshot!`] always agrees with the `insta`
@@ -141,31 +174,85 @@ pub use terminal::{
 #[cfg_attr(docsrs, doc(cfg(feature = "insta")))]
 pub use insta;
 
-/// Snapshot-assert anything that displays like a [`Screen`].
-///
-/// Sugar for [`insta::assert_snapshot!`] through the re-exported `insta`;
-/// accepts the same optional inline-snapshot form:
+/// Snapshot a terminal's screen the way a TUI snapshot has to be taken:
+/// **settled**, **with its styles**, through [`insta::assert_snapshot!`].
 ///
 /// ```no_run
 /// # fn main() -> termlens::Result<()> {
-/// # let t = termlens::Terminal::builder().spawn("true")?;
-/// #[cfg(feature = "insta")]
-/// {
-///     termlens::assert_screen_snapshot!(t.screen());
-/// }
+/// # let mut t = termlens::Terminal::builder().spawn("true")?;
+/// termlens::assert_screen_snapshot!(t);                                  // settle 100ms, styles on
+/// termlens::assert_screen_snapshot!(t, styles = false);                  // text only
+/// termlens::assert_screen_snapshot!(t, after = |s| s.contains("Ready")); // wait for it, then settle
+/// termlens::assert_screen_snapshot!(t.screen());                         // a Screen you already hold
+/// termlens::assert_screen_snapshot!(t, @"");                             // inline, filled by `cargo insta review`
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # The three decisions it makes
+///
+/// A snapshot of a TUI needs three decisions every time, and forgetting any
+/// one produces a test that passes for the wrong reason:
+///
+/// 1. **Wait for the picture to settle.** `wait_until(pred)` guarantees the
+///    bytes that made `pred` true were processed — and nothing more. A
+///    repaint has no end marker, so the predicate can fire on a half-painted
+///    screen, including half a row. Given a [`Terminal`], this macro takes
+///    the screen after it has held still for 100 ms
+///    ([`wait_stable`](Terminal::wait_stable)); with `after = pred` it waits
+///    for the predicate first and then for the stillness
+///    ([`snapshot_after`](Terminal::snapshot_after)). Name the *last* thing
+///    the application paints, and rule 2 of `docs/DESIGN.md` §2 is met.
+/// 2. **Snapshot the styles, not only the text.** A TUI regression is as often
+///    a colour as a character — a highlight on the wrong row, a masked field
+///    printed in clear — and the text rendering cannot see either. Styles are
+///    on by default; `styles = false` is the text-only snapshot.
+/// 3. **Snapshot one instant.** Every accessor of the [`Screen`] the macro
+///    records reads the same snapshot, so what insta shows is one consistent
+///    picture, never two waits' worth.
+///
+/// Given a [`Screen`] instead of a terminal, the macro records it as it is
+/// (`after =` is refused: an instant has nothing to wait for). Failures come
+/// from insta unchanged; review them with `cargo insta review`. The macro
+/// uses `?`, so the test returns [`Result`] — which every test should, since
+/// the `Display` of every error carries the screen.
+///
+/// `insta::assert_snapshot!(t.screen())` remains the low-level spelling for
+/// a screen already waited for by hand.
 #[cfg(feature = "insta")]
 #[cfg_attr(docsrs, doc(cfg(feature = "insta")))]
 #[macro_export]
 macro_rules! assert_screen_snapshot {
-    ($screen:expr) => {
-        $crate::insta::assert_snapshot!($screen)
+    ($source:expr $(,)?) => {
+        $crate::assert_screen_snapshot!($source, styles = true)
     };
-    ($screen:expr, @$inline:literal) => {
-        $crate::insta::assert_snapshot!($screen, @$inline)
+    ($source:expr, @$inline:literal $(,)?) => {{
+        use $crate::SnapshotSource as _;
+        let __screen = ($source).screen_for_snapshot(::core::option::Option::None)?;
+        $crate::insta::assert_snapshot!(__screen.with_styles(), @$inline)
+    }};
+    ($source:expr, styles = $styles:expr $(,)?) => {{
+        use $crate::SnapshotSource as _;
+        let __screen = ($source).screen_for_snapshot(::core::option::Option::None)?;
+        if $styles {
+            $crate::insta::assert_snapshot!(__screen.with_styles());
+        } else {
+            $crate::insta::assert_snapshot!(__screen);
+        }
+    }};
+    ($source:expr, after = $after:expr $(,)?) => {
+        $crate::assert_screen_snapshot!($source, after = $after, styles = true)
     };
+    ($source:expr, after = $after:expr, styles = $styles:expr $(,)?) => {{
+        use $crate::SnapshotSource as _;
+        let __after: &mut dyn ::core::ops::FnMut(&$crate::Screen) -> bool = &mut $after;
+        let __screen = ($source).screen_for_snapshot(::core::option::Option::Some(__after))?;
+        if $styles {
+            $crate::insta::assert_snapshot!(__screen.with_styles());
+        } else {
+            $crate::insta::assert_snapshot!(__screen);
+        }
+    }};
 }
 
 /// Spawn one of this package's binaries under the harness defaults.

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -676,6 +676,182 @@ impl Signal {
     }
 }
 
+/// Cells a recording holds before its oldest frames are dropped:
+/// [`TerminalBuilder::record_budget`]'s default.
+const DEFAULT_RECORD_BUDGET: usize = 2_000_000;
+
+/// The frames a `Recorder` has collected, shared with the reader thread,
+/// which pushes every completed frame here until the recorder is stopped.
+#[derive(Debug)]
+struct RecordingState {
+    started: Instant,
+    frames: VecDeque<(Duration, Screen)>,
+    cells: usize,
+    budget: usize,
+    dropped: u64,
+}
+
+impl RecordingState {
+    fn push(&mut self, frame: Screen) {
+        let cells = usize::from(frame.cols()) * usize::from(frame.rows());
+        while !self.frames.is_empty() && self.cells + cells > self.budget {
+            if let Some((_, gone)) = self.frames.pop_front() {
+                self.cells -= usize::from(gone.cols()) * usize::from(gone.rows());
+                self.dropped += 1;
+            }
+        }
+        self.cells += cells;
+        self.frames.push_back((self.started.elapsed(), frame));
+    }
+}
+
+/// A recording in progress: every complete frame from
+/// [`Terminal::record`] on, timestamped, until [`stop`](Self::stop).
+///
+/// Holds no borrow of the terminal, so the test drives it — `send`,
+/// `wait_frame` — while the recording runs.
+pub struct Recorder {
+    state: Arc<Mutex<RecordingState>>,
+    shared: Arc<Monitor<EmuState>>,
+}
+
+impl fmt::Debug for Recorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        f.debug_struct("Recorder")
+            .field("frames", &state.frames.len())
+            .field("dropped", &state.dropped)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Recorder {
+    /// Stop recording and hand back every frame collected, oldest first.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Input`] when the application has never emitted a DEC 2026
+    /// synchronized update — the diagnosis [`wait_frame`](Terminal::wait_frame)
+    /// gives. A recording is made of complete frames; sampling the grid on a
+    /// timer instead would be the torn-frame problem in a new hat.
+    pub fn stop(self) -> Result<Recording> {
+        let frames_seen = self.shared.mutate(|state| {
+            state
+                .recorders
+                .retain(|recorder| !Arc::ptr_eq(recorder, &self.state));
+            state.frames_seen
+        });
+        let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        if frames_seen == 0 {
+            return Err(Error::Input(
+                "nothing to record — the application never emitted a DEC 2026 synchronized \
+                 update. A recording is made of complete frames, as wait_frame is; an \
+                 application that does not bracket its repaints has no frames to record, and \
+                 sampling on a timer would record torn ones. Use snapshot_after for what the \
+                 screen showed at a moment."
+                    .to_owned(),
+            ));
+        }
+        Ok(Recording {
+            frames: state.frames.iter().cloned().collect(),
+            dropped: state.dropped,
+        })
+    }
+}
+
+/// What a [`Recorder`] collected: complete frames with the time each ended,
+/// measured from [`Terminal::record`], oldest first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Recording {
+    frames: Vec<(Duration, Screen)>,
+    dropped: u64,
+}
+
+impl Recording {
+    /// The frames, oldest first, each with the time its synchronized update
+    /// ended, measured from the moment recording started.
+    #[must_use]
+    pub fn frames(&self) -> &[(Duration, Screen)] {
+        &self.frames
+    }
+
+    /// How many frames are here.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Whether no frame was recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// Frames dropped to stay within [`TerminalBuilder::record_budget`] —
+    /// the oldest ones, so the recording is honest about being a tail.
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.dropped
+    }
+
+    /// The recording as an [asciicast v2] document: a header line, then one
+    /// event per frame at its timestamp, each a full repaint — clear, home,
+    /// then the frame through [`Screen::to_ansi`] — which is what the format
+    /// expects and what `asciinema play` and `agg` render. termlens ships no
+    /// image encoder; this is the file those tools turn into a GIF.
+    ///
+    /// [asciicast v2]: https://docs.asciinema.org/manual/asciicast/v2/
+    #[must_use]
+    pub fn to_asciicast(&self) -> String {
+        let (cols, rows) = self
+            .frames
+            .first()
+            .map_or((80, 24), |(_, frame)| frame.size());
+        let mut out = format!(
+            "{{\"version\": 2, \"width\": {cols}, \"height\": {rows}, \
+             \"env\": {{\"TERM\": \"xterm-256color\"}}}}\n"
+        );
+        for (at, frame) in &self.frames {
+            let mut data = String::from("\x1b[H\x1b[2J");
+            data.push_str(&frame.to_ansi().replace('\n', "\r\n"));
+            out.push_str(&format!(
+                "[{:.6}, \"o\", {}]\n",
+                at.as_secs_f64(),
+                json_string(&data)
+            ));
+        }
+        out
+    }
+
+    /// Write [`to_asciicast`](Self::to_asciicast) to `path`.
+    ///
+    /// # Errors
+    ///
+    /// The I/O error, if the file cannot be written.
+    pub fn write_asciicast(&self, path: impl AsRef<Path>) -> io::Result<()> {
+        std::fs::write(path, self.to_asciicast())
+    }
+}
+
+/// `text` as a JSON string literal, control characters escaped.
+fn json_string(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for c in text.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// Exit status of the child process.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExitStatus {
@@ -820,6 +996,9 @@ struct EmuState {
     frames: VecDeque<(u64, Screen)>,
     /// Per-frame cost, kept separately and for longer than `frames`.
     timings: VecDeque<FrameTiming>,
+    /// Recordings in progress: every completed frame is handed to each,
+    /// timestamped, until its `Recorder` is stopped (#254).
+    recorders: Vec<Arc<Mutex<RecordingState>>>,
     /// Whether to answer recognized terminal queries (builder-configured).
     respond: bool,
     /// Background color reported to OSC 11 queries.
@@ -892,6 +1071,7 @@ impl EmuState {
             frames_seen: 0,
             frames: VecDeque::with_capacity(FRAME_HISTORY),
             timings: VecDeque::new(),
+            recorders: Vec::new(),
             respond,
             background,
             foreground,
@@ -1187,6 +1367,7 @@ pub struct TerminalBuilder {
     cell_size: Option<(u16, u16)>,
     graphics: Graphics,
     capture_graphics: usize,
+    record_budget: usize,
 }
 
 impl Default for TerminalBuilder {
@@ -1206,6 +1387,7 @@ impl Default for TerminalBuilder {
             cell_size: None,
             graphics: Graphics::None,
             capture_graphics: DEFAULT_CAPTURE,
+            record_budget: DEFAULT_RECORD_BUDGET,
         }
     }
 }
@@ -1399,6 +1581,17 @@ impl TerminalBuilder {
     #[must_use]
     pub fn capture_graphics(mut self, bytes: usize) -> Self {
         self.capture_graphics = bytes;
+        self
+    }
+
+    /// How much a [`record`](Terminal::record)ing may hold, in **cells**
+    /// (frames × grid size), before its oldest frames are dropped — and
+    /// reported as dropped. The default, two million cells, is about a
+    /// thousand 80x24 frames; an animation test wants a few, a session
+    /// recording wants them all and knows how long it runs.
+    #[must_use]
+    pub fn record_budget(mut self, cells: usize) -> Self {
+        self.record_budget = cells;
         self
     }
 
@@ -1763,6 +1956,7 @@ impl TerminalBuilder {
             command_desc,
             frame_cursor: 0,
             last_frame: None,
+            record_budget: self.record_budget,
             cell_size: self.cell_size,
         })
     }
@@ -2120,6 +2314,12 @@ fn reader_loop(
                                 if state.frames.len() == FRAME_HISTORY {
                                     state.frames.pop_front();
                                 }
+                                for recorder in &state.recorders {
+                                    recorder
+                                        .lock()
+                                        .unwrap_or_else(PoisonError::into_inner)
+                                        .push(frame.clone());
+                                }
                                 state.frames.push_back((state.frames_seen, frame));
                                 // Timings outlive the frame ring: a
                                 // performance line is held over a run, not
@@ -2250,6 +2450,8 @@ pub struct Terminal {
     /// The frame `wait_frame` last returned, so a timeout can show what
     /// changed since rather than the live grid alone (#246).
     last_frame: Option<Screen>,
+    /// The builder's recording budget, handed to each `record()`.
+    record_budget: usize,
     /// Declared pixels per cell, kept so a resize can recompute the PTY's
     /// pixel geometry rather than silently dropping it.
     cell_size: Option<(u16, u16)>,
@@ -2294,6 +2496,49 @@ impl Terminal {
     #[must_use]
     pub fn screen(&self) -> Screen {
         self.shared.lock().snapshot()
+    }
+
+    /// Start recording every complete frame from now on, timestamped.
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().spawn("true")?;
+    /// let rec = t.record();                              // every complete frame from here on
+    /// t.send(termlens::Key::Char('j'))?;
+    /// let frame = t.wait_frame(|s| s.contains("Counter: 1"))?;
+    /// let frames = rec.stop()?;                          // oldest first, with timestamps
+    /// assert_eq!(frames.len(), 1, "one keystroke, one repaint");
+    /// frames.write_asciicast("counter.cast")?;           // render with `agg`
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Two uses share this: asserting on the *sequence* of repaints an
+    /// animation, a progress bar or a multi-step redraw went through — every
+    /// intermediate frame, not the one a predicate happened to name — and
+    /// recording a session for a bug report or a README, which
+    /// [`Recording::write_asciicast`] turns into a file `asciinema` plays and
+    /// `agg` renders.
+    ///
+    /// The recorder receives what the frame ring receives: complete DEC 2026
+    /// synchronized updates, and only those. Bounded by
+    /// [`record_budget`](TerminalBuilder::record_budget), oldest frames
+    /// dropped and the drop reported. The recorder holds no borrow of the
+    /// terminal; drive the application as usual while it runs.
+    pub fn record(&mut self) -> Recorder {
+        let state = Arc::new(Mutex::new(RecordingState {
+            started: Instant::now(),
+            frames: VecDeque::new(),
+            cells: 0,
+            budget: self.record_budget,
+            dropped: 0,
+        }));
+        self.shared
+            .mutate(|shared| shared.recorders.push(Arc::clone(&state)));
+        Recorder {
+            state,
+            shared: Arc::clone(&self.shared),
+        }
     }
 
     /// Per-frame cost for every repaint this terminal has seen, oldest

--- a/crates/termlens/tests/readme_example.rs
+++ b/crates/termlens/tests/readme_example.rs
@@ -16,18 +16,17 @@ fn readme_example_compiles_and_runs() -> termlens::Result<()> {
         .timeout(Duration::from_secs(5))
         .spawn(util::fixture_bin("hello-tui"))?;
 
-    // The same shape as the README's predicate: the status text AND the
-    // bottom-right corner, which is the fixture's last byte — rule 2 of
-    // `docs/DESIGN.md` §2: a whole-screen snapshot must wait on the last
-    // thing the application paints, or it races the rest of the frame at a
-    // chunk boundary. The README waited on the first marker alone until
-    // #216; a reviewer diffing the two should see no discrepancy in shape.
-    t.wait_until(|screen| screen.contains("status: ready") && screen.contains("╯"))?;
-    // The README's most distinctive line, compiled against the `insta` the
-    // crate itself dev-depends on. A dev-dependency is present in every
-    // feature configuration, so this needs no `cfg(feature = "insta")`: the
-    // `--no-default-features` CI job builds and runs it too.
-    insta::assert_snapshot!(t.screen());
+    // The README's most distinctive line: wait for the marker, settle,
+    // snapshot with styles — the macro makes the three decisions rule 2 of
+    // `docs/DESIGN.md` §2 used to ask the reader to make by hand. The macro
+    // is behind the default `insta` feature, so the no-default-features leg
+    // takes the low-level spelling with the same three steps.
+    #[cfg(feature = "insta")]
+    termlens::assert_screen_snapshot!(t, after = |s| s.contains("status: ready"));
+    #[cfg(not(feature = "insta"))]
+    insta::assert_snapshot!(t
+        .snapshot_after(|s| s.contains("status: ready"))?
+        .with_styles());
 
     t.send(Key::Char('q'))?;
     assert!(t.wait_exit()?.success());

--- a/crates/termlens/tests/record.rs
+++ b/crates/termlens/tests/record.rs
@@ -1,0 +1,128 @@
+//! `Terminal::record`: every complete frame, in order, with timestamps;
+//! bounded, honest about drops, refusing an application without
+//! synchronized updates, and exportable as asciicast v2 (#254).
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+
+/// Three frames in one write once released, so the recording has an
+/// ordered sequence to be about.
+const BURST: &str =
+    r"\e[?2026h\e[HSTEP 1\e[?2026l\e[?2026h\e[HSTEP 2\e[?2026l\e[?2026h\e[HSTEP 3\e[?2026l";
+
+fn emit(builder: termlens::TerminalBuilder, steps: &[&str]) -> termlens::Result<Terminal> {
+    common::spawn_emit(builder.size(40, 6).timeout(Duration::from_secs(10)), steps)
+}
+
+#[test]
+fn a_recording_holds_every_frame_in_order_with_its_time() -> termlens::Result<()> {
+    let mut t = emit(
+        Terminal::builder(),
+        &["READY", "--wait", "--raw", BURST, " DONE", "--wait"],
+    )?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let rec = t.record();
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let frames = rec.stop()?;
+    assert_eq!(frames.len(), 3, "three complete frames, none skipped");
+    assert_eq!(frames.dropped(), 0);
+    let steps: Vec<String> = frames
+        .frames()
+        .iter()
+        .map(|(_, s)| s.row_text(0).trim_end().to_owned())
+        .collect();
+    assert_eq!(steps, ["STEP 1", "STEP 2", "STEP 3"], "in the order drawn");
+    let times: Vec<Duration> = frames.frames().iter().map(|(at, _)| *at).collect();
+    assert!(
+        times.windows(2).all(|w| w[0] <= w[1]),
+        "timestamps never run backwards: {times:?}"
+    );
+    // Frames before `record()` was called are not in it.
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn the_budget_drops_the_oldest_frames_and_says_so() -> termlens::Result<()> {
+    // Two 40x6 frames fit; the third pushes the first out.
+    let mut t = emit(
+        Terminal::builder().record_budget(40 * 6 * 2),
+        &["READY", "--wait", "--raw", BURST, " DONE", "--wait"],
+    )?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let rec = t.record();
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let frames = rec.stop()?;
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames.dropped(), 1, "the drop is reported, not silent");
+    assert!(
+        frames.frames()[0].1.contains("STEP 2"),
+        "the oldest went first"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn an_application_without_synchronized_updates_is_refused() -> termlens::Result<()> {
+    let mut t = emit(Terminal::builder(), &["plain text\nDONE", "--wait"])?;
+    let rec = t.record();
+    t.wait_until(|s| s.contains("DONE"))?;
+    let err = rec.stop().expect_err("nothing bracketed, nothing recorded");
+    assert!(matches!(err, termlens::Error::Input(_)), "{err}");
+    assert!(
+        err.to_string()
+            .contains("never emitted a DEC 2026 synchronized update"),
+        "the diagnosis wait_frame gives: {err}"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn the_asciicast_is_a_v2_header_and_one_full_repaint_per_frame() -> termlens::Result<()> {
+    let mut t = emit(
+        Terminal::builder(),
+        &["READY", "--wait", "--raw", BURST, " DONE", "--wait"],
+    )?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let rec = t.record();
+    t.send(Key::Enter)?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let frames = rec.stop()?;
+
+    let cast = frames.to_asciicast();
+    let mut lines = cast.lines();
+    let header = lines.next().expect("a header line");
+    assert!(
+        header.starts_with("{\"version\": 2, \"width\": 40, \"height\": 6"),
+        "{header}"
+    );
+    let events: Vec<&str> = lines.collect();
+    assert_eq!(events.len(), 3, "one event per frame:\n{cast}");
+    for (event, step) in events.iter().zip(["STEP 1", "STEP 2", "STEP 3"]) {
+        assert!(event.starts_with('[') && event.ends_with(']'), "{event}");
+        assert!(
+            event.contains(", \"o\", \"\\u001b[H\\u001b[2J"),
+            "a full repaint: {event}"
+        );
+        assert!(event.contains(step), "{event}");
+    }
+
+    let path = std::env::temp_dir().join(format!("termlens-record-{}.cast", std::process::id()));
+    frames.write_asciicast(&path)?;
+    let written = std::fs::read_to_string(&path)?;
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(written, cast);
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/crates/termlens/tests/record.rs
+++ b/crates/termlens/tests/record.rs
@@ -18,6 +18,10 @@ fn emit(builder: termlens::TerminalBuilder, steps: &[&str]) -> termlens::Result<
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so a recorded frame never holds what was drawn (#149)"
+)]
 fn a_recording_holds_every_frame_in_order_with_its_time() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder(),
@@ -48,6 +52,10 @@ fn a_recording_holds_every_frame_in_order_with_its_time() -> termlens::Result<()
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so a recorded frame never holds what was drawn (#149)"
+)]
 fn the_budget_drops_the_oldest_frames_and_says_so() -> termlens::Result<()> {
     // Two 40x6 frames fit; the third pushes the first out.
     let mut t = emit(
@@ -88,6 +96,10 @@ fn an_application_without_synchronized_updates_is_refused() -> termlens::Result<
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "ConPTY closes a DEC 2026 bracket before the content it wrapped, so a recorded frame never holds what was drawn (#149)"
+)]
 fn the_asciicast_is_a_v2_header_and_one_full_repaint_per_frame() -> termlens::Result<()> {
     let mut t = emit(
         Terminal::builder(),

--- a/crates/termlens/tests/snapshot_macro.rs
+++ b/crates/termlens/tests/snapshot_macro.rs
@@ -1,0 +1,51 @@
+//! `assert_screen_snapshot!` makes the three decisions a TUI snapshot needs
+//! (#253): settle, styles on, one instant — and still takes a `Screen`.
+
+#![cfg(feature = "insta")]
+
+use std::time::Duration;
+
+use termlens::{Key, Terminal};
+
+mod common;
+
+fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
+    common::spawn_emit(
+        Terminal::builder()
+            .size(30, 3)
+            .timeout(Duration::from_secs(10)),
+        steps,
+    )
+}
+
+#[test]
+fn a_terminal_is_settled_and_snapshotted_with_styles() -> termlens::Result<()> {
+    let mut t = emit(&["--raw", r"\e[1mReady\e[0m later", "--wait"])?;
+    termlens::assert_screen_snapshot!(t, after = |s| s.contains("later"));
+    termlens::assert_screen_snapshot!(t, after = |s| s.contains("later"), styles = false);
+    termlens::assert_screen_snapshot!(t);
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn a_screen_is_recorded_as_it_is_and_refuses_a_wait() -> termlens::Result<()> {
+    let mut t = emit(&["fixed", "--wait"])?;
+    t.wait_until(|s| s.contains("fixed"))?;
+    let screen = t.screen();
+    termlens::assert_screen_snapshot!(screen);
+    termlens::assert_screen_snapshot!(t.screen(), styles = false);
+    let refused: termlens::Result<()> = (|| {
+        termlens::assert_screen_snapshot!(screen, after = |s| s.contains("fixed"));
+        Ok(())
+    })();
+    let err = refused.expect_err("a Screen is one instant already");
+    assert!(
+        err.to_string().contains("pass the Terminal instead"),
+        "{err}"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}

--- a/crates/termlens/tests/snapshots/readme_example__readme_example_compiles_and_runs.snap
+++ b/crates/termlens/tests/snapshots/readme_example__readme_example_compiles_and_runs.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/termlens/tests/readme_example.rs
-expression: t.screen()
+expression: __screen.with_styles()
 ---
 size: 80x24  cursor: hidden
 ╭──────────────────────────────╮
@@ -9,3 +9,24 @@ size: 80x24  cursor: hidden
 │ status: ready                │
 │ press q to quit              │
 ╰──────────────────────────────╯
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+styles:
+(none)

--- a/crates/termlens/tests/snapshots/snapshot_macro__a_screen_is_recorded_as_it_is_and_refuses_a_wait-2.snap
+++ b/crates/termlens/tests/snapshots/snapshot_macro__a_screen_is_recorded_as_it_is_and_refuses_a_wait-2.snap
@@ -1,0 +1,6 @@
+---
+source: crates/termlens/tests/snapshot_macro.rs
+expression: __screen
+---
+size: 30x3  cursor: 0,5
+fixed

--- a/crates/termlens/tests/snapshots/snapshot_macro__a_screen_is_recorded_as_it_is_and_refuses_a_wait.snap
+++ b/crates/termlens/tests/snapshots/snapshot_macro__a_screen_is_recorded_as_it_is_and_refuses_a_wait.snap
@@ -1,0 +1,11 @@
+---
+source: crates/termlens/tests/snapshot_macro.rs
+expression: __screen.with_styles()
+---
+size: 30x3  cursor: 0,5
+fixed
+
+
+
+styles:
+(none)

--- a/crates/termlens/tests/snapshots/snapshot_macro__a_terminal_is_settled_and_snapshotted_with_styles-2.snap
+++ b/crates/termlens/tests/snapshots/snapshot_macro__a_terminal_is_settled_and_snapshotted_with_styles-2.snap
@@ -1,0 +1,6 @@
+---
+source: crates/termlens/tests/snapshot_macro.rs
+expression: __screen
+---
+size: 30x3  cursor: 0,11
+Ready later

--- a/crates/termlens/tests/snapshots/snapshot_macro__a_terminal_is_settled_and_snapshotted_with_styles-3.snap
+++ b/crates/termlens/tests/snapshots/snapshot_macro__a_terminal_is_settled_and_snapshotted_with_styles-3.snap
@@ -1,0 +1,11 @@
+---
+source: crates/termlens/tests/snapshot_macro.rs
+expression: __screen.with_styles()
+---
+size: 30x3  cursor: 0,11
+Ready later
+
+
+
+styles:
+0: 0-4 bold

--- a/crates/termlens/tests/snapshots/snapshot_macro__a_terminal_is_settled_and_snapshotted_with_styles.snap
+++ b/crates/termlens/tests/snapshots/snapshot_macro__a_terminal_is_settled_and_snapshotted_with_styles.snap
@@ -1,0 +1,11 @@
+---
+source: crates/termlens/tests/snapshot_macro.rs
+expression: __screen.with_styles()
+---
+size: 30x3  cursor: 0,11
+Ready later
+
+
+
+styles:
+0: 0-4 bold


### PR DESCRIPTION
Closes #253, #254.

**#253 `assert_screen_snapshot!`** — it was `insta::assert_snapshot!` under another name. Given a `Terminal` it now makes the three decisions a TUI snapshot needs: settle (`wait_stable(100ms)`, or `snapshot_after(pred)` with `after = pred`), styles on by default (`styles = false` for text only), one instant. A `Screen` argument still records the screen as it is (and refuses `after =`, since an instant has nothing to wait for); the inline `@""` form still works. Implemented through a hidden `SnapshotSource` trait on `&mut Terminal` and `&Screen` so the macro's method-call syntax borrows whichever it was handed; built on the two existing waits, so no waiting logic of its own. The rustdoc is now the home of the race rules; the README's first example uses it and drops the rule-2 paragraph; `tests/readme_example.rs` follows (with the low-level spelling on the no-default-features leg, where the macro is not compiled).

**#254 `Terminal::record()`** — a `Recorder` receives every complete frame the frame ring receives, timestamped from `record()`, until `stop()` returns a `Recording`: `frames()`, `len()`, `dropped()`, `to_asciicast()` / `write_asciicast()` (v2 header, one event per frame, each a full repaint through `to_ansi`). Bounded by `TerminalBuilder::record_budget` in cells (default ≈ a thousand 80x24 frames), oldest dropped and the drop reported. `stop()` refuses an application that never emitted a synchronized update with `wait_frame`'s diagnosis — a sampled recording would be the torn-frame problem again. The recorder holds no borrow of the terminal.

Tests: a three-frame burst recorded in order with non-decreasing timestamps; the budget dropping the oldest and saying so; the refusal; the asciicast shape, written and read back. Macro: settled-with-styles, text-only, `after =`, a `Screen`, and the refusal. Every local gate green across all feature configurations.