### PR TITLE
docs(readme): link Ratatui's snapshot-testing recipe; say what the renderers are for

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ terminal.
 [![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](https://github.com/vyncint/termlens/blob/main/Cargo.toml)
 [![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](#license)
 
+Ratatui's [snapshot-testing recipe](https://ratatui.rs/recipes/testing/snapshots/)
+includes a termlens example for testing a compiled application through a PTY.
+Use it alongside `TestBackend` snapshots to cover interactions and process
+behaviour.
+
 ```sh
 cargo add termlens --dev
 cargo add insta --dev    # used by the snapshot assertions below
@@ -91,8 +96,11 @@ finds it without installing anything, through `.claude/skills/termlens`.
 - **Not** an expect-style stream matcher — [rexpect] and [expectrl] already
   do that well. Byte streams can't answer "is the cursor on the third menu
   item?".
-- **Not** an SVG transcript generator for pretty docs — that's
-  [term-transcript].
+- **Not** an SVG transcript generator for documentation — that's
+  [term-transcript]. termlens does render a screen to ANSI, SVG and HTML
+  (`Screen::to_svg`, `termlens render`), for one purpose: so a *failing*
+  screen can be looked at in a CI job summary or a pull request, which is
+  what the [report action](#at-a-shell-prompt-and-in-ci) uses them for.
 - **It is**: a real PTY + an emulated screen + snapshot assertions, so you
   test what a user would *see*.
 


### PR DESCRIPTION
Two documentation-only changes to the README, from #333.

**Ratatui recipe.** Ratatui's [snapshot-testing recipe](https://ratatui.rs/recipes/testing/snapshots/) includes a termlens example that drives a compiled application through a PTY. A short paragraph after the badges links it, worded to claim exactly what the page says — a documentation reference — not "recommended by" or "official".

**What the renderers are for.** "What it is (and is not)" said termlens is *not* an SVG transcript generator, while the crate ships `to_svg`, `to_html` and `termlens render`. Both statements are true; the bullet now explains the purpose — a *failing* screen as a CI artifact, which is what the report action uses them for — and links the CI section.

No code changes. Rendered output checked in the diff; the in-page anchor `#at-a-shell-prompt-and-in-ci` matches the existing heading.

Closes #333

Signed-off-by: Vyncint Ng <115854244+vyncint@users.noreply.github.com>
