### PR TITLE
docs(skill): say 0.10.1, which is the behaviour it already describes

### DIFF
--- a/skills/termlens/SKILL.md
+++ b/skills/termlens/SKILL.md
@@ -5,7 +5,7 @@ description: Write, fix or review headless terminal tests for a Rust CLI or TUI 
 
 # Testing terminal programs with termlens
 
-Written against **termlens 0.10.0**. Every `rust` block below is a complete
+Written against **termlens 0.10.1**. Every `rust` block below is a complete
 integration test that is compiled against the crate in CI, so the API it
 shows is the API that exists. The recipes spawn a binary called `myapp`
 that draws a list with a `> ` highlight, a status line ending in


### PR DESCRIPTION
The skill's header has said **0.10.0** since the docs pass, but #301 rewrote its cheat-sheet mask line to *"`mask_matching` is a literal (rows included — it spans a wrap the way `find_all` does)"*.

Spanning a wrap is **0.10.1** behaviour: 0.10.0 reported a row-spanning needle through `find_all` and then masked nothing (#300). So the file documents 0.10.1 and claims to document 0.10.0.

One line. It matters because consumers **vendor this file** — mossaic keeps a copy under `.claude/skills/termlens/` and pins it to the version the header names, so a wrong marker propagates into other repositories as a wrong claim about which behaviour they can rely on.