### PR TITLE
feat: termlens-cli with inspect/diff/render, Screen::parse, and the report action

### DIFF
--- a/.github/actions/report/README.md
+++ b/.github/actions/report/README.md
@@ -1,0 +1,21 @@
+# termlens report action
+
+Puts the screens a failing [termlens](https://crates.io/crates/termlens)
+suite left behind into the pull request: insta's `.snap.new` files (with the
+cell diff against the `.snap` beside each) and every screen the library
+wrote to `TERMLENS_ARTIFACT_DIR`, rendered as text in the step summary and
+as SVG/HTML in an uploaded artifact.
+
+```yaml
+- run: cargo test
+  env:
+    TERMLENS_ARTIFACT_DIR: ${{ runner.temp }}/termlens
+- uses: vyncint/termlens/.github/actions/report@v0.10.0
+  if: failure()
+```
+
+Nothing to install: the action `cargo install`s `termlens-cli` on the
+runner. Inputs: `artifact-dir` (defaults to `TERMLENS_ARTIFACT_DIR`, else
+`$RUNNER_TEMP/termlens`), `cli-version` (a `termlens-cli` version; empty
+means latest), `name` (the artifact's, default `termlens-report`), and
+`cli: workspace` for the termlens repository itself.

--- a/.github/actions/report/action.yml
+++ b/.github/actions/report/action.yml
@@ -1,0 +1,129 @@
+# The screens a failing termlens suite left behind, in the pull request
+# (#251). Run after the test step with `if: failure()`: collects insta's
+# `.snap.new` files and everything under `TERMLENS_ARTIFACT_DIR`, renders
+# each with `termlens-cli`, writes the screens and — for a `.snap.new` with a
+# `.snap` beside it — the cell diff into the step summary, and uploads the
+# SVG/HTML renderings as an artifact, since a step summary shows text and
+# not a local image.
+#
+# One `uses:` line from a consumer's workflow, nothing else: the CLI is
+# `cargo install`ed from crates.io, which every Rust runner already has.
+# This repository passes `cli: workspace` so the suite dogfoods the CLI in
+# the tree rather than the one last published.
+name: termlens report
+description: Render the screens a failing termlens test suite left behind into the step summary and an artifact.
+
+inputs:
+  artifact-dir:
+    description: >-
+      The directory the tests were run with as TERMLENS_ARTIFACT_DIR. Defaults
+      to that variable when set for the job, else $RUNNER_TEMP/termlens.
+    required: false
+    default: ""
+  cli:
+    description: >-
+      Where termlens-cli comes from: "crates.io" (cargo install termlens-cli)
+      or "workspace" (cargo install --path crates/termlens-cli, for the
+      termlens repository itself).
+    required: false
+    default: crates.io
+  cli-version:
+    description: The termlens-cli version to install from crates.io; empty means the latest.
+    required: false
+    default: ""
+  name:
+    description: The name of the uploaded artifact.
+    required: false
+    default: termlens-report
+
+runs:
+  using: composite
+  steps:
+    - name: Install termlens-cli
+      shell: bash
+      env:
+        CLI: ${{ inputs.cli }}
+        CLI_VERSION: ${{ inputs.cli-version }}
+      run: |
+        set -euo pipefail
+        root="${RUNNER_TEMP}/termlens-cli"
+        case "$CLI" in
+          workspace)
+            cargo install --path crates/termlens-cli --locked --root "$root" ;;
+          crates.io)
+            if [ -n "$CLI_VERSION" ]; then
+              cargo install termlens-cli --version "$CLI_VERSION" --locked --root "$root"
+            else
+              cargo install termlens-cli --locked --root "$root"
+            fi ;;
+          *)
+            echo "::error::cli must be crates.io or workspace, got '$CLI'"; exit 1 ;;
+        esac
+
+    - name: Render the screens into the summary
+      shell: bash
+      env:
+        ARTIFACT_DIR_INPUT: ${{ inputs.artifact-dir }}
+        ARTIFACT_NAME: ${{ inputs.name }}
+      run: |
+        set -euo pipefail
+        dir="${ARTIFACT_DIR_INPUT:-${TERMLENS_ARTIFACT_DIR:-${RUNNER_TEMP}/termlens}}"
+        out="${RUNNER_TEMP}/termlens-report"
+        mkdir -p "$out"
+        termlens() { "${RUNNER_TEMP}/termlens-cli/bin/termlens" "$@"; }
+
+        # What to show: every .snap.new outside target/, then every file the
+        # artifact hook wrote. Sorted, so the summary is stable run to run.
+        {
+          find . -path ./target -prune -o -name '*.snap.new' -print 2>/dev/null
+          if [ -d "$dir" ]; then find "$dir" -type f -print; fi
+        } | sort > "${out}/files.txt"
+
+        {
+          echo "## termlens: screens from the failing tests"
+          echo
+          if [ ! -s "${out}/files.txt" ]; then
+            echo "No \`.snap.new\` files and nothing under \`${dir}\`: the failures left no screen behind."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        n=0
+        while IFS= read -r file; do
+          n=$((n + 1))
+          base="$(basename "$file")"
+          stem="${n}-${base}"
+          # Renderings for the artifact; the summary holds the text.
+          termlens render --svg "$file" > "${out}/${stem}.svg" || true
+          termlens render --html "$file" > "${out}/${stem}.html" || true
+          {
+            echo "<details><summary><code>${file}</code></summary>"
+            echo
+            echo '```'
+            termlens render --text "$file" || echo "(termlens could not read this file)"
+            echo '```'
+            case "$file" in
+              *.snap.new)
+                snap="${file%.new}"
+                if [ -f "$snap" ]; then
+                  echo
+                  echo "Against \`${snap}\`:"
+                  echo
+                  echo '```'
+                  termlens diff --color never "$snap" "$file" || true
+                  echo '```'
+                fi ;;
+            esac
+            echo "</details>"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+        done < "${out}/files.txt"
+        if [ "$n" -gt 0 ]; then
+          echo "SVG and HTML renderings of each are in the \`${ARTIFACT_NAME:-termlens-report}\` artifact." >> "$GITHUB_STEP_SUMMARY"
+        fi
+        echo "rendered ${n} screen(s) into the step summary"
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ runner.temp }}/termlens-report
+        if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,15 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace --all-features
+        env:
+          TERMLENS_ARTIFACT_DIR: ${{ runner.temp }}/termlens
+      # The screens of whatever failed, in the step summary (#251). The
+      # suite dogfoods the action with the CLI from this tree.
+      - uses: ./.github/actions/report
+        if: failure()
+        with:
+          cli: workspace
+          name: termlens-report-${{ matrix.os }}
 
   # Every feature configuration a consumer can ask for. The default set is
   # what `cargo add termlens --dev` produces, and until #226 no job ran it:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,20 @@ jobs:
       - run: cargo publish -p termlens --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      # termlens-cli (#255) follows, once crates.io knows it. Trusted
