### PR TITLE
docs: what 1.0 means, the backend comparison, and a required Windows leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,15 +124,14 @@ jobs:
 
   # The Windows leg (#149): the whole suite over ConPTY, with the tests that
   # ConPTY cannot honour marked `#[cfg_attr(windows, ignore = "…")]`, each
-  # with its reason. Non-required while it earns it — `continue-on-error`
-  # keeps a ConPTY surprise from blocking a Unix fix, and required-green does
-  # not list it. Promoting it is two edits: drop continue-on-error, add it
-  # to required-green's needs. windows.yml is the dispatchable version with
-  # the ConPTY probe and the report.
+  # with its reason. Required since #280: it ran non-required first and held
+  # on every push to main from the day it landed through the 0.10 series.
+  # A ConPTY surprise now blocks a merge, which is the point — the platform
+  # is claimed in docs/STABILITY.md. windows.yml is the dispatchable version
+  # with the ConPTY probe and the report, for reading rather than gating.
   windows:
-    name: windows (non-required)
+    name: windows
     runs-on: windows-latest
-    continue-on-error: true
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -268,7 +267,7 @@ jobs:
   required-green:
     name: required-green
     if: always()
-    needs: [fmt, clippy, test, features, windows-check, msrv, docs, deny, zizmor, gates-listed, skill]
+    needs: [fmt, clippy, test, features, windows-check, windows, msrv, docs, deny, zizmor, gates-listed, skill]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every needed job succeeded

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,18 +1,15 @@
 name: windows
 
-# The Windows machine this project does not otherwise have (#149).
+# The Windows report (#149), on demand against any ref.
 #
-# Windows is not a CI leg: the suite drives `/bin/sh` at 99 sites (#249) and
-# ConPTY re-renders rather than forwards, so a required leg today would be
-# red on the shell before it said anything about the crate. This workflow
-# runs on demand instead — against any ref — and reports rather than gates:
-# the whole suite with nothing stopping early, then the ConPTY probe
+# ci.yml's `windows` job is the gate: the whole suite on windows-latest,
+# required since #280. This workflow is for reading rather than gating —
+# the suite with nothing stopping early, then the ConPTY probe
 # (`tests/conpty_probe.rs`), which prints per escape sequence whether the
 # master read what the child wrote. Both logs are the artifact; the pass
 # count and the probe table go to the job summary so no download is needed.
-#
-# The build itself is defended on every PR by ci.yml's `windows-check`,
-# from a Linux runner. This is the half that needs the OS.
+# Run it when a ConPTY claim in docs/STABILITY.md §1 needs re-measuring, or
+# to see the ignored-test count for a branch before opening the PR.
 
 on:
   workflow_dispatch:
@@ -42,8 +39,8 @@ jobs:
       - name: Build everything first, so a compile error is not read as a test failure
         run: cargo build --workspace --all-targets --all-features
       - name: Run the whole suite without stopping
