### PR TITLE
fix(cli): handle --version in each subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`termlens <subcommand> --version` is no longer an unknown option.**
+  The flag was handled only in the top-level dispatch, so `termlens inspect
+  --version` exited 2 while `-h`/`--help` worked in that position. All three
+  subcommands now print the same version string as the top-level command. (#310)
+
 ## [0.10.1] - 2026-09-08
 
 ### Changed

--- a/crates/termlens-cli/src/main.rs
+++ b/crates/termlens-cli/src/main.rs
@@ -92,6 +92,11 @@ fn fail(message: &str) -> ExitCode {
     ExitCode::from(2)
 }
 
+/// The one-line string every `--version` flag prints.
+fn version() -> String {
+    format!("termlens {}\n", env!("CARGO_PKG_VERSION"))
+}
+
 fn main() -> ExitCode {
     let mut args = std::env::args().skip(1);
     let Some(command) = args.next() else {
@@ -101,7 +106,7 @@ fn main() -> ExitCode {
     let rest: Vec<String> = args.collect();
     match command.as_str() {
         "-h" | "--help" => print(&format!("{USAGE}\n")),
-        "--version" => print(&format!("termlens {}\n", env!("CARGO_PKG_VERSION"))),
+        "--version" => print(&version()),
         "inspect" => inspect(rest),
         "diff" => diff(&rest),
         "render" => render(&rest),
@@ -164,6 +169,7 @@ fn diff(args: &[String]) -> ExitCode {
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "-h" | "--help" => return print(&format!("{DIFF_USAGE}\n")),
+            "--version" => return print(&version()),
             "--color" => {
                 color = match args.next().map(String::as_str) {
                     Some("auto") => ColorWhen::Auto,
@@ -281,6 +287,7 @@ fn render(args: &[String]) -> ExitCode {
     for arg in args {
         match arg.as_str() {
             "-h" | "--help" => return print(&format!("{RENDER_USAGE}\n")),
+            "--version" => return print(&version()),
             "--svg" | "--html" | "--ansi" | "--text" => format = Some(arg.as_str()),
             other if other.starts_with('-') && other != "-" => {
                 return fail(&format!(
@@ -349,6 +356,7 @@ fn inspect(args: Vec<String>) -> ExitCode {
         let flag = args.next().unwrap_or_default();
         let parsed = match flag.as_str() {
             "-h" | "--help" => return print(&format!("{INSPECT_USAGE}\n")),
+            "--version" => return print(&version()),
             "--" => break,
             "--size" => take(&mut args, "--size", "COLSxROWS", "120x40", |spec| {
                 let (c, r) = spec.split_once('x')?;

--- a/crates/termlens-cli/tests/cli.rs
+++ b/crates/termlens-cli/tests/cli.rs
@@ -213,3 +213,26 @@ fn help_and_version() -> termlens::Result<()> {
     let _: Screen = Screen::parse("size: 1x1  cursor: 0,0\n")?;
     Ok(())
 }
+
+#[test]
+fn subcommand_version_prints_same_string_as_top_level() -> termlens::Result<()> {
+    // The top-level version string is the reference.
+    let mut top = termlens::bin!("termlens", args(["--version"]))?;
+    assert_eq!(top.wait_exit()?.code(), Some(0));
+    let expected = concat!("termlens ", env!("CARGO_PKG_VERSION"));
+
+    for subcommand in ["diff", "render", "inspect"] {
+        let mut t = termlens::bin!("termlens", args([subcommand, "--version"]))?;
+        assert_eq!(
+            t.wait_exit()?.code(),
+            Some(0),
+            "`termlens {subcommand} --version` exited non-zero"
+        );
+        assert!(
+            t.screen().contains(expected),
+            "`termlens {subcommand} --version` output:\n{}",
+            t.screen()
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Fixes #310.

## Problem

`termlens --version` worked, but `termlens inspect|diff|render --version` returned exit code 2 with `unknown option`.

## Fix

- Extracted `version() -> String` helper so the formatted version string lives in one place.
- Added `--version` handling to the flag loop of each subcommand (`diff`, `render`, `inspect`), mirroring how `-h`/`--help` is handled.
- Added `subcommand_version_prints_same_string_as_top_level` test in `crates/termlens-cli/tests/cli.rs` that checks all three subcommands exit 0 and print the same string as `termlens --version`.

Signed-off-by: Jabrail <78273416+jabrailkhalil@users.noreply.github.com>