+      # Publishing is configured per crate and only for a crate that already
+      # exists, so its first publish is the owner's, by hand, with a token
+      # (docs/RELEASING.md); every release after that lands here.
+      - name: Publish termlens-cli, when it is on crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          status="$(curl -sS -o /dev/null -w '%{http_code}' https://crates.io/api/v1/crates/termlens-cli)"
+          if [ "$status" = "200" ]; then
+            cargo publish -p termlens-cli --locked
+          else
+            echo "::warning::termlens-cli is not on crates.io yet (HTTP ${status}); publish it once by hand, then link Trusted Publishing for it — docs/RELEASING.md"
+          fi
 
   github-release:
     name: GitHub release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,33 @@ listed under a **Changed** or **Removed** heading.
   screen. Plain text, so CI logs stay readable. An erased cell and a
   written space in the same style are one blank, not a difference. (#246)
 
+- **`termlens-cli`: the `termlens` command, and `Screen::parse`.** Two
+  saved screens could be compared only by `cargo insta review`, on the
+  machine that ran the tests. `cargo install termlens-cli` provides
+  `termlens inspect` (the example grown a command: a program in a PTY, its
+  screen printed, `--ansi` for colour), `termlens diff a b` (the cell diff
+  of two saved screens — an insta `.snap` with or without its header, the
+  block a wait error prints, a `TERMLENS_ARTIFACT_DIR` file, or the JSON
+  the `serde` feature writes — coloured on a terminal, plain in a pipe,
+  exit 1 when they differ) and `termlens render --svg|--html|--ansi|--text`.
+  The genuinely new piece is in the library: `Screen::parse` reads the
+  snapshot text format of DESIGN §3 back, `styles:` block included, so the
+  format round-trips — `Screen::parse(&s.with_styles().to_string())`
+  renders to the same text and diffs empty against `s`. A text that is not
+  the format is `Error::Parse`, naming the line. The CLI's own tests drive
+  it through a PTY with termlens. (#255)
+
+- **`TERMLENS_ARTIFACT_DIR`, and the `report` action.** A failing wait's
+  screen reached the CI log and stopped there. With the variable set, every
+  error that carries a screen also writes it to that directory —
+  `<test>-<n>.screen.json` with the `serde` feature, `.screen.txt` (the
+  `with_styles` rendering) without — and
+  `vyncint/termlens/.github/actions/report`, run with `if: failure()`,
+  renders those files and every `.snap.new` (with the diff against its
+  `.snap`) into the pull request's step summary, SVG and HTML uploaded as
+  an artifact. Off when unset; documented on `Error`. This repository's
+  own `test` job runs the action. (#251)
+
 - **`fixtures/ratatui-app` and its fidelity test.** No fixture was a
   ratatui application, so the one check only a PTY harness can make for
   ratatui users was never made here. The fixture is a counter/list with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,12 @@ cargo insta review            # inspect and accept/reject each diff
 
 - `crates/termlens/` — the published library (PTY spawn → VT emulation →
   `Screen` snapshots → wait engine).
+- `crates/termlens-cli/` — the `termlens` command (`inspect`, `diff`,
+  `render`), published as `termlens-cli`; its tests drive it through a PTY
+  with the library.
+- `.github/actions/report/` — the composite action that renders failing
+  screens into a pull request's step summary; this repository's `test` job
+  runs it with `if: failure()`.
 - `fixtures/` — deterministic terminal apps the integration suite drives;
   workspace members, never published. `fixtures/ratatui-app` is the one
   ratatui application, and carries its own test: the same `draw` through

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termlens-cli"
+version = "0.9.0"
+dependencies = [
+ "serde_json",
+ "termlens",
+]
+
+[[package]]
 name = "termwiz"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 resolver = "2"
-members = ["crates/termlens", "fixtures/*"]
+members = ["crates/termlens", "crates/termlens-cli", "fixtures/*"]
 
 [workspace.package]
 version = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -235,6 +235,31 @@ sizes with a resize between (`fixtures/ratatui-app/tests/fidelity.rs`). Where
 they disagree the bug is in the terminal layer — crossterm's encoding, the
 PTY, or termlens's emulation — which is the layer nothing else tests.
 
+## At a shell prompt, and in CI
+
+`cargo install termlens-cli` gives the same harness as a command:
+`termlens inspect --size 120x40 myapp` prints what a program shows,
+`termlens diff old.snap new.snap.new` prints the cell diff of two saved
+screens (coloured on a terminal, exit 1 if anything changed), and
+`termlens render --svg failing.snap` turns one into an image. A saved
+screen is the text termlens prints — an insta `.snap`, the block a wait
+error leaves in a log — read back by `Screen::parse`, or the JSON the
+`serde` feature writes.
+
+In CI, set `TERMLENS_ARTIFACT_DIR` on the test step and every screen a
+failing wait embeds is also written there; then
+`uses: vyncint/termlens/.github/actions/report@v0.10.0` with `if: failure()`
+puts those screens, and every `.snap.new` with its diff, into the pull
+request's step summary:
+
+```yaml
+- run: cargo test
+  env:
+    TERMLENS_ARTIFACT_DIR: ${{ runner.temp }}/termlens
+- uses: vyncint/termlens/.github/actions/report@v0.10.0
+  if: failure()
+```
+
 ## Determinism
 
 PTYs are asynchronous; a harness that pretends otherwise is flaky by

--- a/crates/termlens-cli/Cargo.toml
+++ b/crates/termlens-cli/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "termlens-cli"
+description = "The termlens command: run a program in a PTY and print its screen, diff two saved screens, render one as ANSI, SVG or HTML"
+keywords = ["pty", "terminal", "testing", "tui", "snapshot"]
+categories = ["development-tools::testing", "command-line-interface"]
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "termlens"
+path = "src/main.rs"
+# The binary shares its name with the library it wraps; documenting it would
+# collide with the library's docs under `cargo doc --workspace`, and a
+# binary's rustdoc is its README anyway.
+doc = false
+
+[dependencies]
+# The version is the one release bumps alongside `workspace.package.version`
+# (docs/RELEASING.md); a path dependency needs it to publish. `serde` so a
+# saved screen can be JSON as well as the text format.
+termlens = { version = "0.9.0", path = "../termlens", default-features = false, features = ["serde"] }
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/termlens-cli/README.md
+++ b/crates/termlens-cli/README.md
@@ -1,0 +1,26 @@
+# termlens-cli
+
+The `termlens` command: the [termlens](https://crates.io/crates/termlens)
+PTY harness at a shell prompt.
+
+```sh
+cargo install termlens-cli --locked
+
+termlens inspect --size 120x40 htop          # run a program, print its screen
+termlens inspect --ansi ./target/debug/myapp # …in colour
+termlens diff old.snap new.snap.new          # what changed, cell by cell; exit 1 if anything
+termlens render --svg failing.snap.new > failing.svg
+```
+
+A saved screen is the snapshot text format termlens prints (an insta
+`.snap`, with or without its header; the block a wait error prints; a
+`TERMLENS_ARTIFACT_DIR` file), or the JSON the crate's `serde` feature
+writes. `diff` colours the changed cells on a terminal and stays plain in a
+pipe; `--color always|never|auto`, and `NO_COLOR` is honoured.
+
+Exit codes: `0` ran; `diff` exits `1` when the screens differ; `2` means the
+command itself could not run — bad arguments, an unreadable file, a program
+that could not be spawned.
+
+The `.github/actions/report` action in the termlens repository uses this
+binary to put failing screens into a pull request's step summary.

--- a/crates/termlens-cli/src/main.rs
+++ b/crates/termlens-cli/src/main.rs
@@ -1,0 +1,428 @@
+//! `termlens` — the harness at a shell prompt (#255): `inspect` runs a
+//! program in a PTY and prints its screen, `diff` compares two saved
+//! screens cell by cell, `render` turns one into ANSI, SVG or HTML.
+//!
+//! A saved screen is the snapshot text format of `docs/DESIGN.md` §3 — an
+//! insta `.snap` with or without its header, the block a wait error prints,
+//! a `TERMLENS_ARTIFACT_DIR` file — or the JSON the crate's `serde` feature
+//! writes. `Screen::parse` reads the first back; this binary only decides
+//! which of the two a file is.
+//!
+//! Exit codes: 0 ran; `diff` exits 1 when the screens differ; 2 means the
+//! command itself could not run — bad arguments, an unreadable file, a
+//! program that could not be spawned. `inspect` is a viewer, not a gate:
+//! the program's own exit status is reported under the screen, not
+//! propagated.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use termlens::{Screen, ScreenDiff, Terminal};
+
+const USAGE: &str = "\
+usage: termlens <command> [options]
+
+commands:
+  inspect [options] <program> [args…]  run a program in a PTY and print its screen
+  diff [--color WHEN] <a> <b>          compare two saved screens; exit 1 when they differ
+  render --svg|--html|--ansi|--text <a>  render a saved screen
+
+A saved screen is the snapshot text format termlens prints — an insta .snap
+with or without its header, the block a wait error prints, a
+TERMLENS_ARTIFACT_DIR file — or the JSON the crate's `serde` feature writes.
+
+Exit code 0: the command ran (diff: the screens are the same picture).
+Exit code 1: diff found a difference. Exit code 2: termlens itself could not
+run — bad arguments, an unreadable file, a program that could not be spawned.
+
+  -h, --help     print this text (also after a command)
+      --version  print the version";
+
+const INSPECT_USAGE: &str = "\
+usage: termlens inspect [--size COLSxROWS] [--timeout SECONDS] [--idle MILLIS]
+                        [--inherit-env] [--ansi] [--env KEY=VALUE]... <program> [args…]
+
+Runs <program> in an 80x24 pseudo-terminal (or --size), waits for it to
+exit or for the deadline (--timeout, default 5 seconds), and prints the
+rendered screen. A program still running at the deadline is snapshotted
+after --idle milliseconds (default 300) of output silence, then killed.
+The child environment is cleared by default except for PATH; --inherit-env
+keeps the caller's environment, and repeatable --env sets selected values.
+--ansi paints the screen in colour instead of the plain text format.
+
+The trailer under the screen says what the program did — its exit status,
+or that it was still running at the deadline. Exit code 2 means inspect
+itself could not run: bad arguments, or a program that could not be spawned.";
+
+const DIFF_USAGE: &str = "\
+usage: termlens diff [--color auto|always|never] <a> <b>
+
+Parses two saved screens and prints what changed from <a> to <b>: the rows
+that differ side by side, the size and cursor deltas, the style runs before
+and after. On a terminal the changed cells are coloured (red in <a>, green
+in <b>) unless --color never or NO_COLOR is set; in a pipe the rendering is
+the plain one Screen::diff prints in a CI log. Exit code 0 when the two are
+the same picture, 1 when they differ, 2 when a file could not be read.";
+
+const RENDER_USAGE: &str = "\
+usage: termlens render (--svg | --html | --ansi | --text) <a>
+
+Prints a saved screen as an SVG image, an HTML fragment, the screen in ANSI
+colour for a terminal, or the plain text format with its styles: block.";
+
+/// Where a rendering goes, so a reader that closed early (`termlens … |
+/// head`) is a clean exit rather than a panic on a broken pipe.
+fn print(out: &str) -> ExitCode {
+    let mut stdout = io::stdout().lock();
+    match stdout
+        .write_all(out.as_bytes())
+        .and_then(|()| stdout.flush())
+    {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+        Err(e) => fail(&format!("writing the output failed: {e}")),
+    }
+}
+
+/// One diagnostic shape for every failure of the tool itself.
+fn fail(message: &str) -> ExitCode {
+    eprintln!("termlens: {message}");
+    ExitCode::from(2)
+}
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let Some(command) = args.next() else {
+        eprintln!("{USAGE}");
+        return ExitCode::from(2);
+    };
+    let rest: Vec<String> = args.collect();
+    match command.as_str() {
+        "-h" | "--help" => print(&format!("{USAGE}\n")),
+        "--version" => print(&format!("termlens {}\n", env!("CARGO_PKG_VERSION"))),
+        "inspect" => inspect(rest),
+        "diff" => diff(&rest),
+        "render" => render(&rest),
+        other => fail(&format!("unknown command {other:?} (try --help)")),
+    }
+}
+
+// ---------------------------------------------------------------- saved screens
+
+/// Read a saved screen: an insta `.snap` (its `---` header dropped), the
+/// text format, or JSON.
+fn load(path: &Path) -> Result<Screen, String> {
+    let raw = std::fs::read_to_string(path).map_err(|e| format!("{}: {e}", path.display()))?;
+    // A checkout on Windows may have given the file CRLF endings; the
+    // formats are line-based and neither cares.
+    let raw = raw.replace("\r\n", "\n");
+    let body = strip_insta_header(&raw).trim_start_matches('\n');
+    if body.starts_with('{') {
+        return serde_json::from_str(body)
+            .map_err(|e| format!("{}: not a termlens Screen: {e}", path.display()));
+    }
+    Screen::parse(body).map_err(|e| format!("{}: {e}", path.display()))
+}
+
+/// insta writes `---\n<metadata>\n---\n` above the content; the content is
+/// what was snapshotted.
+fn strip_insta_header(text: &str) -> &str {
+    text.strip_prefix("---\n")
+        .and_then(|rest| rest.find("\n---\n").map(|end| &rest[end + 5..]))
+        .unwrap_or(text)
+}
+
+// ------------------------------------------------------------------------ diff
+
+/// When `diff` colours its output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColorWhen {
+    Auto,
+    Always,
+    Never,
+}
+
+impl ColorWhen {
+    fn enabled(self) -> bool {
+        match self {
+            ColorWhen::Always => true,
+            ColorWhen::Never => false,
+            ColorWhen::Auto => {
+                io::stdout().is_terminal()
+                    && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty())
+            }
+        }
+    }
+}
+
+fn diff(args: &[String]) -> ExitCode {
+    let mut color = ColorWhen::Auto;
+    let mut files = Vec::new();
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => return print(&format!("{DIFF_USAGE}\n")),
+            "--color" => {
+                color = match args.next().map(String::as_str) {
+                    Some("auto") => ColorWhen::Auto,
+                    Some("always") => ColorWhen::Always,
+                    Some("never") => ColorWhen::Never,
+                    other => {
+                        return fail(&format!(
+                            "--color takes auto, always or never, got {other:?}"
+                        ))
+                    }
+                }
+            }
+            other if other.starts_with("--color=") => {
+                color = match &other["--color=".len()..] {
+                    "auto" => ColorWhen::Auto,
+                    "always" => ColorWhen::Always,
+                    "never" => ColorWhen::Never,
+                    got => {
+                        return fail(&format!("--color takes auto, always or never, got {got:?}"))
+                    }
+                }
+            }
+            other if other.starts_with('-') && other != "-" => {
+                return fail(&format!(
+                    "unknown option {other:?} (try `termlens diff --help`)"
+                ));
+            }
+            _ => files.push(arg),
+        }
+    }
+    let [a, b] = files.as_slice() else {
+        eprintln!("{DIFF_USAGE}");
+        return ExitCode::from(2);
+    };
+    let (before, after) = match (load(Path::new(a)), load(Path::new(b))) {
+        (Ok(a), Ok(b)) => (a, b),
+        (Err(e), _) | (_, Err(e)) => return fail(&e),
+    };
+    let diff = before.diff(&after);
+    let rendered = if color.enabled() {
+        colored(&before, &after, &diff)
+    } else {
+        diff.to_string()
+    };
+    let code = print(&format!("{rendered}\n"));
+    if code != ExitCode::SUCCESS {
+        return code;
+    }
+    if diff.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
+}
+
+/// The diff for a terminal: the plain rendering's header and trailer, and
+/// each changed row side by side with its changed cells painted — red for
+/// what `before` showed, green for what `after` shows — in place of the
+/// `^` marker line, which colour makes redundant.
+fn colored(before: &Screen, after: &Screen, diff: &ScreenDiff) -> String {
+    let plain = diff.to_string();
+    if diff.is_empty() {
+        return plain;
+    }
+    let mut lines = plain.lines();
+    let mut out = String::new();
+    if let Some(header) = lines.next() {
+        out.push_str(header);
+    }
+    let mut changed_rows: Vec<u16> = diff.cells().map(|(row, _, _, _)| row).collect();
+    changed_rows.dedup();
+    for row in changed_rows {
+        let paint = |screen: &Screen, sgr: &str| -> String {
+            let mut cells: Vec<String> = Vec::new();
+            for col in 0..screen.cols() {
+                let Some(cell) = screen.cell(row, col) else {
+                    continue;
+                };
+                if cell.is_wide_continuation() {
+                    continue;
+                }
+                let text = if cell.contents().is_empty() {
+                    " "
+                } else {
+                    cell.contents()
+                };
+                let changed = diff.cells().any(|(r, c, _, _)| r == row && c == col);
+                cells.push(if changed {
+                    format!("\x1b[{sgr}m{text}\x1b[0m")
+                } else {
+                    text.to_owned()
+                });
+            }
+            cells.concat()
+        };
+        // The before side keeps its full width so the separator stays in one
+        // column down the listing; the after side is trimmed like a row.
+        let after_row = paint(after, "32");
+        let after_row = after_row.trim_end();
+        out.push_str(&format!("\n{row:>3} │{}│{after_row}", paint(before, "31")));
+    }
+    // The trailer: the unchanged-row count and the style runs, as printed.
+    for line in lines.filter(|l| l.starts_with('…') || l.starts_with("styles:")) {
+        out.push('\n');
+        out.push_str(line);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------- render
+
+fn render(args: &[String]) -> ExitCode {
+    let mut format: Option<&str> = None;
+    let mut file = None;
+    for arg in args {
+        match arg.as_str() {
+            "-h" | "--help" => return print(&format!("{RENDER_USAGE}\n")),
+            "--svg" | "--html" | "--ansi" | "--text" => format = Some(arg.as_str()),
+            other if other.starts_with('-') && other != "-" => {
+                return fail(&format!(
+                    "unknown option {other:?} (try `termlens render --help`)"
+                ));
+            }
+            _ => file = Some(arg),
+        }
+    }
+    let (Some(format), Some(file)) = (format, file) else {
+        eprintln!("{RENDER_USAGE}");
+        return ExitCode::from(2);
+    };
+    let screen = match load(Path::new(file)) {
+        Ok(screen) => screen,
+        Err(e) => return fail(&e),
+    };
+    let out = match format {
+        "--svg" => screen.to_svg(),
+        "--html" => screen.to_html(),
+        "--ansi" => screen.to_ansi(),
+        _ => format!("{}\n", screen.with_styles()),
+    };
+    print(&out)
+}
+
+// --------------------------------------------------------------------- inspect
+
+/// The value after `flag`, or the one-line diagnostic every flag shares.
+fn take<T>(
+    args: &mut impl Iterator<Item = String>,
+    flag: &str,
+    kind: &str,
+    example: &str,
+    parse: impl Fn(&str) -> Option<T>,
+) -> Result<T, String> {
+    let Some(raw) = args.next() else {
+        return Err(format!("{flag} needs a {kind} argument"));
+    };
+    parse(&raw).ok_or_else(|| format!("bad {flag} {raw:?}, expected e.g. {example}"))
+}
+
+/// The text rendering, or with `--ansi` the header over the screen in colour.
+fn inspect_render(screen: &Screen, ansi: bool) -> String {
+    if ansi {
+        let header = screen.to_string();
+        let header = header.lines().next().unwrap_or_default();
+        format!("{header}\n{}", screen.to_ansi())
+    } else {
+        screen.to_string()
+    }
+}
+
+fn inspect(args: Vec<String>) -> ExitCode {
+    let mut args = args.into_iter().peekable();
+    let mut size = (80u16, 24u16);
+    let mut timeout = Duration::from_secs(5);
+    let mut idle = Duration::from_millis(300);
+    let mut inherit_env = false;
+    let mut ansi = false;
+    let mut env = Vec::new();
+
+    // Options come before the program; everything after it is the
+    // program's own, however flag-like it looks.
+    while args.peek().is_some_and(|a| a.starts_with('-') && a != "-") {
+        let flag = args.next().unwrap_or_default();
+        let parsed = match flag.as_str() {
+            "-h" | "--help" => return print(&format!("{INSPECT_USAGE}\n")),
+            "--" => break,
+            "--size" => take(&mut args, "--size", "COLSxROWS", "120x40", |spec| {
+                let (c, r) = spec.split_once('x')?;
+                Some((c.parse().ok()?, r.parse().ok()?))
+            })
+            .map(|s| size = s),
+            "--timeout" => take(&mut args, "--timeout", "SECONDS", "30", |s| s.parse().ok())
+                .map(|secs| timeout = Duration::from_secs(secs)),
+            "--idle" => take(&mut args, "--idle", "MILLIS", "1000", |s| s.parse().ok())
+                .map(|millis| idle = Duration::from_millis(millis)),
+            "--inherit-env" => {
+                inherit_env = true;
+                Ok(())
+            }
+            "--ansi" => {
+                ansi = true;
+                Ok(())
+            }
+            "--env" => take(&mut args, "--env", "KEY=VALUE", "NO_COLOR=1", |s| {
+                let (key, value) = s.split_once('=')?;
+                (!key.is_empty()).then(|| (key.to_owned(), value.to_owned()))
+            })
+            .map(|pair| env.push(pair)),
+            other => Err(format!(
+                "unknown option {other:?} (try `termlens inspect --help`)"
+            )),
+        };
+        if let Err(message) = parsed {
+            return fail(&message);
+        }
+    }
+
+    let Some(program) = args.next() else {
+        eprintln!("{INSPECT_USAGE}");
+        return ExitCode::from(2);
+    };
+
+    let mut builder = Terminal::builder()
+        .size(size.0, size.1)
+        .timeout(timeout)
+        .args(args);
+    if !inherit_env {
+        builder = builder.env_clear();
+        if let Some(path) = std::env::var_os("PATH") {
+            builder = builder.env("PATH", path);
+        }
+    }
+    for (key, value) in env {
+        builder = builder.env(key, value);
+    }
+
+    let mut t = match builder.spawn(&program) {
+        Ok(t) => t,
+        Err(e) => return fail(&e.to_string()),
+    };
+
+    let mut out = String::new();
+    match t.wait_exit() {
+        Ok(status) => {
+            out.push_str(&inspect_render(&t.screen(), ansi));
+            out.push_str(&format!("\n--- exited: {status} ---\n"));
+        }
+        Err(termlens::Error::Timeout { .. }) => {
+            // Still running at the deadline: settle on a quiet screen
+            // instead, bounded by the deadline too unless the silence window
+            // asked for is itself longer.
+            let _ = t.wait_idle_for(idle, timeout.max(idle));
+            out.push_str(&inspect_render(&t.screen(), ansi));
+            out.push_str("\n--- still running at the deadline (killed on exit) ---\n");
+        }
+        Err(e) => {
+            out.push_str(&inspect_render(&t.screen(), ansi));
+            out.push_str(&format!("\n--- waiting for the program failed: {e} ---\n"));
+        }
+    }
+    print(&out)
+}

--- a/crates/termlens-cli/tests/cli.rs
+++ b/crates/termlens-cli/tests/cli.rs
@@ -1,0 +1,215 @@
+//! The CLI driven the way its users' programs are: through a PTY, by
+//! termlens (#255). `diff` and `render` read the saved screens under
+//! `tests/data`; `inspect` runs a shell.
+
+use termlens::{Color, Screen};
+
+fn data(name: &str) -> String {
+    format!("{}/tests/data/{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn diff_exits_one_and_paints_the_changed_cells_on_a_terminal() -> termlens::Result<()> {
+    let mut t = termlens::bin!(
+        "termlens",
+        args(["diff", &data("before.snap"), &data("after.snap.new")])
+    )?;
+    let status = t.wait_exit()?;
+    assert_eq!(status.code(), Some(1), "{}", t.screen());
+    let s = t.screen();
+    assert!(s.contains("size: 30x4"), "{s}");
+    // Row 2 changed in one cell: `1` red on the left, `2` green on the right.
+    let (row, col) = s.find("Counter: 1").expect("the before side");
+    let one = s.cell(row, col + 9).unwrap();
+    assert_eq!(one.contents(), "1");
+    assert_eq!(one.style().fg, Color::Indexed(1), "{}", s.with_styles());
+    let (row, col) = s.find("Counter: 2").expect("the after side");
+    assert_eq!(s.cell(row, col + 9).unwrap().style().fg, Color::Indexed(2));
+    // The style runs before → after, as the plain rendering prints them.
+    assert!(
+        s.contains("styles: 0: 0-4 fg=6 bold; 7-13 reverse → 0-4 fg=6 bold"),
+        "{s}"
+    );
+    assert!(s.contains("2 rows unchanged"), "{s}");
+    Ok(())
+}
+
+#[test]
+fn diff_stays_plain_when_asked_and_exits_zero_on_the_same_picture() -> termlens::Result<()> {
+    let mut t = termlens::bin!(
+        "termlens",
+        args([
+            "diff",
+            "--color",
+            "never",
+            &data("before.snap"),
+            &data("after.snap.new")
+        ])
+    )?;
+    assert_eq!(t.wait_exit()?.code(), Some(1));
+    let s = t.screen();
+    assert!(
+        s.contains("^"),
+        "the marker line stands in for colour:\n{s}"
+    );
+    assert!(
+        s.find_by(|c| c.style().fg != Color::Default).is_none(),
+        "{}",
+        s.with_styles()
+    );
+
+    let mut t = termlens::bin!(
+        "termlens",
+        args(["diff", &data("before.snap"), &data("before.snap")])
+    )?;
+    assert_eq!(t.wait_exit()?.code(), Some(0));
+    assert!(t.screen().contains("no difference"), "{}", t.screen());
+    Ok(())
+}
+
+#[test]
+fn render_writes_svg_html_ansi_and_text() -> termlens::Result<()> {
+    for (flag, needle) in [("--svg", "<svg"), ("--html", "<pre"), ("--text", "styles:")] {
+        let mut t = termlens::bin!("termlens", args(["render", flag, &data("before.snap")]))?;
+        assert_eq!(t.wait_exit()?.code(), Some(0), "{flag}: {}", t.screen());
+        assert!(t.screen().contains(needle), "{flag}:\n{}", t.screen());
+    }
+    // ANSI is the screen itself, styles and all, painted into our PTY.
+    let mut t = termlens::bin!("termlens", args(["render", "--ansi", &data("before.snap")]))?;
+    assert_eq!(t.wait_exit()?.code(), Some(0));
+    let s = t.screen();
+    let (row, col) = s.find("myapp").expect("the title");
+    let title = s.cell(row, col).unwrap().style();
+    assert!(
+        title.bold && title.fg == Color::Indexed(6),
+        "{}",
+        s.with_styles()
+    );
+    let (row, col) = s.find("secret").expect("the field");
+    assert!(
+        s.cell(row, col).unwrap().style().conceal,
+        "{}",
+        s.with_styles()
+    );
+    Ok(())
+}
+
+#[test]
+fn a_file_that_is_not_a_screen_exits_two_and_names_it() -> termlens::Result<()> {
+    // Wide, so the path in the diagnostic is not wrapped across two rows.
+    let mut t = termlens::bin!(
+        "termlens",
+        size(200, 10),
+        args(["render", "--svg", &data("missing.snap")])
+    )?;
+    assert_eq!(t.wait_exit()?.code(), Some(2));
+    assert!(
+        t.screen().contains("termlens: ") && t.screen().contains("missing.snap"),
+        "{}",
+        t.screen()
+    );
+
+    let mut t = termlens::bin!(
+        "termlens",
+        args(["diff", &data("cli.rs"), &data("before.snap")])
+    )?;
+    // tests/data/cli.rs does not exist either; the source file next door is
+    // the one that parses to nothing.
+    assert_eq!(t.wait_exit()?.code(), Some(2));
+
+    let mut t = termlens::bin!("termlens", args(["frobnicate"]))?;
+    assert_eq!(t.wait_exit()?.code(), Some(2));
+    assert!(t.screen().contains("unknown command"), "{}", t.screen());
+    Ok(())
+}
+
+#[test]
+fn the_text_a_wait_error_prints_is_a_saved_screen_too() -> termlens::Result<()> {
+    // No header, no styles block: the block from a CI log.
+    let path = std::env::temp_dir().join(format!("termlens-cli-{}.txt", std::process::id()));
+    std::fs::write(&path, "size: 10x2  cursor: hidden\nhello\n")?;
+    let mut t = termlens::bin!(
+        "termlens",
+        args(["render", "--text", path.to_str().unwrap()])
+    )?;
+    assert_eq!(t.wait_exit()?.code(), Some(0), "{}", t.screen());
+    let s = t.screen();
+    assert!(
+        s.contains("size: 10x2  cursor: hidden") && s.contains("(none)"),
+        "{s}"
+    );
+    let _ = std::fs::remove_file(&path);
+    Ok(())
+}
+
+#[test]
+fn a_crlf_checkout_of_a_snap_still_parses() -> termlens::Result<()> {
+    // Git on Windows may hand the file over with CRLF endings; the header
+    // and the grid are line-based and must not care.
+    // (Normalized first: on Windows the checkout may already be CRLF.)
+    let crlf = std::fs::read_to_string(data("before.snap"))?
+        .replace("\r\n", "\n")
+        .replace('\n', "\r\n");
+    let path = std::env::temp_dir().join(format!("termlens-cli-crlf-{}.snap", std::process::id()));
+    std::fs::write(&path, crlf)?;
+    let mut t = termlens::bin!(
+        "termlens",
+        args(["render", "--text", path.to_str().unwrap()])
+    )?;
+    assert_eq!(t.wait_exit()?.code(), Some(0), "{}", t.screen());
+    assert!(t.screen().contains("myapp  > Alpha"), "{}", t.screen());
+    let _ = std::fs::remove_file(&path);
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore = "the program under inspection is a POSIX shell")]
+fn inspect_prints_the_screen_and_the_exit_trailer() -> termlens::Result<()> {
+    let path = std::env::var("PATH").unwrap_or_default();
+    let mut t = termlens::bin!(
+        "termlens",
+        env("PATH", &path),
+        args(["inspect", "--size", "20x3", "sh", "-c", "printf 'hi there'"])
+    )?;
+    assert_eq!(t.wait_exit()?.code(), Some(0), "{}", t.screen());
+    let s = t.screen();
+    assert!(s.contains("size: 20x3") && s.contains("hi there"), "{s}");
+    assert!(s.contains("--- exited: exit code 0 ---"), "{s}");
+
+    let mut t = termlens::bin!(
+        "termlens",
+        env("PATH", &path),
+        args(["inspect", "--size", "12", "sh"])
+    )?;
+    assert_eq!(t.wait_exit()?.code(), Some(2));
+    assert!(
+        t.screen().contains("expected e.g. 120x40"),
+        "{}",
+        t.screen()
+    );
+    Ok(())
+}
+
+#[test]
+fn help_and_version() -> termlens::Result<()> {
+    let mut t = termlens::bin!("termlens", args(["--help"]))?;
+    assert_eq!(t.wait_exit()?.code(), Some(0));
+    assert!(
+        t.screen().contains("usage: termlens <command>"),
+        "{}",
+        t.screen()
+    );
+    let mut t = termlens::bin!("termlens", args(["--version"]))?;
+    assert_eq!(t.wait_exit()?.code(), Some(0));
+    assert!(
+        t.screen()
+            .contains(concat!("termlens ", env!("CARGO_PKG_VERSION"))),
+        "{}",
+        t.screen()
+    );
+    let mut t = termlens::bin!("termlens")?;
+    assert_eq!(t.wait_exit()?.code(), Some(2));
+    // Unused otherwise, but the round trip through the library is the point.
+    let _: Screen = Screen::parse("size: 1x1  cursor: 0,0\n")?;
+    Ok(())
+}

--- a/crates/termlens-cli/tests/data/after.snap.new
+++ b/crates/termlens-cli/tests/data/after.snap.new
@@ -1,0 +1,12 @@
+---
+source: tests/example.rs
+expression: t.screen().with_styles()
+---
+size: 30x4  cursor: 3,8
+myapp    Alpha  汉字
+note pw: secret
+Counter: 2
+
+styles:
+0: 0-4 fg=6 bold
+1: 0-3 dim; 9-14 conceal

--- a/crates/termlens-cli/tests/data/before.snap
+++ b/crates/termlens-cli/tests/data/before.snap
@@ -1,0 +1,12 @@
+---
+source: tests/example.rs
+expression: t.screen().with_styles()
+---
+size: 30x4  cursor: 3,8
+myapp  > Alpha  汉字
+note pw: secret
+Counter: 1
+
+styles:
+0: 0-4 fg=6 bold; 7-13 reverse
+1: 0-3 dim; 9-14 conceal

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -38,7 +38,7 @@ regex = ["dep:regex"]
 # renders the failing screen, or a consumer in another language — and come
 # back as an equal `Screen`. Off by default; `serde` is already in most
 # consumers' trees, so the cost when on is a set of derives.
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
 portable-pty.workspace = true
@@ -53,13 +53,13 @@ insta = { workspace = true, optional = true }
 miniz_oxide = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
-serde_json.workspace = true
 anyhow.workspace = true
 
 [lints]

--- a/crates/termlens/src/error.rs
+++ b/crates/termlens/src/error.rs
@@ -1,6 +1,10 @@
 //! Error types. The prime directive: when a wait fails in CI, the log must
 //! show what the terminal actually looked like — so timeout/EOF errors embed
 //! a full [`Screen`] snapshot and render it in their `Display` output.
+//!
+//! The same screens reach a directory when `TERMLENS_ARTIFACT_DIR` is set
+//! (#251), so a step after the tests can render them into the pull request
+//! rather than leaving them in the log; see [`Error`].
 
 use std::time::Duration;
 
@@ -10,6 +14,20 @@ use crate::Screen;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Errors returned by [`Terminal`](crate::Terminal) operations.
+///
+/// # `TERMLENS_ARTIFACT_DIR`
+///
+/// Every variant that carries a [`Screen`] prints it, so a CI log shows
+/// what the application displayed. When the environment variable
+/// `TERMLENS_ARTIFACT_DIR` names a directory, the same screen is also
+/// written there as it is embedded: `<test>-<n>.screen.json` with the
+/// `serde` feature, `<test>-<n>.screen.txt` (the `with_styles` rendering,
+/// which [`Screen::parse`] reads back) without, where `<test>` is the
+/// current thread's name — under `cargo test`, the test's path. Unset, the
+/// hook is one environment read and nothing else; insta's `.snap.new`
+/// files stay where insta puts them. This repository's `report` action
+/// (`.github/actions/report`) renders that directory into a pull
+/// request's step summary.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
@@ -95,6 +113,12 @@ pub enum Error {
     #[error("input not receivable: {0}")]
     Input(String),
 
+    /// A saved screen could not be read back by [`Screen::parse`]: the text
+    /// is not the snapshot format of `docs/DESIGN.md` §3. The message names
+    /// the line.
+    #[error("could not parse a saved screen: {0}")]
+    Parse(String),
+
     /// Typed input could not be delivered: the child is gone and the OS
     /// tore the terminal down, or it stopped reading its input and the
     /// write gave up at the terminal's deadline rather than blocking
@@ -127,6 +151,83 @@ impl Error {
             | Error::Write { screen, .. } => Some(screen),
             _ => None,
         }
+    }
+
+    /// The `TERMLENS_ARTIFACT_DIR` hook (#251): every error that carries a
+    /// screen passes through here on its way out of the crate, and when the
+    /// variable is set the screen is also written to that directory. The
+    /// call is a no-op when it is not — the common case, and the reason
+    /// the check is one environment read.
+    pub(crate) fn recorded(self) -> Self {
+        if let Some(screen) = self.screen() {
+            artifact::write(screen);
+        }
+        self
+    }
+}
+
+/// The `TERMLENS_ARTIFACT_DIR` hook. A CI log shows the screen a failing
+/// wait embedded; this puts the same screen somewhere a step after the
+/// tests can pick it up — the `report` action in this repository renders
+/// each into the pull request's step summary.
+pub(crate) mod artifact {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::Screen;
+
+    /// The environment variable naming the directory. Unset means off.
+    pub(crate) const VAR: &str = "TERMLENS_ARTIFACT_DIR";
+
+    /// One counter per test process, so two screens from one test are two
+    /// files rather than one overwritten.
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// Write `screen` to `$TERMLENS_ARTIFACT_DIR/<test>-<n>.screen.json`
+    /// (with the `serde` feature) or `.screen.txt` (the `with_styles`
+    /// rendering, which `Screen::parse` reads back). `<test>` is the
+    /// current thread's name, which under `cargo test` is the test's path.
+    /// Best effort: a directory that cannot be written is reported once on
+    /// stderr, and the error the screen came from is returned regardless.
+    pub(crate) fn write(screen: &Screen) {
+        let Some(dir) = std::env::var_os(VAR).filter(|d| !d.is_empty()) else {
+            return;
+        };
+        let dir = PathBuf::from(dir);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+        let thread = std::thread::current();
+        let test: String = thread
+            .name()
+            .unwrap_or("screen")
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        let (name, body) = render(screen, &format!("{test}-{n}"));
+        let path = dir.join(name);
+        if let Err(e) = std::fs::create_dir_all(&dir).and_then(|()| std::fs::write(&path, body)) {
+            eprintln!("termlens: could not write {} ({VAR}): {e}", path.display());
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    fn render(screen: &Screen, stem: &str) -> (String, String) {
+        let json =
+            serde_json::to_string(screen).unwrap_or_else(|_| screen.with_styles().to_string());
+        (format!("{stem}.screen.json"), json)
+    }
+
+    #[cfg(not(feature = "serde"))]
+    fn render(screen: &Screen, stem: &str) -> (String, String) {
+        (
+            format!("{stem}.screen.txt"),
+            screen.with_styles().to_string(),
+        )
     }
 }
 

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -13,6 +13,7 @@ use unicode_normalization::UnicodeNormalization;
 use crate::graphics::GraphicsSeen;
 
 mod diff;
+mod parse;
 mod render;
 #[cfg(feature = "serde")]
 mod serde_impl;

--- a/crates/termlens/src/screen/parse.rs
+++ b/crates/termlens/src/screen/parse.rs
@@ -1,0 +1,323 @@
+//! The snapshot text format read back into a [`Screen`] (#255): the
+//! `Display` rendering of `docs/DESIGN.md` §3, with or without the
+//! `styles:` block `with_styles` adds, so a saved screen — an insta `.snap`,
+//! a `TERMLENS_ARTIFACT_DIR` file, a block copied out of a CI log — can be
+//! diffed and rendered outside the test run that produced it.
+//!
+//! What the text format does not carry cannot come back: the out-of-band
+//! state is default, and an erased cell and a written blank are both a
+//! blank. That is the format's contract, not a loss here — `Screen::diff`
+//! and the renderings see the same picture either way.
+
+use unicode_width::UnicodeWidthChar;
+
+use super::{Cell, Color, Screen, Style, TermState};
+use crate::{Error, Result};
+
+impl Screen {
+    /// Parse the snapshot text format back into a `Screen`.
+    ///
+    /// Accepts exactly what [`Display`](std::fmt::Display) and
+    /// [`with_styles`](Self::with_styles) write: the `size:`/`cursor:`
+    /// header, the grid one row per line with trailing blanks stripped
+    /// (missing trailing rows and columns are blank), and optionally a blank
+    /// line, `styles:` and its span lines (or `(none)`). Everything else is
+    /// an [`Error::Parse`] naming the line.
+    ///
+    /// The round trip is exact for what the format carries: the parsed
+    /// screen renders to the same text, with the same `styles:` block, and
+    /// [`diff`](Self::diff)s empty against the original. It does not
+    /// compare `==` to the original — the title, the modes, the counters
+    /// and the history are not in the text and come back default.
+    ///
+    /// ```
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder()
+    /// #     .args(["-c", "printf '\\033[1;31mError:\\033[0m disk full'; read q"]).spawn("sh")?;
+    /// # t.wait_until(|s| s.contains("disk full"))?;
+    /// let saved = t.screen().with_styles().to_string();
+    /// let parsed = termlens::Screen::parse(&saved)?;
+    /// assert_eq!(parsed.with_styles().to_string(), saved);
+    /// assert!(t.screen().diff(&parsed).is_empty());
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    pub fn parse(text: &str) -> Result<Screen> {
+        let mut lines = text.lines();
+        let header = lines
+            .next()
+            .ok_or_else(|| Error::Parse("empty input; expected a `size: …` header".into()))?;
+        let (cols, rows, cursor) = parse_header(header)?;
+        let body: Vec<&str> = lines.collect();
+
+        // Where the grid ends: at the `styles:` marker when there is one,
+        // else at the end. A grid row could read `styles:` itself, so the
+        // marker is the one preceded by a blank line (or first) and followed
+        // by nothing but span lines — the shape `with_styles` writes.
+        let marker = body.iter().enumerate().position(|(i, line)| {
+            line.trim_end() == "styles:"
+                && (i == 0 || body[i - 1].trim().is_empty())
+                && body[i + 1..].iter().all(|l| is_span_line(l))
+        });
+        let (grid, styles) = match marker {
+            // The blank separator before the marker is not a grid row.
+            Some(at) => (&body[..at.saturating_sub(1)], &body[at + 1..]),
+            None => (&body[..], &body[body.len()..]),
+        };
+
+        // Fewer grid lines than rows is a grid whose trailing blank rows
+        // were dropped; more is only tolerated when the extra lines are
+        // blank, so a stray line is an error rather than a lost row.
+        let mut cells = vec![
+            Cell::new(String::new(), Style::default(), false, false);
+            usize::from(cols) * usize::from(rows)
+        ];
+        for (index, line) in grid.iter().enumerate() {
+            let number = index + 2;
+            if index >= usize::from(rows) {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                return Err(Error::Parse(format!(
+                    "line {number}: expected `styles:` or the end of the text after the {rows}-row grid, got {line:?}"
+                )));
+            }
+            parse_row(
+                line,
+                number,
+                cols,
+                &mut cells[index * usize::from(cols)..][..usize::from(cols)],
+            )?;
+        }
+
+        let mut screen = Screen::from_parts(
+            cols,
+            rows,
+            cursor.0,
+            cursor.1,
+            cursor.2,
+            cells,
+            TermState::default(),
+        );
+        let first_style_line = marker.map_or(body.len(), |at| at + 1) + 2;
+        parse_styles(styles, first_style_line, &mut screen)?;
+        Ok(screen)
+    }
+}
+
+/// A line the `styles:` block may hold: `(none)`, blank, or `ROW: …`.
+fn is_span_line(line: &str) -> bool {
+    let line = line.trim_end();
+    line.is_empty()
+        || line == "(none)"
+        || line
+            .split_once(": ")
+            .is_some_and(|(row, _)| !row.is_empty() && row.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// `size: <cols>x<rows>  cursor: <row>,<col>` or `cursor: hidden`.
+fn parse_header(line: &str) -> Result<(u16, u16, (u16, u16, bool))> {
+    let bad = || {
+        Error::Parse(format!("line 1: expected `size: COLSxROWS  cursor: ROW,COL` (or `cursor: hidden`), got {line:?}"))
+    };
+    let rest = line.strip_prefix("size: ").ok_or_else(bad)?;
+    let (size, cursor) = rest.split_once("cursor:").ok_or_else(bad)?;
+    let (cols, rows) = size.trim().split_once('x').ok_or_else(bad)?;
+    let cols: u16 = cols.parse().map_err(|_| bad())?;
+    let rows: u16 = rows.parse().map_err(|_| bad())?;
+    if cols == 0 || rows == 0 {
+        return Err(Error::Parse(format!(
+            "line 1: a screen has at least one column and one row, got {cols}x{rows}"
+        )));
+    }
+    let cursor = cursor.trim();
+    let cursor = if cursor == "hidden" {
+        (0, 0, false)
+    } else {
+        let (r, c) = cursor.split_once(',').ok_or_else(bad)?;
+        let r: u16 = r.parse().map_err(|_| bad())?;
+        let c: u16 = c.parse().map_err(|_| bad())?;
+        if r >= rows || c >= cols {
+            return Err(Error::Parse(format!(
+                "line 1: cursor {r},{c} is outside the {cols}x{rows} grid"
+            )));
+        }
+        (r, c, true)
+    };
+    Ok((cols, rows, cursor))
+}
+
+/// One grid line into `row`, a slice of exactly `cols` cells. Zero-width
+/// characters join the cell before them; a wide character takes two.
+fn parse_row(line: &str, number: usize, cols: u16, row: &mut [Cell]) -> Result<()> {
+    let mut col = 0usize;
+    for ch in line.chars() {
+        let width = ch.width().unwrap_or(0);
+        if width == 0 {
+            match col.checked_sub(1).map(|c| &mut row[c]) {
+                Some(cell) if !cell.contents.is_empty() => cell.contents.push(ch),
+                _ => {
+                    return Err(Error::Parse(format!(
+                        "line {number}: {ch:?} has no character to combine with"
+                    )));
+                }
+            }
+            continue;
+        }
+        if col + width > usize::from(cols) {
+            return Err(Error::Parse(format!(
+                "line {number}: the row is wider than the {cols} columns the header declares"
+            )));
+        }
+        row[col] = Cell::new(ch.to_string(), Style::default(), width == 2, false);
+        if width == 2 {
+            row[col + 1] = Cell::new(String::new(), Style::default(), false, true);
+        }
+        col += width;
+    }
+    Ok(())
+}
+
+/// The span lines after `styles:` — `(none)`, or `<row>: <spans>` — applied
+/// onto `screen`'s cells. `first_line` is the 1-based number of the first,
+/// for the errors.
+fn parse_styles(lines: &[&str], first_line: usize, screen: &mut Screen) -> Result<()> {
+    if lines.is_empty() {
+        return Ok(());
+    }
+    let cols = screen.cols;
+    let mut cells: Vec<Cell> = screen.cells.to_vec();
+    for (offset, line) in lines.iter().enumerate() {
+        let number = first_line + offset;
+        let line = line.trim_end();
+        if line.is_empty() || line == "(none)" {
+            continue;
+        }
+        let bad = |what: &str| Error::Parse(format!("line {number}: {what} in {line:?}"));
+        let (row, spans) = line
+            .split_once(": ")
+            .ok_or_else(|| bad("expected `ROW: SPANS`"))?;
+        let row: u16 = row.trim().parse().map_err(|_| bad("bad row number"))?;
+        if row >= screen.rows {
+            return Err(bad("row is outside the grid"));
+        }
+        for span in spans.split("; ") {
+            let mut tokens = span.split_whitespace();
+            let range = tokens.next().ok_or_else(|| bad("empty span"))?;
+            let column = |text: &str| text.parse::<u16>().map_err(|_| bad("bad column"));
+            let (start, end) = match range.split_once('-') {
+                Some((s, e)) => (column(s)?, column(e)?),
+                None => {
+                    let c = column(range)?;
+                    (c, c)
+                }
+            };
+            if end < start || end >= cols {
+                return Err(bad("span is outside the grid"));
+            }
+            let mut style = Style::default();
+            for token in tokens {
+                match token {
+                    "bold" => style.bold = true,
+                    "dim" => style.dim = true,
+                    "italic" => style.italic = true,
+                    "underline" => style.underline = true,
+                    "blink" => style.blink = true,
+                    "reverse" => style.reverse = true,
+                    "conceal" => style.conceal = true,
+                    "strikethrough" => style.strikethrough = true,
+                    _ => {
+                        if let Some(color) = token.strip_prefix("fg=") {
+                            style.fg = parse_color(color).ok_or_else(|| bad("bad colour"))?;
+                        } else if let Some(color) = token.strip_prefix("bg=") {
+                            style.bg = parse_color(color).ok_or_else(|| bad("bad colour"))?;
+                        } else {
+                            return Err(bad("unknown style token"));
+                        }
+                    }
+                }
+            }
+            for col in start..=end {
+                cells[usize::from(row) * usize::from(cols) + usize::from(col)].style = style;
+            }
+        }
+    }
+    screen.cells = cells.into();
+    Ok(())
+}
+
+/// `4` (indexed) or `#rrggbb`.
+fn parse_color(text: &str) -> Option<Color> {
+    if let Some(hex) = text.strip_prefix('#') {
+        if hex.len() != 6 {
+            return None;
+        }
+        let channel = |i: usize| u8::from_str_radix(&hex[i..i + 2], 16).ok();
+        return Some(Color::Rgb(channel(0)?, channel(2)?, channel(4)?));
+    }
+    text.parse().ok().map(Color::Indexed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_grid_with_styles_round_trips() {
+        let saved = "size: 6x2  cursor: 1,2\nab 東\n\n\nstyles:\n0: 0-1 fg=1 bold; 3-4 bg=#1e1e2e\n1: 5 reverse";
+        let screen = Screen::parse(saved).unwrap();
+        assert_eq!(screen.size(), (6, 2));
+        assert_eq!(screen.cursor(), (1, 2, true));
+        assert!(screen.cell(0, 3).unwrap().is_wide());
+        assert!(screen.cell(0, 4).unwrap().is_wide_continuation());
+        assert_eq!(screen.cell(0, 0).unwrap().style().fg, Color::Indexed(1));
+        assert_eq!(
+            screen.cell(0, 4).unwrap().style().bg,
+            Color::Rgb(0x1e, 0x1e, 0x2e)
+        );
+        assert!(screen.cell(1, 5).unwrap().style().reverse);
+        assert_eq!(screen.with_styles().to_string(), saved);
+    }
+
+    #[test]
+    fn a_short_grid_is_padded_and_none_is_accepted() {
+        let screen = Screen::parse("size: 4x3  cursor: hidden\nhi\n\nstyles:\n(none)").unwrap();
+        assert_eq!(screen.row_text(0), "hi  ");
+        assert_eq!(screen.row_text(2), "    ");
+        assert_eq!(screen.cursor(), (0, 0, false));
+        let plain = Screen::parse("size: 4x3  cursor: hidden\nhi").unwrap();
+        assert!(screen.diff(&plain).is_empty());
+    }
+
+    #[test]
+    fn combining_marks_join_the_cell_before_them() {
+        let screen = Screen::parse("size: 3x1  cursor: 0,0\ne\u{301}x").unwrap();
+        assert_eq!(screen.cell(0, 0).unwrap().contents(), "e\u{301}");
+        assert_eq!(screen.cell(0, 1).unwrap().contents(), "x");
+    }
+
+    #[test]
+    fn errors_name_the_line() {
+        let long = Screen::parse("size: 2x1  cursor: 0,0\nabc")
+            .unwrap_err()
+            .to_string();
+        assert!(long.contains("line 2") && long.contains("wider"), "{long}");
+        let header = Screen::parse("80x24").unwrap_err().to_string();
+        assert!(header.contains("line 1"), "{header}");
+        let cursor = Screen::parse("size: 2x1  cursor: 5,0")
+            .unwrap_err()
+            .to_string();
+        assert!(cursor.contains("outside"), "{cursor}");
+        let token = Screen::parse("size: 2x1  cursor: 0,0\nab\n\nstyles:\n0: 0 shiny")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            token.contains("line 5") && token.contains("unknown style token"),
+            "{token}"
+        );
+        let junk = Screen::parse("size: 2x1  cursor: 0,0\nab\nextra\n")
+            .unwrap_err()
+            .to_string();
+        assert!(junk.contains("expected `styles:`"), "{junk}");
+    }
+}

--- a/crates/termlens/src/terminal.rs
+++ b/crates/termlens/src/terminal.rs
@@ -1256,9 +1256,12 @@ impl EmuState {
     /// The error every screen-based wait returns once the emulator has
     /// failed. `None` while it is healthy.
     fn emulator_failure(&self) -> Option<Error> {
-        self.emu_panic.as_ref().map(|detail| Error::Emulator {
-            detail: detail.clone(),
-            screen: self.peek_snapshot(),
+        self.emu_panic.as_ref().map(|detail| {
+            Error::Emulator {
+                detail: detail.clone(),
+                screen: self.peek_snapshot(),
+            }
+            .recorded()
         })
     }
 
@@ -3045,7 +3048,8 @@ impl Terminal {
             Err(reason) => Err(Error::Write {
                 what: format!("{what} to `{}` ({reason})", self.command_desc).into(),
                 screen: self.screen(),
-            }),
+            }
+            .recorded()),
         }
     }
 
@@ -3085,7 +3089,8 @@ impl Terminal {
         Err(Error::Write {
             what: format!("{what} to `{}` ({reason})", self.command_desc).into(),
             screen: self.screen(),
-        })
+        }
+        .recorded())
     }
 
     /// Write to the child, bounded by the default deadline.
@@ -3236,7 +3241,8 @@ impl Terminal {
                 return Some(Err(Error::Eof {
                     waiting_for: format!("{WHAT}{}{}", state.query_note(), history_note(&screen)),
                     screen,
-                }));
+                }
+                .recorded()));
             }
             None
         });