-        # A red suite is the expected outcome until #249 lands; the log is
-        # the deliverable, so the step must not end the job.
+        # The log is the deliverable, so a failure must not end the job
+        # before the probe and the summary run.
         continue-on-error: true
         run: cargo test --workspace --all-features --no-fail-fast 2>&1 | tee suite.log
       - name: Ask ConPTY what it forwards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ listed under a **Changed** or **Removed** heading.
   screen. Plain text, so CI logs stay readable. An erased cell and a
   written space in the same style are one blank, not a difference. (#246)
 
+- **`docs/STABILITY.md`: what 1.0 means.** Not a feature list — three
+  decisions written down with the measurement that decided each: Windows
+  (screen assertions yes, frame assertions no; the ConPTY probe), the
+  emulator backend (`vt100` stays and so does the shadow parser;
+  `docs/BACKENDS.md` compares it with `alacritty_terminal`, which drops
+  blink and brings an event loop, and `wezterm-term`, which is not on
+  crates.io), and styled history (a knob, off by default, 90 ms against
+  40 ms). Plus which public items the promise covers, which stay behind
+  features, and which are heuristics. `docs/RELEASING.md` requires all
+  three sections for a 1.0 tag. (#256, #150)
+
 - **`termlens-cli`: the `termlens` command, and `Screen::parse`.** Two
   saved screens could be compared only by `cargo insta review`, on the
   machine that ran the tests. `cargo install termlens-cli` provides
@@ -169,6 +180,12 @@ listed under a **Changed** or **Removed** heading.
   crate in CI, and the README shows the one-line install for Claude Code.
 
 ### Changed
+
+- **The `windows-latest` leg is a required check.** It ran non-required
+  from #279 and held on every push to `main` since; a ConPTY surprise now
+  blocks a merge, which is what claiming the platform in
+  `docs/STABILITY.md` means. `windows.yml` stays as the on-demand report
+  with the probe. (#280)
 
 - **`assert_screen_snapshot!` earns its name.** It was `insta::assert_snapshot!`
   under another name. Given a `Terminal` it now settles the picture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,9 @@ cargo insta review            # inspect and accept/reject each diff
 - `docs/DESIGN.md` — the architecture in four layers, wait semantics, and the
   snapshot format spec. **Read this before touching `wait.rs`, `terminal.rs`,
   or the emulator.**
+- `docs/STABILITY.md` — what 1.0 means: three decisions (Windows, backend,
+  styled history) with their measurements, and what the promise covers.
+  `docs/BACKENDS.md` is the emulator comparison behind the second.
 - `skills/termlens/` — the skill for AI coding agents that write tests
   *with* termlens (`AGENTS.md` briefs agents working *on* it). Every Rust
   block in `SKILL.md` is compiled against the crate by

--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ design. termlens's position:
   them). The tests for each are `#[cfg_attr(windows, ignore = "…")]` with
   the reason in the attribute; the probe that measured all of this is
   `tests/conpty_probe.rs`, and the `windows` workflow re-runs it on demand.
+  The `windows-latest` leg is a required check. This is decision 1 of
+  [docs/STABILITY.md](docs/STABILITY.md).
 - A child that writes and exits within its first milliseconds can lose
   output to the OS PTY teardown (macOS especially). Long-lived TUIs are
   unaffected; for run-and-exit programs, end the script with a `read` and
@@ -448,8 +450,12 @@ check excludes it.
 
 PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) (dev setup, testing
 policy, DCO sign-off, AI tooling policy) and
-[docs/DESIGN.md](docs/DESIGN.md) before touching wait semantics. Security
-reports: [SECURITY.md](SECURITY.md).
+[docs/DESIGN.md](docs/DESIGN.md) before touching wait semantics. What 1.0
+means — three decisions written down with their measurements, and which
+public items the promise covers — is [docs/STABILITY.md](docs/STABILITY.md);
+the emulator-backend comparison behind one of them is
+[docs/BACKENDS.md](docs/BACKENDS.md). Security reports:
+[SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -1,0 +1,89 @@
+# Emulator backends: the comparison behind decision 2
+
+[STABILITY.md](STABILITY.md) §2 says `vt100` stays and the attribute
+shadow stays on purpose. This is the comparison it rests on (#150),
+measured in September 2026 against the seven methods the `Emulator` trait
+needs — `process`, `snapshot`, `mid_sequence`, `in_sync_update`,
+`input_modes`, `mode_state`, `set_size` — and against the three places the
+backend, not the design, was the limit: blink/conceal/strikethrough (the
+shadow), mouse modes collapsing into one value, and exotic grapheme
+clusters rendering however the backend renders them.
+
+## The candidates
+
+| | `vt100` 0.16.2 | `alacritty_terminal` 0.26.0 | `wezterm-term` |
+|---|---|---|---|
+| On crates.io | yes | yes | **no** — git-only in the wezterm workspace; the `tattoy-wezterm-term` fork is a third party's |
+| Licence | MIT | Apache-2.0 only | MIT |
+| MSRV | 1.70 | 1.85.0, moves with Alacritty releases | wezterm's, moves with wezterm |
+| Source size | 3,950 lines | 11,739 lines | larger; a workspace of crates (`wezterm-cell`, `-escape-parser`, `-surface`, `termwiz`) |
+| Dependency tree (`default-features = false`) | 9 crates: `vte`, `unicode-width`, `itoa`, and theirs | 27 crates: `vte`, `polling`, `rustix`, `rustix-openpty`, `signal-hook`, `parking_lot`, `regex-automata`, `base64`, `home`… — the tty/event-loop half is not feature-gated | `image`, `serde`, `terminfo`, `url`, `lru`, `miniz_oxide`, `unicode-normalization`, `wezterm-bidi`… |
+| Headless driving | `Parser::process(bytes)`; `Callbacks` trait for what it does not handle | `Term::new(config, dims, EventListener)` + `vte::ansi::Processor::advance`; `VoidListener` exists | `Terminal::new` with a `TerminalConfiguration` and a writer; designed around a renderer |
+| SGR blink (`5`/`6`) | dropped | **dropped** — no `Flags::BLINK`; `Attr::Blink` is not handled | tracked |
+| SGR conceal (`8`) | dropped | tracked (`HIDDEN`) | tracked |
+| SGR strikethrough (`9`) | dropped | tracked (`STRIKEOUT`) | tracked |
+| Extra attributes | — | double/curly/dotted/dashed underline, underline colour | the same and more |
+| Mouse modes | one value (the last set) | distinct flags: `MOUSE_REPORT_CLICK`, `MOUSE_DRAG`, `MOUSE_MOTION`, `SGR_MOUSE`; no 1005 | distinct |
+| Kitty keyboard, focus, bracketed paste, alt screen, insert, origin, LNM | partial (see below) | all as `TermMode` flags | all |
+| Grapheme clusters | one `char` + width; zero-width chars appended to the previous cell | one `char` + `zerowidth: Vec<char>`, same shape | `finl_unicode` segmentation; the strongest of the three |
+| Scrollback reflow on resize | no | yes (`grid/resize.rs`) | yes |
+| Unhandled-sequence hook | `Callbacks::unhandled_*` — the basis of `Screen::unsupported` | none; unknown sequences are silently ignored | none |
+| Release cadence | slow: 0.16.2 (July 2025) is the newest | with Alacritty, several a year, breaking freely | with wezterm |
+
+## What termlens already does in front of the backend
+
+The `Emulator` trait was meant as a swap point, but the more useful thing
+it turned out to be is a place to stand *in front of* the backend with a
+staged stream both parsers receive. Everything below is termlens's own and
+would survive any swap unchanged:
+
+- **Character sets** (G0–G3, SO/SI, SS2/SS3, DEC Special Graphics, UK):
+  glyph substitution before the parser.
+- **Tab stops** (HTS/TBC/CHT/CBT, and plain `HT`): rewritten to `CHA`.
+- **Insert mode** (IRM): rewritten to `ICH` sized in columns.
+- **The unsupported record** (`Screen::unsupported`): every sequence the
+  backend did not implement, from `Callbacks` — the honesty layer that
+  says "this grid may be wrong" instead of looking plausible.
+- **Queries and their answers**, the title, the clipboard, links, the
+  counters, graphics payloads: the sequence tracker, not the emulator.
+- **Blink, conceal, strikethrough**: the shadow parser.
+
+## Why a swap does not pay today
+
+1. **`wezterm-term` cannot be depended on.** It is not published;
+   `deny.toml` refuses git sources and crates.io refuses git dependencies.
+   It would have to be vendored, which is the option the shadow was chosen
+   over at 3,950 lines, now at many times that.
+2. **`alacritty_terminal` does not close the gap it would be adopted
+   for.** It tracks two of the three attributes and drops blink. A swap
+   keeps a shadow (or a fork) for one attribute, so the mechanism stays
+   and only the reason shrinks. It also pulls an event loop and a tty
+   layer termlens has its own of, triples the dependency count, moves the
+   MSRV onto Alacritty's schedule, and — because it ignores what it does
+   not implement — would cost `Screen::unsupported` its source.
+3. **The shadow is not a performance problem.** 40,000 lines through an
+   80x24 screen: 260 ms with it, 263 ms without; 284 ms against 282 ms
+   when every line carries four SGR sequences. A terminal's throughput is
+   the PTY round trip.
+4. **The three limits have been answered in front of the backend, or
+   accepted.** Mouse modes: `Screen::mouse_modes` reports the set the
+   application enabled from the tracker (#151). Graphemes: the
+   unicode-torture fixture pins vt100's rendering rather than promising
+   one, and no candidate promises Unicode-correct segmentation *and* the
+   rest of this table.
+
+## What would reopen the question
+
+- **vt100 gains blink, conceal and strikethrough** (three spare bits in
+  `mode: u8`, an 80-line patch): `emu/shadow.rs` deletes and
+  `convert_cell` reads the flags. This is the outcome to watch for, and
+  the module header says so.
+- **A candidate appears that is published, tracks all three attributes,
+  can be driven headless without an event loop, and reports the
+  sequences it does not handle.** Then the comparison is worth re-running
+  against the trait, behind a feature flag, with the fixture suite as the
+  judge — the ratatui fidelity test and the unicode-torture snapshot are
+  the two that would move.
+- **A consumer needs reflowed history.** Neither the design nor the
+  backend offers it today (`Terminal::resize` says why); a backend that
+  does would be an argument, not a decision.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,6 +13,13 @@ One page, copy-pasteable. Maintainers only.
   minted from a branch. (Optionally set the environment name `release`
   on the crates.io side too, for the server-side binding.)
 
+## Before a 1.0 tag
+
+`v1.0.0` requires all three sections of [STABILITY.md](STABILITY.md) —
+Windows, backend, styled history — to be filled in with their decision
+and the measurement behind it, and the "What the promise covers" list to
+match `lib.rs`. A 1.0 with an open section is a 0.x with a bigger number.
+
 ## Cutting vX.Y.Z
 
 ```sh

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -1,0 +1,125 @@
+# What 1.0 means
+
+termlens is `0.x`, and every minor is allowed to break a consumer. 1.0 is
+not a feature list — it is **three decisions written down with the
+measurement that decided each**, plus a statement of which public items
+the promise covers. A 1.0 tag requires all three sections below to be
+filled in ([RELEASING.md](RELEASING.md) says so), and each was allowed to
+come out *no*: an honest no is a 1.0 that means something.
+
+Decided in 0.10 (September 2026). The issue each was decided in links
+back here.
+
+## 1. Windows — screen assertions yes, frame assertions no (#149)
+
+**The question.** Does termlens run on Windows, and if so which of
+`wait_until`, `wait_frame` and the query responder are supported there?
+
+**The measurement.** `tests/conpty_probe.rs` sends twenty-one escape
+sequences through a ConPTY (`portable-pty` 0.9, no passthrough mode) and
+reports, per sequence, what the master read. Six came out verbatim. The
+rest ConPTY eats (DA1, OSC 10/11, XTGETTCAP, DECRQM, mouse and focus mode
+sets, kitty and sixel payloads, HTS/TBC), rewrites equivalently (SGR
+reordered, OSC 2 as OSC 0, DEC graphics as UTF-8, a tab as `CUF`, link ids
+of its own) or reorders: a DEC 2026 bracket closes *before* the content it
+wrapped. It also sends every child a preamble (`CSI 6 n`, `?9001h`,
+`?1004h`, a title, `?25h`) and does not start the child until the `6n` is
+answered, and a child's exit is not EOF on the pipe. The mechanics are in
+[DESIGN.md](DESIGN.md) §1.
+
+**The decision.** Windows is a supported platform for what survives the
+re-render — the grid (text, cells, styles, cursor, wide characters, box
+drawing, title, links by URL, clipboard, bracketed paste, cursor shape,
+bell, the alternate screen), resize, typed input, `wait_until`,
+`wait_stable`, `snapshot_after`, `wait_exit`, `bin!` — and is documented
+as Unix-only for what does not: `wait_frame`, `frame_timings`, `record`,
+graphics, the responder's outbound claims (`Graphics`, `background_rgb`,
+`foreground_rgb`, `cell_size`), `mouse_mode(s)`, `focus_events`, link
+ids, `Terminal::signal`, non-UTF-8 bytes. Each test the platform cannot
+honour is `#[cfg_attr(windows, ignore = "<the probe row>")]`. The
+`windows-latest` leg runs the whole suite on every pull request and is a
+required check; the `windows` workflow re-runs the probe on demand. The
+README's Known limitations carry the user-facing list. A change to what
+ConPTY does is a change to this section, not a bug in termlens.
+
+## 2. Backend — `vt100` stays, and so does the shadow parser (#150)
+
+**The question.** Does the emulator behind the `Emulator` trait stay
+`vt100`, or move to `wezterm-term` or `alacritty_terminal` — which would
+retire the second parser that recovers blink, conceal and strikethrough,
+and give mouse modes and grapheme clusters a stronger footing?
+
+**The measurement.** [BACKENDS.md](BACKENDS.md) holds the comparison:
+attribute coverage, grapheme handling, mouse-mode fidelity, reflow,
+dependency weight, MSRV, licence, publishability and maintenance cadence
+of the three, against the seven methods the trait needs. The numbers that
+decided it: `wezterm-term` is not on crates.io (a git dependency cannot be
+published, and `deny.toml` refuses it); `alacritty_terminal` tracks
+conceal and strikethrough but **not blink**, so a swap keeps one carrier
+attribute in a shadow or a fork anyway, and brings 27 crates (an event
+loop, `polling`, `rustix`, `signal-hook` — its tty half is not optional)
+against `vt100`'s 9, under a single Apache-2.0 licence and an MSRV that
+moves with the Alacritty release train; and the shadow's measured cost is
+noise (260 ms with, 263 ms without, for 40,000 lines through 80x24).
+
+**The decision.** `vt100` stays, and the shadow stays on purpose: two
+parsers over one stream is a mechanism whose soundness is argued from
+vt100's own code (attributes never influence geometry) and checked by a
+debug assertion on every snapshot. What the backend does not do, termlens
+does in front of it — character sets, tab stops, insert mode, the
+unsupported-sequence record — on the same staged stream, which is why the
+shadow keeps its shape. The trait remains the swap point, and BACKENDS.md
+names what would reopen the question: upstream vt100 gaining the three
+attributes (the shadow deletes), or a candidate that is published, tracks
+all three, and can be driven headless without an event loop.
+
+## 3. Styled history — a knob, off by default (#146)
+
+**The question.** What is a scrolled-off row: text, or cells with styles?
+The masked-password assertion — the one the shadow parser exists for —
+silently degraded to text the moment the screen filled.
+
+**The measurement.** With history retained as cells, 20,000 lines
+through an 80x24 screen cost about 90 ms against 40 ms text-only (release
+build, `tests/styled_history.rs`'s ignored probe). The cost lands where a
+suite feels it: every read that scrolls captures cells, and a snapshot
+pays one refcount per retained row.
+
+**The decision.** History is text by default and cells on request:
+`TerminalBuilder::scrollback_styles(true)` retains the styled rows, the
+shadow parser keeps the same history and is read in lockstep so the three
+recovered attributes come along, and `Screen::scrollback_cell` and
+`styled_scrollback` read them back. `Screen::locate` answers the
+addressing half — grid or history, and honest that a history column is
+the row's *as captured*, since history is not reflowed (the reason is
+`Terminal::resize`'s: a record exists, and the cost is what decides it).
+Off by default because a suite that never scrolls should not pay, and
+because the one assertion that needs it can ask.
+
+## What the promise covers
+
+Once the three sections above stand, 1.0 promises semver over:
+
+- every `pub` item exported from `lib.rs` without a feature gate: the
+  `Terminal`/`TerminalBuilder` surface, `Screen` and its accessors,
+  `Cell`, `Style`, `Color`, the mode enums, `Error` (`#[non_exhaustive]`,
+  so variants may be *added*), `bin!`;
+- the snapshot text format of [DESIGN.md](DESIGN.md) §3, which
+  `Screen::parse` reads back — a snapshot file recorded under 1.0 stays
+  valid;
+- the coordinate conventions: `(row, col)` for cells, `(cols, rows)` for
+  geometry.
+
+Behind features, versioned with the feature's dependency rather than with
+termlens: `insta` (the macro follows insta), `decode`, `regex`, `serde`
+(the JSON shape follows the types' derives).
+
+Documented as heuristics, promised to keep their *shape* and not their
+timing: `wait_idle` and `wait_stable` (a quiet window is a judgement),
+`snapshot_after`'s 100 ms settle, and the frame-history and record
+budgets, whose defaults may move.
+
+Not covered: the `Emulator` trait and everything under `emu/` (internal),
+the exact text of error messages (they carry screens; the prefixes in the
+skill's failure table are kept stable, the rest is prose), the fixtures,
+and `termlens-cli`'s output format beyond its exit codes.

--- a/skills/termlens/SKILL.md
+++ b/skills/termlens/SKILL.md
@@ -5,7 +5,7 @@ description: Write, fix or review headless terminal tests for a Rust CLI or TUI 
 
 # Testing terminal programs with termlens
 
-Written against **termlens 0.9.0**. Every `rust` block below is a complete
+Written against **termlens 0.10.0**. Every `rust` block below is a complete
 integration test that is compiled against the crate in CI, so the API it
 shows is the API that exists. The recipes spawn a binary called `myapp`
 that draws a list with a `> ` highlight, a status line ending in
@@ -17,7 +17,10 @@ application's own texts where the comments say so.
 termlens spawns your **real binary** in a **real pseudo-terminal**, drains
 its output on a reader thread through a VT emulator into an in-memory
 **screen grid**, and lets a test wait on and assert against that grid —
-Playwright for the terminal. Unix only (Linux, macOS).
+Playwright for the terminal. Linux and macOS in full; on Windows (ConPTY)
+screen assertions work and frame assertions do not — `wait_frame`,
+`record`, graphics and mouse modes are Unix-only there, and a test that
+needs one is `#[cfg_attr(windows, ignore = "…")]` with the reason.
 
 Use it for the things an in-process mock cannot see:
 
@@ -109,9 +112,11 @@ your test ── send(Key) · click · paste · resize ──▶ PTY     └─�
 8. **`wait_frame` only works for applications that emit DEC 2026
    synchronized updates.** Stock ratatui 0.30 with crossterm does **not**
    (measured: `repaints()` stays 0), so `wait_frame` times out against it
-   with a message saying exactly that. Default to `snapshot_after`. Use
-   `wait_frame` only if the application brackets its repaints in
-   `BeginSynchronizedUpdate` / `EndSynchronizedUpdate`.
+   with a message saying exactly that, and `Terminal::record()` refuses
+   for the same reason. Default to `snapshot_after`. Use `wait_frame` only
+   if the application brackets its repaints in `BeginSynchronizedUpdate` /
+   `EndSynchronizedUpdate` — then a `wait_frame` timeout also shows the
+   diff from the last frame it returned to the live screen.
 
 9. **Return `termlens::Result<()>` from the test and use `?`.** The
    `Display` of every error carries the screen, so a failing wait prints
@@ -120,9 +125,11 @@ your test ── send(Key) · click · paste · resize ──▶ PTY     └─�
 10. **Snapshot the `Screen`, not its text.** `insta::assert_snapshot!(screen)`
     records the header (`size: 80x24  cursor: 3,5` or `cursor: hidden`) and
     the grid; `screen.with_styles()` adds a `styles:` block that catches a
-    colour regression. `.text()` drops the header and `format!("{:?}")` is
-    the same as `Display`. Review changes with `cargo insta review`; never
-    blind-accept with `INSTA_UPDATE=always`.
+    colour regression. The one-liner that gets all three decisions right —
+    wait, settle, styles — is `termlens::assert_screen_snapshot!(t, after =
+    |s| s.contains("Ready"))`. `.text()` drops the header and
+    `format!("{:?}")` is the same as `Display`. Review changes with `cargo
+    insta review`; never blind-accept with `INSTA_UPDATE=always`.
 
 11. **The environment is hermetic by default — set what the app reads.**
     Under `env_clear()` (which `bin!` applies) the child sees only
@@ -136,16 +143,25 @@ your test ── send(Key) · click · paste · resize ──▶ PTY     └─�
     (CJK, most emoji) occupies two cells: the leading one `is_wide()`, the
     next `is_wide_continuation()`. `find` reports real terminal columns.
     `contains` and `find` fold both sides to NFC and search the **visible
-    screen only** — text that scrolled off is in `full_text()`, and a line
-    that wrapped is two rows, so a needle spanning the wrap is not found.
+    screen only** — text that scrolled off is in `full_text()` (and
+    `locate` says which region holds a needle), and a line that wrapped is
+    two rows, so a needle spanning the wrap is found by `logical_text()`,
+    not by `contains`. `find_all` lists every match; a volatile cell is
+    masked in the grid with `mask_rect` / `mask_matching`, never edited in
+    the text.
 
 ## 4. Setup
 
 ```toml
 [dev-dependencies]
-termlens = "0.9"
+termlens = "0.10"
 insta = "1"          # for the snapshot recipes; termlens also re-exports it as `termlens::insta`
 ```
+
+Features, all off by default except `insta`: `regex` (a pattern over a row
+of the screen: `wait_until_matches`, `find_match`, `mask_matches`),
+`serde` (a `Screen` as JSON and back, for `assert_json_snapshot!` or a CI
+step), `decode` (the pixels of inline images).
 
 - Put the tests in `tests/` **of the package that owns the `[[bin]]`**:
   Cargo sets `CARGO_BIN_EXE_<name>` only there, and `bin!` needs it at
@@ -153,9 +169,10 @@ insta = "1"          # for the snapshot recipes; termlens also re-exports it as 
   to `Terminal::builder().spawn(path)` instead.
 - The binary is built by `cargo test` before the tests run. Tests run in
   parallel by default; each spawns its own PTY, which is fine.
-- Gate the test file with `#![cfg(unix)]` if the crate must also build on
-  Windows.
-- `add --features decode` only if you assert on the pixels of inline images.
+- The crate builds and runs on Windows over ConPTY. Do not gate whole files
+  with `#![cfg(unix)]`; mark the individual tests the platform cannot
+  honour — frames, graphics, mouse modes, signals — with
+  `#[cfg_attr(windows, ignore = "…")]` naming the reason.
 
 ## 5. Recipes
 
@@ -318,6 +335,49 @@ fn cells_styles_and_wide_characters() -> termlens::Result<()> {
 }
 ```
 
+### Recipe E — the snapshot macro, a cell diff, and a masked clock
+
+```rust
+use termlens::{Key, Screen};
+
+#[test]
+fn snapshot_diff_and_mask() -> termlens::Result<()> {
+    let mut t = termlens::bin!("myapp")?;
+
+    // Wait for the marker, let the picture settle, snapshot WITH styles:
+    // the three decisions every TUI snapshot needs, in one line. `styles =
+    // false` for text only; `(&screen)` snapshots a Screen you already hold.
+    termlens::assert_screen_snapshot!(t, after = |s| s.contains("Ready"));
+
+    // Two screens, and what changed between them — rows, columns, style
+    // runs — rendered in the assertion message rather than two whole grids.
+    let before = t.screen();
+    t.send(Key::Char('j'))?;
+    let after = t.snapshot_after(|s| s.contains("> Beta"))?;
+    let diff = before.diff(&after);
+    assert!(!diff.is_empty(), "j should have moved the highlight:\n{diff}");
+    assert!(diff.cells().any(|(row, _, _, _)| row == 1), "{diff}");
+
+    // A clock in the top-right corner breaks whole-screen snapshots. Mask
+    // it in the GRID — the mask keeps every column and style where it was,
+    // which a text filter over the rendering cannot. (cols, rows), like size().
+    let masked: Screen = after.mask_rect(70..80, 0..1);
+    // Or by shape: every digit anywhere becomes `#`.
+    let _digits_hidden = after.mask_matching("0123456789", '#');
+    termlens::assert_screen_snapshot!(&masked);
+
+    // Every occurrence, not just the first; and a needle that spans a soft
+    // wrap, which contains() cannot see across rows.
+    let separators = after.find_all("│");
+    assert!(separators.len() >= 2, "{after}");
+    assert!(after.logical_text().contains("Ready: j/k move, q quits"));
+
+    t.send(Key::Char('q'))?;
+    assert!(t.wait_exit()?.success());
+    Ok(())
+}
+```
+
 ## 6. Reading a failure
 
 Every error's `Display` ends with the screen, under a header that says
@@ -330,7 +390,8 @@ Read the first line for the cause:
 | `… note: N rows have scrolled off the top` | the text went into history | assert with `full_text()` / `scrollback_text()` |
 | `… note: the application queried the terminal (^[[?u …) and received no answer` | the app is blocked on a probe termlens deliberately does not answer | the app needs a fallback; see the termlens README's Known limitations |
 | `terminal closed (EOF) while waiting for …` | the app exited before the predicate held | check `wait_exit()` first, or the app crashed — the final screen shows why |
-| `the application never emitted a DEC 2026 synchronized update` | `wait_frame` against an app without synchronized output | use `snapshot_after` / `wait_until` (rule 8) |
+| `the application never emitted a DEC 2026 synchronized update` | `wait_frame` or `record().stop()` against an app without synchronized output | use `snapshot_after` / `wait_until` (rule 8) |
+| `--- last returned frame → live screen ---` under a `wait_frame` timeout | the app repainted, but never into the predicate | the diff shows what did change; the predicate is looking at the wrong thing |
 | `input not receivable: the application has not enabled mouse tracking` | `click`/`drag`/`scroll` before the app enabled the mouse | `wait_until(|s| s.mouse_mode() != MouseMode::None)` first |
 | `input not receivable: mouse at (50, 2) is outside the 20x5 grid` | coordinates swapped or out of range | rule 6 |
 | `failed to spawn \`sh\`: \`sh\` is a bare program name and env_clear() removed PATH` | bare program name under `env_clear` | absolute path, `bin!`, or `.env("PATH", …)` |
@@ -350,6 +411,8 @@ Read the first line for the cause:
 | `.env(k, v)` / `.envs([..])` / `.env_clear()` | environment; `env_clear` keeps `TERM` and `SHELL` pinned and drops the rest |
 | `.current_dir(path)` | default: the test process's directory |
 | `.scrollback(rows)` | history retained (default 1000, text only) |
+| `.scrollback_styles(true)` | retain scrolled rows as cells too, so `scrollback_cell` keeps a masked-field assertion alive after it scrolls (measured cost in the rustdoc) |
+| `.record_budget(cells)` | how much `record()` retains before dropping the oldest frames |
 | `.spawn(program) -> Result<Terminal>` | program is a path or a name on `PATH` |
 
 **Wait** (all return `termlens::Result`, all embed the screen on failure, all have a `_for(…, timeout)` twin):
@@ -362,6 +425,8 @@ Read the first line for the cause:
 | `wait_idle(quiet)` | `()` | no *bytes* for `quiet` — a weaker, older sibling of `wait_stable` |
 | `wait_frame(\|s\| bool)` | `Screen` | complete DEC 2026 frames only (rule 8) |
 | `wait_exit()` | `ExitStatus` | the child's exit; `success()`, `code() -> Option<u32>`, `signal() -> Option<&str>` |
+| `wait_until_matches(&Regex)` | `Screen` | feature `regex`: a pattern over a row of the screen — the expect-style wait, on the grid |
+| `record()` … `.stop()` | `Recording` | every complete DEC 2026 frame with its time; `frames()`, `write_asciicast(path)` for a file `asciinema` plays |
 
 **Drive**: `send(Key)`, `send_str("text")` (no Enter — send `Key::Enter`
 yourself; `"\n"` would send LF, not CR), `paste("text")` (bracketed if the
@@ -379,17 +444,24 @@ from_r, to_c, to_r)`, `scroll(col, row, Scroll::Down)`, `resize(cols, rows)`,
 
 | Accessor | Returns |
 |---|---|
-| `contains(&str)` / `find(&str)` | `bool` / `Option<(row, col)>` — visible grid, NFC-folded |
+| `contains(&str)` / `find(&str)` / `find_all(&str)` | `bool` / `Option<(row, col)>` / `Vec<(row, col)>` — visible grid, NFC-folded |
+| `locate(&str)` | `Option<Location>`: `Screen { row, col }` or `History { row, col }` |
+| `logical_text()` / `row_wrapped(row)` | wrapped rows joined back into lines / where the backend wrapped |
 | `find_by(\|&Cell\| bool)` | `Option<(row, col)>` |
 | `cell(row, col)` | `Option<&Cell>`: `contents()`, `style()`, `is_wide()`, `is_wide_continuation()` |
 | `row_text(row)` / `text()` / `rect_text(cols, rows)` | `String` |
 | `full_text()` / `scrollback_text()` / `scrollback_rows()` | history + screen / history / count |
+| `scrollback_cell(row, col)` / `styled_scrollback()` | history as cells, with `scrollback_styles(true)` |
 | `size()` / `cols()` / `rows()` | `(cols, rows)` |
 | `cursor()` | `(row, col, visible)`; `cursor_shape()`, `cursor_blink()` |
 | `alternate_screen()`, `bracketed_paste()`, `application_cursor()`, `focus_events()` | mode flags |
 | `mouse_mode()` / `mouse_modes()` | reporting protocol / the set the app enabled |
 | `title()`, `clipboard()`, `links()`, `bells()`, `repaints()`, `graphics()` | out-of-band state |
+| `unsupported()` / `insert_mode()` | sequences the emulator did not implement (`^[[20h`…), so a plausible grid can be told from a right one / IRM left on |
 | `with_styles()` | `Display` with a `styles:` block; snapshot this to catch colour regressions |
+| `diff(&other)` | `ScreenDiff`: `is_empty()`, `cells()`, and a `Display` of only the rows that changed |
+| `mask_rect(cols, rows)` / `mask_matching(chars, fill)` / `mask_cells(pred)` | a new `Screen` with those cells replaced, styles and columns intact |
+| `to_ansi()` / `to_svg()` / `to_html()` | renderings a person can see; `Screen::parse(text)` reads the text format back |
 
 **Style** (`Copy`, public fields): `fg`, `bg` (`Color::Default` /
 `Color::Indexed(u8)` / `Color::Rgb(u8, u8, u8)`), `bold`, `dim`, `italic`,
@@ -399,8 +471,10 @@ double underline are not modelled.
 **Errors** (`termlens::Error`, `#[non_exhaustive]`): `Timeout { waiting_for,
 timeout, screen }`, `Eof { waiting_for, screen }`, `Spawn { command, reason }`,
 `Size(String)`, `Input(String)`, `Write { what, screen }`, `Emulator {
-detail, screen }`, `Pty(String)`, `Io(std::io::Error)`. `err.screen()` returns
-the embedded screen when there is one.
+detail, screen }`, `Parse(String)`, `Pty(String)`, `Io(std::io::Error)`.
+`err.screen()` returns the embedded screen when there is one. With
+`TERMLENS_ARTIFACT_DIR` set, every such screen is also written to that
+directory (see §9b).
 
 ## 8. Pitfalls an agent falls into, and the fix
 
@@ -431,9 +505,13 @@ the embedded screen when there is one.
 - `insta::assert_snapshot!("name", screen)` — several snapshots in one test.
 - Inline snapshots work: `insta::assert_snapshot!(screen, @"")`, then
   `cargo insta review` fills the literal.
-- `termlens::assert_screen_snapshot!(screen)` is the same call through the
-  `insta` termlens re-exports, for crates that do not want their own `insta`
-  dev-dependency.
+- `termlens::assert_screen_snapshot!(t)` settles the terminal (100 ms of
+  stillness) and snapshots **with styles**; `(t, after = |s| …)` waits for
+  the predicate first; `(t, styles = false)` for text only; `(&screen)`
+  for a `Screen` already in hand; `(t, @"…")` inline. Through the `insta`
+  termlens re-exports, so no separate `insta` dev-dependency is needed.
+- With the `serde` feature, `insta::assert_json_snapshot!(screen)` records
+  the structured form and takes insta's redactions per field.
 - Volatile content (a clock, a PID, a spinner) breaks whole-screen
   snapshots. insta's text filters are not grid-aware — a shorter replacement
   shifts every column after it — so prefer asserting the stable region with
@@ -441,6 +519,19 @@ the embedded screen when there is one.
   and snapshot the whole screen only when nothing on it moves.
 - Snapshot files live in `tests/snapshots/`; commit them. Review every
   change with `cargo insta review`; a diff you cannot explain is a bug.
+
+## 9b. At a shell prompt, and in CI
+
+- `cargo install termlens-cli` gives the harness as a command: `termlens
+  inspect --size 120x40 myapp` prints what a program shows (`--ansi` for
+  colour), `termlens diff old.snap new.snap.new` prints the cell diff of two
+  saved screens and exits 1 if anything changed, `termlens render --svg
+  failing.snap` makes an image. A saved screen is any text termlens prints
+  — an insta `.snap`, the grid a wait error leaves in a log.
+- In CI, set `TERMLENS_ARTIFACT_DIR: ${{ runner.temp }}/termlens` on the
+  test step and add `uses: vyncint/termlens/.github/actions/report@v0.10.0`
+  with `if: failure()` after it: every screen a failing wait embedded, and
+  every `.snap.new` with its diff, lands in the pull request's step summary.
 
 ## 10. A checklist before you finish
 


### PR DESCRIPTION
- **`docs/STABILITY.md`** — 1.0 as three decisions written down with the measurement behind each: Windows (screen assertions yes, frame assertions no), the emulator backend (`vt100` stays, and so does the shadow parser), styled history (a knob, off by default). Plus what the promise covers, what stays behind features, what is a heuristic. RELEASING.md requires all three sections for a 1.0 tag; the README's contributing section links it.
- **`docs/BACKENDS.md`** — the comparison behind decision 2, measured: `wezterm-term` is not on crates.io; `alacritty_terminal` 0.26 tracks conceal and strikethrough but **drops blink** (no `Flags::BLINK`), brings 27 crates including an event loop and a tty layer against vt100's 9, Apache-2.0 alone, MSRV on Alacritty's schedule; the shadow's cost is noise. What would reopen the question.
- **Windows leg required** (#280): non-required since #279, green on every push to `main` since; `windows.yml` stays as the on-demand report.
- **Skill at 0.10.0**: Windows note, features, the new APIs in the cheat sheet, a compile-checked recipe for the macro + `diff` + masks, a section on the CLI and the report action.

Closes #256
Closes #150
Closes #280