### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-09-08
+
 ### Added
 
 - **Styled history, opt in: `TerminalBuilder::scrollback_styles(true)` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "emit"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "libc",
 ]
@@ -432,7 +432,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form-echo"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "crossterm",
 ]
@@ -524,7 +524,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-tui"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "crossterm",
  "termlens",
@@ -544,7 +544,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image-echo"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "miniz_oxide",
 ]
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-app"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ratatui",
  "serde_json",
@@ -1217,7 +1217,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "resize-echo"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "crossterm",
 ]
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "termlens-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde_json",
  "termlens",
@@ -1696,7 +1696,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "unicode-truncate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "crates/termlens-cli", "fixtures/*"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.

--- a/crates/termlens-cli/Cargo.toml
+++ b/crates/termlens-cli/Cargo.toml
@@ -23,7 +23,7 @@ doc = false
 # The version is the one release bumps alongside `workspace.package.version`
 # (docs/RELEASING.md); a path dependency needs it to publish. `serde` so a
 # saved screen can be JSON as well as the text format.
-termlens = { version = "0.9.0", path = "../termlens", default-features = false, features = ["serde"] }
+termlens = { version = "0.10.0", path = "../termlens", default-features = false, features = ["serde"] }
 serde_json.workspace = true
 
 [lints]


### PR DESCRIPTION
Version bump to 0.10.0 (`workspace.package.version` and `termlens-cli`'s `termlens = { version = … }`), the CHANGELOG's `[Unreleased]` section moved to `[0.10.0] - 2026-09-08` with a fresh empty `[Unreleased]` above it, `Cargo.lock` refreshed.

Per `docs/RELEASING.md`: the stress workflow on `main` is running against the final merge (`7e5695d`); this merges once it is green, then `v0.10.0` is tagged on the squash commit. `cargo semver-checks` against 0.9.0 reports no update required for a 0.10.0 (the two `Changed` entries — `drag`'s arity, `Style` non-exhaustive — are within a 0.x minor).

Note for after the tag: `release.yml` will publish `termlens` and then **warn** about `termlens-cli`, which is not on crates.io yet — its first publish is by hand (RELEASING.md, "termlens-cli's first publish").