@@ -3249,7 +3255,8 @@ impl Terminal {
                     waiting_for: format!("{WHAT}{note}{}", history_note(&screen)),
                     timeout,
                     screen,
-                })
+                }
+                .recorded())
             }
         }
     }
@@ -3413,7 +3420,8 @@ impl Terminal {
                 return Some(Err(Error::Eof {
                     waiting_for: format!("{WHAT}{}{}", state.query_note(), history_note(&screen)),
                     screen,
-                }));
+                }
+                .recorded()));
             }
             None
         });
@@ -3481,7 +3489,8 @@ impl Terminal {
                     waiting_for,
                     timeout,
                     screen,
-                })
+                }
+                .recorded())
             }
         }
     }
@@ -3586,7 +3595,8 @@ impl Terminal {
                     waiting_for,
                     timeout,
                     screen,
-                });
+                }
+                .recorded());
             }
             // Sleep until the quiet period could complete, the deadline
             // hits, or new bytes arrive (notification) — whichever first.
@@ -3781,7 +3791,8 @@ impl Terminal {
                     waiting_for,
                     timeout,
                     screen,
-                });
+                }
+                .recorded());
             }
             // Sleep until the stillness could complete, the deadline hits,
             // or new bytes arrive — whichever first; poll-cap while only a
