### PR TITLE
feat: styled history behind a builder knob, and Screen::locate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ listed under a **Changed** or **Removed** heading.
 
 ### Added
 
+- **Styled history, opt in: `TerminalBuilder::scrollback_styles(true)` and
+  `Screen::scrollback_cell`.** A row lost every style the moment it scrolled
+  off, so the masked-password assertion — the one v0.4 paid a second parser
+  for — silently degraded to text the instant the screen filled. With the
+  knob, the scrolled rows are retained as cells beside the text, the shadow
+  parser keeps the same history and is read in lockstep so conceal, blink
+  and strikethrough come along, and a snapshot still pays one refcount per
+  retained row. Off by default, because the cost lands where a suite feels
+  it — every read that scrolls captures cells, and a full history is re-read
+  on each — and measured in the knob's rustdoc: about 90 ms against 40 ms
+  for 20,000 lines. (#146)
+
+- **`Screen::locate`**: where a needle is, on the grid or in history, as a
+  `Location` that says which. The addressing half of the scrolled-off-text
+  problem, honest about what history can promise: a history column is the
+  row's display column as it was captured, not a grid coordinate, and does
+  not survive a narrowing resize. (#147)
+
 - **`Terminal::record()`.** Every complete frame from that moment on,
   timestamped, until `stop()`: `Recording::frames()` for asserting on the
   sequence of repaints an animation went through, and `write_asciicast()`

--- a/README.md
+++ b/README.md
@@ -268,7 +268,13 @@ design. termlens's position:
   line that wraps does the same (a one-row terminal that scrolls by newline
   is fine). Larger grids are refused because every snapshot costs one entry
   per cell.
-- Scrollback is **bounded** (1000 rows by default), **text only** — a
+- Scrollback is **bounded** (1000 rows by default) and **text only unless
+  asked**: `scrollback_styles(true)` on the builder retains cells too, so
+  `Screen::scrollback_cell` keeps a masked-password assertion alive after
+  the line scrolls off, at a measured cost the knob's docs quote. Either
+  way `Screen::locate` says which region — grid or history — holds a
+  needle, and a history column is the row's *as captured*: history is not
+  reflowed, so it does not survive a narrowing resize. Otherwise a
   scrolled-off row has no styles and no cell addressing — and is **not
   reflowed** by a `resize`: rows keep the width they were captured at, by
   decision (`Terminal::resize` says why). The visible grid stays the

--- a/crates/termlens/src/emu/shadow.rs
+++ b/crates/termlens/src/emu/shadow.rs
@@ -94,14 +94,22 @@ pub(super) struct AttrShadow {
 }
 
 impl AttrShadow {
-    pub(super) fn new(rows: u16, cols: u16) -> Self {
+    /// `scrollback` is zero unless the terminal retains styled history:
+    /// text-only history needs the shadow for the visible grid alone, while
+    /// styled history reads the shadow's scrolled rows in lockstep with the
+    /// primary's (#146).
+    pub(super) fn new(rows: u16, cols: u16, scrollback: usize) -> Self {
         Self {
-            // No scrollback: history is text-only, so the shadow is needed
-            // for the visible grid alone.
-            parser: ::vt100::Parser::new(rows, cols, 0),
+            parser: ::vt100::Parser::new(rows, cols, scrollback),
             state: State::Ground,
             pending: Vec::new(),
         }
+    }
+
+    /// Move the shadow's history view, exactly as the primary's is moved
+    /// while scrolled rows are captured; always restored to 0 afterwards.
+    pub(super) fn set_scrollback(&mut self, rows: usize) {
+        self.parser.screen_mut().set_scrollback(rows);
     }
 
     pub(super) fn set_size(&mut self, rows: u16, cols: u16) {
@@ -331,7 +339,7 @@ mod tests {
 
     /// The real rewriter's output, as a readable string.
     fn shadowed(bytes: &[u8]) -> String {
-        let mut shadow = AttrShadow::new(4, 20);
+        let mut shadow = AttrShadow::new(4, 20, 0);
         let mut out = shadow.rewrite_stream(bytes);
         // Anything still held at the end of the stream is not an SGR.
         out.append(&mut shadow.pending);
@@ -445,7 +453,7 @@ mod tests {
 
     #[test]
     fn a_sequence_split_across_feeds_is_not_lost() {
-        let mut shadow = AttrShadow::new(2, 10);
+        let mut shadow = AttrShadow::new(2, 10, 0);
         shadow.feed(b"\x1b[8");
         // Mid-sequence: nothing applied yet, exactly as the primary sees it.
         assert!(!shadow.cell(0, 0).is_some_and(::vt100::Cell::italic));

--- a/crates/termlens/src/emu/vt100.rs
+++ b/crates/termlens/src/emu/vt100.rs
@@ -37,6 +37,10 @@ pub(crate) struct Vt100Emulator {
     /// chatty stream). A snapshot then costs one `Arc` clone per row
     /// instead of rebuilding the whole history.
     history: VecDeque<Arc<str>>,
+    /// The same rows as cells, when the terminal was built to retain
+    /// styles in history (#146); `None` otherwise, so a suite that never
+    /// asks pays nothing. Kept in lockstep with `history`, one entry each.
+    history_cells: Option<VecDeque<Arc<[Cell]>>>,
     /// Rows of vt100's own scrollback already copied into `history`, so a
     /// read that scrolled nothing costs one length check.
     captured: usize,
@@ -71,7 +75,13 @@ impl Vt100Emulator {
         }
     }
 
-    pub(crate) fn new(rows: u16, cols: u16, scrollback_len: usize, capture: usize) -> Self {
+    pub(crate) fn new(
+        rows: u16,
+        cols: u16,
+        scrollback_len: usize,
+        capture: usize,
+        styled_history: bool,
+    ) -> Self {
         Self {
             parser: ::vt100::Parser::new_with_callbacks(
                 rows,
@@ -80,7 +90,9 @@ impl Vt100Emulator {
                 Unhandled::default(),
             ),
             tracker: SeqTracker::new(capture, cols),
-            shadow: AttrShadow::new(rows, cols),
+            // The shadow keeps history only when its cells will be read.
+            shadow: AttrShadow::new(rows, cols, if styled_history { scrollback_len } else { 0 }),
+            history_cells: styled_history.then(VecDeque::new),
             colors: ColorNormalizer::new(),
             scrollback_len,
             frame_started: None,
@@ -228,6 +240,9 @@ impl Vt100Emulator {
         }
         let from = if at_cap {
             self.history.clear();
+            if let Some(cells) = &mut self.history_cells {
+                cells.clear();
+            }
             0
         } else {
             self.captured
@@ -245,10 +260,40 @@ impl Vt100Emulator {
                 self.history
                     .push_back(Arc::from(restore_replacement(line.trim_end()).as_ref()));
             }
+            // Styled history: the same rows as cells, the shadow moved to
+            // the same offset so blink, conceal and strikethrough come
+            // along — the correspondence invariant extended from the grid
+            // to history. Cell reads are O(row) each in vt100, so this is
+            // the cost the builder's knob documents.
+            if let Some(cells) = &mut self.history_cells {
+                self.shadow.set_scrollback(len - i);
+                for row in 0..u16::try_from(take).unwrap_or(u16::MAX) {
+                    let mut converted: Vec<Cell> = Vec::with_capacity(usize::from(cols));
+                    for col in 0..cols {
+                        let mut cell = screen.cell(row, col).map_or_else(
+                            || Cell::new(String::new(), Style::default(), false, false),
+                            |cell| convert_cell(cell, self.shadow.cell(row, col)),
+                        );
+                        if col > 0 && cell.is_wide_continuation() {
+                            if let Some(lead) = converted.last() {
+                                cell = Cell::new(String::new(), *lead.style(), false, true);
+                            }
+                        }
+                        converted.push(cell);
+                    }
+                    cells.push_back(converted.into());
+                }
+                self.shadow.set_scrollback(0);
+            }
             i += take;
         }
         while self.history.len() > self.scrollback_len {
             self.history.pop_front();
+        }
+        if let Some(cells) = &mut self.history_cells {
+            while cells.len() > self.scrollback_len {
+                cells.pop_front();
+            }
         }
         self.captured = len;
         screen.set_scrollback(0);
@@ -406,6 +451,10 @@ impl Emulator for Vt100Emulator {
             // Filled in by the terminal, which owns the frame count.
             repaints: 0,
             scrollback: self.history.iter().cloned().collect(),
+            scrollback_cells: self
+                .history_cells
+                .as_ref()
+                .map(|cells| cells.iter().cloned().collect()),
             // The backend's own record of a soft wrap, per row (#265).
             wrapped: (0..rows).map(|row| screen.row_wrapped(row)).collect(),
             insert_mode: self.tracker.insert_mode(),
@@ -622,7 +671,7 @@ mod tests {
     }
 
     fn emu_with(bytes: &[u8]) -> Vt100Emulator {
-        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, bytes);
         emu
     }
@@ -672,7 +721,7 @@ mod tests {
         assert_eq!(screen.find("done"), Some((0, 5)));
 
         // Scrolled into history, it is still U+FFFD — never the stand-in.
-        let mut emu = Vt100Emulator::new(4, 10, 100, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 100, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(
             &mut emu,
             "caf\u{FFFD} done\r\n1\r\n2\r\n3\r\n4\r\n5".as_bytes(),
@@ -786,7 +835,7 @@ mod tests {
 
     #[test]
     fn colon_form_colours_support_optional_colour_space_and_chunking() {
-        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE, false);
         emu.feed(b"\x1b[38:2:10:");
         emu.feed(b"20:30mA\x1b[48:5:196mB");
         let s = emu.snapshot();
@@ -864,7 +913,7 @@ mod tests {
     /// designation split across chunks must still apply.
     #[test]
     fn translation_survives_chunk_boundaries_and_frame_stops() {
-        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, b"\x1b(");
         feed_all(&mut emu, b"0\x1b[?2026hl");
         feed_all(&mut emu, b"q\x1b[?2026lk");
@@ -881,7 +930,7 @@ mod tests {
 
     #[test]
     fn mid_sequence_tracks_partial_escape() {
-        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, b"text\x1b[3");
         assert!(emu.mid_sequence());
         feed_all(&mut emu, b"1m");
@@ -890,7 +939,7 @@ mod tests {
 
     #[test]
     fn process_stops_at_the_end_of_a_synchronized_update() {
-        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE, false);
         let stream = b"\x1b[?2026hframe1\x1b[?2026lnext";
 
         let first = emu.process(stream);
@@ -915,7 +964,7 @@ mod tests {
 
     #[test]
     fn in_sync_update_is_true_between_bsu_and_esu() {
-        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 0, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, b"\x1b[?2026hpartial");
         assert!(emu.in_sync_update());
         assert!(!emu.mid_sequence()); // the escape itself is finished
@@ -947,7 +996,8 @@ mod tests {
 
     /// Feed a stream into an emulator with `scrollback` rows of history.
     fn emu_with_history(scrollback: usize, bytes: &[u8]) -> Vt100Emulator {
-        let mut emu = Vt100Emulator::new(4, 10, scrollback, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu =
+            Vt100Emulator::new(4, 10, scrollback, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, bytes);
         emu
     }
@@ -972,7 +1022,7 @@ mod tests {
     fn history_is_bounded_and_drops_its_oldest_rows() {
         // Ten rows, each ending in a newline, on a 4-row screen: seven
         // scroll off (row1..row7) and the cap of 3 keeps the newest three.
-        let mut emu = Vt100Emulator::new(4, 10, 3, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 3, crate::graphics::DEFAULT_CAPTURE, false);
         for n in 1..=10 {
             feed_all(&mut emu, format!("row{n}\r\n").as_bytes());
         }
@@ -990,7 +1040,7 @@ mod tests {
         // The rebuild path: once at the cap vt100's length stops changing,
         // so a naive "did the length grow?" check would freeze the history
         // at its first full window.
-        let mut emu = Vt100Emulator::new(4, 10, 2, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(4, 10, 2, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, b"a\r\nb\r\nc\r\nd\r\ne\r\nf\r\n");
         assert_eq!(emu.snapshot().scrollback_text(), "b\nc");
         feed_all(&mut emu, b"g\r\nh\r\n");
@@ -1026,7 +1076,7 @@ mod tests {
         // and not discarded. Rows captured before a narrowing resize keep
         // their width; rows captured after it have the new one; both sit in
         // the same history.
-        let mut emu = Vt100Emulator::new(2, 10, 100, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(2, 10, 100, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, b"0123456789\r\nabcdefghij\r\nnext");
         assert_eq!(emu.snapshot().scrollback_text(), "0123456789");
         emu.set_size(2, 4);
@@ -1126,7 +1176,7 @@ mod tests {
 
     /// A 24-column emulator, the width the issue's reproductions use.
     fn wide_emu(bytes: &[u8]) -> Vt100Emulator {
-        let mut emu = Vt100Emulator::new(2, 24, 0, crate::graphics::DEFAULT_CAPTURE);
+        let mut emu = Vt100Emulator::new(2, 24, 0, crate::graphics::DEFAULT_CAPTURE, false);
         feed_all(&mut emu, bytes);
         emu
     }

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -125,7 +125,8 @@ pub use graphics::{
 };
 pub use keys::{Chord, Input, Key};
 pub use screen::{
-    Cell, Clipboard, Color, CursorShape, Link, MouseMode, MouseModes, Screen, ScreenDiff, Style,
+    Cell, Clipboard, Color, CursorShape, Link, Location, MouseMode, MouseModes, Screen, ScreenDiff,
+    Style,
 };
 #[cfg(unix)]
 pub use terminal::Signal;

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -433,6 +433,9 @@ pub(crate) struct TermState {
     /// history is asserted on for its content. The rows are shared, so a
     /// snapshot pays one `Arc` clone each.
     pub(crate) scrollback: Arc<[Arc<str>]>,
+    /// The scrolled-off rows as cells, when the terminal retains styled
+    /// history; `None` when it does not. In lockstep with `scrollback`.
+    pub(crate) scrollback_cells: Option<Arc<[Arc<[Cell]>]>>,
     /// Per row, whether it ended in a soft wrap rather than a line end —
     /// the backend's own record, never asked for before #265.
     pub(crate) wrapped: Arc<[bool]>,
@@ -463,6 +466,7 @@ impl Default for TermState {
             graphics: GraphicsSeen::default(),
             repaints: 0,
             scrollback: Arc::from([] as [Arc<str>; 0]),
+            scrollback_cells: None,
             wrapped: Arc::from([] as [bool; 0]),
             insert_mode: false,
             unsupported: Arc::from([] as [Arc<str>; 0]),
@@ -518,6 +522,28 @@ impl Cell {
     pub fn is_wide_continuation(&self) -> bool {
         self.wide_continuation
     }
+}
+
+/// Where [`Screen::locate`] found a needle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Location {
+    /// On the visible grid, at this `(row, col)` — the same coordinates
+    /// [`Screen::find`] reports.
+    Screen {
+        /// Grid row, zero-based from the top.
+        row: u16,
+        /// Grid column, zero-based, a real terminal column.
+        col: u16,
+    },
+    /// In the retained history, in row `row` counting from the oldest
+    /// retained row, at display column `col` of that row as it was
+    /// captured. Not a grid coordinate, and not stable across a resize.
+    History {
+        /// History row, oldest first.
+        row: usize,
+        /// Display column within that row, as captured.
+        col: u16,
+    },
 }
 
 /// An immutable snapshot of the terminal screen.
@@ -1087,6 +1113,83 @@ impl Screen {
             out.push_str(row);
         }
         out
+    }
+
+    /// Whether this terminal retains **styles** in history —
+    /// [`TerminalBuilder::scrollback_styles`](crate::TerminalBuilder::scrollback_styles)
+    /// — so [`scrollback_cell`](Self::scrollback_cell) answers.
+    #[must_use]
+    pub fn styled_scrollback(&self) -> bool {
+        self.state.scrollback_cells.is_some()
+    }
+
+    /// The cell at `(row, col)` of the retained history, row 0 the oldest,
+    /// or `None` out of range — and `None` for every cell unless the
+    /// terminal was built with
+    /// [`scrollback_styles(true)`](crate::TerminalBuilder::scrollback_styles).
+    ///
+    /// This is what keeps the masked-password assertion alive once the line
+    /// scrolls: `scrollback_cell(row, col).unwrap().style().conceal` is the
+    /// same question [`cell`](Self::cell) answers on the grid. The column is
+    /// the one the row was captured at — history is not reflowed, so after a
+    /// narrowing resize the rows captured before it are wider than the grid
+    /// is now.
+    #[must_use]
+    pub fn scrollback_cell(&self, row: usize, col: u16) -> Option<&Cell> {
+        self.state
+            .scrollback_cells
+            .as_ref()?
+            .get(row)?
+            .get(usize::from(col))
+    }
+
+    /// Where `needle` is, on the visible screen or in the retained history
+    /// — the search that spans both and says which region it found the
+    /// needle in, so a wait can be written that does not depend on where a
+    /// block currently sits.
+    ///
+    /// The grid is searched first, with [`find`](Self::find)'s semantics
+    /// (NFC on both sides, trailing whitespace trimmed, real columns); then
+    /// history, oldest row first, with the same folding. A history column is
+    /// a display column of the row **as it was captured**: history is not
+    /// reflowed, so it does not survive a narrowing resize, and it is not a
+    /// grid coordinate — nothing here promises one. Multi-row needles are
+    /// searched on the grid only.
+    ///
+    /// ```
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder().size(20, 3)
+    /// #     .args(["-c", "printf 'SECRET\na\nb\nc\nd\n'; read q"]).spawn("sh")?;
+    /// # t.wait_until(|s| s.scrollback_rows() > 0)?;
+    /// use termlens::Location;
+    /// match t.screen().locate("SECRET") {
+    ///     Some(Location::History { row, col }) => assert_eq!((row, col), (0, 0)),
+    ///     other => panic!("scrolled off, so it is in history: {other:?}"),
+    /// }
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn locate(&self, needle: &str) -> Option<Location> {
+        if let Some((row, col)) = self.find(needle) {
+            return Some(Location::Screen { row, col });
+        }
+        if needle.is_empty() || needle.contains('\n') {
+            return None;
+        }
+        let needle = nfc(needle);
+        for (row, line) in self.state.scrollback.iter().enumerate() {
+            let folded = nfc(line);
+            let Some(byte_off) = folded.find(needle.as_str()) else {
+                continue;
+            };
+            let col = unicode_width::UnicodeWidthStr::width(&folded[..byte_off]);
+            return Some(Location::History {
+                row,
+                col: u16::try_from(col).unwrap_or(u16::MAX),
+            });
+        }
+        None
     }
 
     /// History **and** visible screen, as one text block: the retained

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1368,6 +1368,7 @@ pub struct TerminalBuilder {
     graphics: Graphics,
     capture_graphics: usize,
     record_budget: usize,
+    scrollback_styles: bool,
 }
 
 impl Default for TerminalBuilder {
@@ -1388,6 +1389,7 @@ impl Default for TerminalBuilder {
             graphics: Graphics::None,
             capture_graphics: DEFAULT_CAPTURE,
             record_budget: DEFAULT_RECORD_BUDGET,
+            scrollback_styles: false,
         }
     }
 }
@@ -1562,6 +1564,32 @@ impl TerminalBuilder {
     #[must_use]
     pub fn scrollback(mut self, rows: usize) -> Self {
         self.scrollback = rows;
+        self
+    }
+
+    /// Retain **styles** in history as well as text (off by default), so
+    /// [`Screen::scrollback_cell`] answers and a masked-password assertion
+    /// keeps working after the line scrolls off (#146).
+    ///
+    /// Off by default because it is not free, and the cost is in the one
+    /// place a test suite feels it: every read that scrolls captures the
+    /// scrolled rows as cells — one `Cell` per column instead of one string
+    /// per row — and once history is *full* the backend no longer says how
+    /// many rows a read scrolled, so the whole retained window is re-read as
+    /// cells on every read that scrolls. Measured on 20,000 lines through an
+    /// 80x24 screen with the default 1,000-row history, release build: about
+    /// 40 ms text-only, about 90 ms styled — 2.5x on a workload well past
+    /// what a test drives, and one that `scrollback(n)` bounds directly. A
+    /// snapshot pays one refcount per retained row either way, so the cost
+    /// of a wait does not grow with the depth of history.
+    ///
+    /// The attributes only the shadow parser sees — blink, conceal and
+    /// strikethrough — are retained too: the shadow keeps the same history
+    /// and is read in lockstep, so a concealed field is still concealed in
+    /// row 700 of history.
+    #[must_use]
+    pub fn scrollback_styles(mut self, retain: bool) -> Self {
+        self.scrollback_styles = retain;
         self
     }
 
@@ -1838,6 +1866,7 @@ impl TerminalBuilder {
                 self.cols,
                 self.scrollback,
                 self.capture_graphics,
+                self.scrollback_styles,
             )),
             Responder {
                 respond: self.answer_queries,

--- a/crates/termlens/tests/snapshots/export__json__styled_json.snap
+++ b/crates/termlens/tests/snapshots/export__json__styled_json.snap
@@ -2105,6 +2105,7 @@ expression: s
     },
     "repaints": 0,
     "scrollback": [],
+    "scrollback_cells": null,
     "wrapped": [
       false,
       false,

--- a/crates/termlens/tests/styled_history.rs
+++ b/crates/termlens/tests/styled_history.rs
@@ -1,0 +1,169 @@
+//! Styled history (#146) and the history-spanning search (#147): a masked
+//! password stays observably masked after its line scrolls off, and a
+//! needle is located in whichever region holds it.
+
+use std::time::Duration;
+
+use termlens::{Key, Location, Terminal};
+
+mod common;
+
+/// A 30x6 terminal that prints a concealed secret, then enough lines to
+/// scroll it into history, then parks.
+fn scrolled(styles: bool, scrollback: usize) -> termlens::Result<Terminal> {
+    let lines: String = (1..=12).map(|i| format!("line {i}\n")).collect();
+    common::spawn_emit(
+        Terminal::builder()
+            .size(30, 6)
+            .scrollback(scrollback)
+            .scrollback_styles(styles)
+            .timeout(Duration::from_secs(10)),
+        &[
+            "--raw",
+            r"pw: \e[1;31m\e[8mSECRET\e[0m|\n",
+            &lines,
+            "READY",
+            "--wait",
+        ],
+    )
+}
+
+#[test]
+fn a_masked_field_stays_masked_after_it_scrolls_off() -> termlens::Result<()> {
+    let mut t = scrolled(true, 1000)?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let s = t.screen();
+    assert!(s.styled_scrollback());
+    assert!(!s.contains("SECRET"), "it scrolled off the grid: {s}");
+    assert!(
+        s.full_text().contains("SECRET"),
+        "but it reached the terminal"
+    );
+    // Row 0 of history is the secret's row; columns 4..10 are the field.
+    for col in 4..10 {
+        let cell = s.scrollback_cell(0, col).expect("a retained cell");
+        assert!(cell.style().conceal, "column {col} is concealed");
+        assert!(cell.style().bold, "and bold, from the primary parser");
+    }
+    assert!(
+        !s.scrollback_cell(0, 3).unwrap().style().conceal,
+        "the label is not"
+    );
+    assert_eq!(
+        s.scrollback_cell(0, 4).unwrap().contents(),
+        "S",
+        "the text is still there, as a terminal holds it"
+    );
+    assert!(
+        s.scrollback_cell(0, 30).is_none(),
+        "past the captured width"
+    );
+    assert!(
+        s.scrollback_cell(999, 0).is_none(),
+        "past the retained rows"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn without_the_knob_history_stays_text_only() -> termlens::Result<()> {
+    let mut t = scrolled(false, 1000)?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let s = t.screen();
+    assert!(!s.styled_scrollback());
+    assert!(
+        s.scrollback_cell(0, 4).is_none(),
+        "nothing retained, nothing to pay for"
+    );
+    assert!(
+        s.scrollback_text().contains("SECRET"),
+        "the text is retained regardless"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Bounded like the text: at the cap the oldest styled rows are gone, and
+/// the two stay in lockstep.
+#[test]
+fn styled_history_is_bounded_with_the_text() -> termlens::Result<()> {
+    let mut t = scrolled(true, 5)?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let s = t.screen();
+    assert_eq!(s.scrollback_rows(), 5);
+    let first = s.scrollback_text().lines().next().unwrap().to_owned();
+    let cells: String = (0..30)
+        .filter_map(|c| s.scrollback_cell(0, c))
+        .map(|c| {
+            if c.contents().is_empty() {
+                " ".to_owned()
+            } else {
+                c.contents().to_owned()
+            }
+        })
+        .collect();
+    assert_eq!(
+        cells.trim_end(),
+        first,
+        "row 0 of the cells is row 0 of the text"
+    );
+    assert!(s.scrollback_cell(5, 0).is_none());
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+#[test]
+fn locate_says_which_region_holds_the_needle() -> termlens::Result<()> {
+    let mut t = scrolled(false, 1000)?;
+    t.wait_until(|s| s.contains("READY"))?;
+    let s = t.screen();
+    assert_eq!(
+        s.locate("READY"),
+        Some(Location::Screen { row: 5, col: 0 }),
+        "{s}"
+    );
+    assert_eq!(
+        s.locate("SECRET"),
+        Some(Location::History { row: 0, col: 4 })
+    );
+    assert_eq!(
+        s.locate("line 2"),
+        Some(Location::History { row: 2, col: 0 })
+    );
+    assert_eq!(s.locate("nowhere"), None);
+    // The grid wins when a needle is in both: `line 1` also starts `line 10`
+    // on the grid.
+    assert!(
+        matches!(s.locate("line 1"), Some(Location::Screen { .. })),
+        "{s}"
+    );
+    t.send(Key::Enter)?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+
+/// Not a test of correctness: prints how long the two retention modes take
+/// on a flood, for the numbers `scrollback_styles`'s rustdoc quotes.
+#[test]
+#[ignore = "timing probe: run with --ignored --nocapture to remeasure the rustdoc's numbers"]
+fn how_much_styled_history_costs() -> termlens::Result<()> {
+    for styles in [false, true] {
+        let started = std::time::Instant::now();
+        let mut t = common::spawn_emit(
+            Terminal::builder()
+                .size(80, 24)
+                .scrollback_styles(styles)
+                .timeout(Duration::from_secs(120)),
+            &["--seq", "20000", "READY", "--wait"],
+        )?;
+        t.wait_until(|s| s.contains("READY"))?;
+        println!("styles={styles}: {:?}", started.elapsed());
+        t.send(Key::Enter)?;
+        t.wait_exit()?;
+    }
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -478,6 +478,13 @@ re-read, which is by definition the newest N rows. Measured on 50,000
 lines through an 80x24 screen: 352ms with retention off, 327ms below the
 bound (free, within noise), 639ms on the re-read path.
 
+History is text unless the builder asks for styles (`scrollback_styles`),
+in which case the scrolled rows are captured as cells too and the shadow
+parser keeps the same history, read at the same offset, so the
+correspondence invariant extends from the grid to history; the knob's
+rustdoc carries the measured cost. `Screen::locate` searches grid then
+history and names the region.
+
 Two limits are documented rather than papered over: history is bounded, so
 a longer run drops its oldest rows; and resize does not reflow, so rows
 keep the width they were captured at — a decision, recorded on


### PR DESCRIPTION
A row lost every style the moment it scrolled off, so the masked-password assertion — the one v0.4 paid a second parser for — silently degraded to text the instant the screen filled.

- `TerminalBuilder::scrollback_styles(true)` retains scrolled rows as cells beside the text; the shadow parser keeps the same history and is read in lockstep, so conceal, blink and strikethrough come along. `Screen::scrollback_cell(row, col)` and `styled_scrollback()` read them. Off by default; the cost is measured in the knob's rustdoc (about 90 ms against 40 ms for 20,000 lines, release build) and lands where a suite feels it.
- `Screen::locate(needle) -> Option<Location>`: where a needle is, on the grid or in history, honest about what a history column can promise.
- `tests/styled_history.rs` (4 tests + an ignored timing probe), README limitation rewritten, DESIGN §2 note, CHANGELOG.

Closes #146
Closes #147