@@ -3915,7 +3926,8 @@ impl Terminal {
                     ),
                     timeout,
                     screen: self.screen(),
-                });
+                }
+                .recorded());
             }
             thread::sleep(backoff.min(deadline - now));
             backoff = next_backoff(backoff);

--- a/crates/termlens/tests/artifact.rs
+++ b/crates/termlens/tests/artifact.rs
@@ -1,0 +1,60 @@
+//! The `TERMLENS_ARTIFACT_DIR` hook (#251): a wait that fails writes the
+//! screen it embeds to that directory, in the shape the `report` action and
+//! `termlens-cli` read back. Alone in this binary because the variable is
+//! process-wide.
+
+use std::time::Duration;
+
+use termlens::Screen;
+
+mod common;
+
+#[test]
+fn a_failed_wait_writes_its_screen_to_the_artifact_dir() -> termlens::Result<()> {
+    let dir = std::env::temp_dir().join(format!("termlens-artifact-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    // Edition 2021: this is a safe call, and this test is alone in its
+    // process. The hook reads the variable at each failure, so setting it
+    // after the terminal spawned is fine.
+    std::env::set_var("TERMLENS_ARTIFACT_DIR", &dir);
+
+    let mut t = common::emit(&["--raw", r"\e[1mReady\e[0m", "--wait"])?;
+    t.wait_until(|s| s.contains("Ready"))?;
+    let err = t
+        .wait_until_for(|s| s.contains("never"), Duration::from_millis(100))
+        .expect_err("the wait must time out");
+    assert!(matches!(err, termlens::Error::Timeout { .. }));
+
+    let mut files: Vec<_> = std::fs::read_dir(&dir)?
+        .map(|e| e.expect("a directory entry").path())
+        .collect();
+    files.sort();
+    assert_eq!(files.len(), 1, "{files:?}");
+    let name = files[0].file_name().unwrap().to_string_lossy().into_owned();
+    // `<test>-<n>.screen.<ext>`: the thread name is this test's path.
+    assert!(
+        name.starts_with("a_failed_wait_writes_its_screen_to_the_artifact_dir-1.screen."),
+        "{name}"
+    );
+    let body = std::fs::read_to_string(&files[0])?;
+    let saved: Screen = if cfg!(feature = "serde") {
+        assert!(name.ends_with(".json"), "{name}");
+        #[cfg(feature = "serde")]
+        {
+            serde_json::from_str(&body).expect("the file is a Screen")
+        }
+        #[cfg(not(feature = "serde"))]
+        unreachable!()
+    } else {
+        assert!(name.ends_with(".txt"), "{name}");
+        Screen::parse(&body)?
+    };
+    assert!(saved.diff(err.screen().unwrap()).is_empty());
+    assert!(saved.cell(0, 0).unwrap().style().bold, "styles come along");
+
+    std::env::remove_var("TERMLENS_ARTIFACT_DIR");
+    let _ = std::fs::remove_dir_all(&dir);
+    t.send(termlens::Key::Enter)?;
+    t.wait_exit()?;
+    Ok(())
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,8 +20,10 @@ One page, copy-pasteable. Maintainers only.
 gh workflow run stress.yml --ref main
 gh run watch                                  # both OSes must pass
 
-# 1. Bump the version (workspace.package.version in root Cargo.toml).
-$EDITOR Cargo.toml                            # version = "X.Y.Z"
+# 1. Bump the version (workspace.package.version in root Cargo.toml), and
+#    the same number in crates/termlens-cli/Cargo.toml's `termlens = { version
+#    = … }` — a path dependency publishes by its version.
+$EDITOR Cargo.toml crates/termlens-cli/Cargo.toml
 cargo check --workspace                       # refreshes Cargo.lock
 
 # 2. Move the CHANGELOG section.
@@ -46,11 +48,22 @@ Pushing the tag runs `release.yml`, which:
 3. runs `cargo-semver-checks` against the last published release
    (skipped gracefully on the first release),
 4. `cargo publish -p termlens` via Trusted Publishing (OIDC) — the
-   repository stores no tokens,
+   repository stores no tokens — then `cargo publish -p termlens-cli` if
+   crates.io already has that crate (a warning, not a failure, if not),
 5. creates the GitHub Release with notes extracted from the CHANGELOG
    section for that version (`.github/scripts/extract-changelog.sh`), and
 6. runs the registry-consumer check against that published version on Linux
    and macOS.
+
+## termlens-cli's first publish
+
+Trusted Publishing is configured per crate, on a crate that exists. The
+first `termlens-cli` release is therefore by hand, once, from the tagged
+commit: `cargo publish -p termlens-cli --locked` with a crates.io token
+that has publish-new scope, then crates.io → termlens-cli → Settings →
+Trusted Publishing → GitHub, repository `vyncint/termlens`, workflow
+`release.yml`, environment `release`. `release.yml` publishes it on every
+tag after that.
 
 ## If something fails mid-release
 


### PR DESCRIPTION
Two saved screens could be compared only by `cargo insta review`, on the machine that ran the tests, and a failing wait's screen reached the CI log and stopped there. Both halves:

- **`crates/termlens-cli`**, published as `termlens-cli`, the `termlens` command: `inspect` (the example grown a command, `--ansi` for colour), `diff a b` (the cell diff of two saved screens — an insta `.snap` with or without its header, the block a wait error prints, a `TERMLENS_ARTIFACT_DIR` file, or the JSON the `serde` feature writes — coloured on a terminal, plain in a pipe, exit 1 when they differ) and `render --svg|--html|--ansi|--text`. Its tests drive it through a PTY with termlens.
- **`Screen::parse`**: the snapshot text format of DESIGN §3 read back, `styles:` block included, so the format round-trips. `Error::Parse` names the line.
- **`TERMLENS_ARTIFACT_DIR`**: every error that carries a screen also writes it there when set (`.screen.json` with `serde`, `.screen.txt` without). Documented on `Error`.
- **`.github/actions/report`**: composite action, `if: failure()`, renders those files and every `.snap.new` (with the diff against its `.snap`) into the step summary, SVG/HTML uploaded as an artifact. This repository's `test` job runs it with the CLI from the tree.
- `release.yml` publishes `termlens-cli` after `termlens` once crates.io knows it. **Trusted Publishing is per crate and needs the crate to exist, so the first `termlens-cli` publish is by hand** — RELEASING.md has the steps.

Closes #255
Closes #251