### PR TITLE
docs: make the README's links absolute, so the crates.io page stops 404ing

### DIFF
--- a/.github/scripts/check-readme-links.sh
+++ b/.github/scripts/check-readme-links.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Every link in the packaged README must be absolute, and must point at a
+# file that exists.
+#
+# `crates/termlens/Cargo.toml` sets `readme = "../../README.md"`, so this
+# file is shipped as the crate's README and crates.io renders it there.
+# crates.io rewrites a *relative* link against the crate's directory in the
+# repository, not the repository root -- so `docs/DESIGN.md` became
+# `…/blob/HEAD/crates/termlens/docs/DESIGN.md`, and every one of the ten
+# relative links on the 0.10.2 page was a 404. Nothing in this repository
+# could see it: the same file renders correctly on GitHub, where it *is* at
+# the root.
+#
+# So: absolute links only, and the path each one names must exist here.
+# The second half is the more useful one -- it is offline, deterministic,
+# and catches a renamed or deleted target, which a link checker that only
+# asks GitHub would report as a 200 for the wrong reason or not at all.
+#
+# Usage: check-readme-links.sh [README.md]
+set -euo pipefail
+
+readme="${1:-README.md}"
+root=$(cd "$(dirname "$0")/../.." && pwd)
+base="https://github.com/vyncint/termlens/blob/main/"
+status=0
+
+# `[text](target)` with a target that is neither absolute nor a fragment.
+relative=$(grep -oE '\]\([^)]+\)' "$readme" \
+  | sed -E 's/^\]\(//; s/\)$//' \
+  | grep -vE '^(https?:|#|mailto:)' || true)
+if [ -n "$relative" ]; then
+  echo "$relative" | while IFS= read -r link; do
+    echo "README LINK: relative target \"$link\" — crates.io rewrites it against" >&2
+    echo "  crates/termlens/, where it does not exist. Use ${base}$link" >&2
+  done
+  status=1
+fi
+
+# Every in-repo absolute link names a path that is really here.
+checked=0
+missing=0
+for url in $(grep -oE "${base}[^)]+" "$readme" | sort -u); do
+  path=${url#"$base"}
+  path=${path%%#*}
+  checked=$((checked + 1))
+  if [ ! -e "$root/$path" ] && [ ! -d "$root/$path" ]; then
+    echo "README LINK: \"$path\" is linked but not in the repository" >&2
+    missing=$((missing + 1))
+  fi
+done
+if [ "$missing" -gt 0 ]; then
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "readme links: $checked absolute link(s), every target present, none relative"
+fi
+exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,11 @@ jobs:
       # to fail on the pull request rather than after the publish.
       - run: cargo build -p termlens-cli
       - run: .github/scripts/check-cli-contract.sh target/debug/termlens
+      # The README is shipped as this crate's readme, and crates.io rewrites
+      # a relative link against crates/termlens/ rather than the repo root.
+      # Every relative link on the 0.10.2 page was a 404 and nothing here
+      # could see it, because the same file renders correctly on GitHub.
+      - run: .github/scripts/check-readme-links.sh
       # The screens of whatever failed, in the step summary (#251). The
       # suite dogfoods the action with the CLI from this tree.
       - uses: ./.github/actions/report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every link on the crates.io page pointed at a 404** (#341). The root
+  README is shipped as this crate's readme (`readme = "../../README.md"`),
+  and crates.io rewrites a *relative* link against the crate's directory in
+  the repository rather than the repository root — so `docs/DESIGN.md`
+  became `…/blob/HEAD/crates/termlens/docs/DESIGN.md`, and all ten relative
+  links on the 0.10.2 page were dead: the design, stability, limitations and
+  backends documents, the skill, the changelog, contributing, security, both
+  licences and the stress workflow.
+
+  Nothing here could see it. The same file renders correctly on GitHub,
+  where it really is at the root, so the bug existed only on the surface
+  most new readers arrive at.
+
+  The links are absolute now, and `.github/scripts/check-readme-links.sh`
+  (in `ci.yml`) refuses a relative one — and separately checks that every
+  absolute target still exists in the repository, offline, which catches a
+  renamed file that a link checker asking GitHub would miss.
+
+  Fixed for future releases only: crates.io renders each version's readme as
+  published, so the 0.10.2 page and earlier stay as they are.
+
 ## [0.10.2] - 2026-09-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ an assertion sees one consistent instant. The emulator sits behind a small
 internal trait; `vt100` is the backend, with a second parser recovering the
 three style attributes it drops (blink, conceal, strikethrough). The
 mechanics, and the reasoning behind each decision, are in
-[docs/DESIGN.md](docs/DESIGN.md).
+[docs/DESIGN.md](https://github.com/vyncint/termlens/blob/main/docs/DESIGN.md).
 
 ## Waiting without flakes
 
@@ -152,7 +152,7 @@ bounded too: typing into an application that has stopped reading, or into a
 child that has exited, is an error carrying the screen rather than a hang.
 The three rules for race-free waits — one predicate per instant, wait on
 the last thing painted, settle before whole-screen snapshots — are
-[docs/DESIGN.md](docs/DESIGN.md) §2.
+[docs/DESIGN.md](https://github.com/vyncint/termlens/blob/main/docs/DESIGN.md) §2.
 
 ## Snapshots that survive volatile content
 
@@ -274,11 +274,11 @@ that, so what termlens claims on Windows is what survives the re-render.
 The whole suite runs on `windows-latest` as a required check; each test the
 platform cannot honour is `#[cfg_attr(windows, ignore = "…")]` with the
 reason. The measurement is `tests/conpty_probe.rs`; the decision is
-[docs/STABILITY.md](docs/STABILITY.md) §1.
+[docs/STABILITY.md](https://github.com/vyncint/termlens/blob/main/docs/STABILITY.md) §1.
 
 ## Stability and versioning
 
-termlens is `0.x`. [docs/STABILITY.md](docs/STABILITY.md) states what 1.0
+termlens is `0.x`. [docs/STABILITY.md](https://github.com/vyncint/termlens/blob/main/docs/STABILITY.md) states what 1.0
 means — three decisions written down with the measurement behind each —
 and which public items the compatibility promise covers. **0.11 is the
 stability candidate**: from that release no promised item changes
@@ -293,7 +293,7 @@ published crate.
 ## Limitations
 
 The short list; the full one, with the reason behind each entry, is
-[docs/LIMITATIONS.md](docs/LIMITATIONS.md).
+[docs/LIMITATIONS.md](https://github.com/vyncint/termlens/blob/main/docs/LIMITATIONS.md).
 
 - Terminal dimensions are 2–1000 cells per axis.
 - `wait_frame` needs the application to bracket repaints in DEC 2026
@@ -312,7 +312,7 @@ The short list; the full one, with the reason behind each entry, is
 
 Agents write terminal tests badly in predictable ways — a `sleep` where a
 wait belongs, a snapshot taken mid-repaint, `(row, col)` handed to a method
-that wants `(col, row)`. [`skills/termlens/SKILL.md`](skills/termlens/SKILL.md)
+that wants `(col, row)`. [`skills/termlens/SKILL.md`](https://github.com/vyncint/termlens/blob/main/skills/termlens/SKILL.md)
 is the counter to each: the model, the rules, the API on one page and four
 recipes. Every Rust block in it is compiled against the crate in CI.
 
@@ -327,28 +327,28 @@ Other agents take the same file — a Cursor rule, or a reference from
 
 | | |
 | --- | --- |
-| [docs/DESIGN.md](docs/DESIGN.md) | the four layers, wait semantics and the three rules, the snapshot text format, why the emulator is where it is |
-| [docs/STABILITY.md](docs/STABILITY.md) | what 1.0 means, and what the promise covers |
-| [docs/LIMITATIONS.md](docs/LIMITATIONS.md) | everything termlens does not model or claim, with reasons |
-| [docs/BACKENDS.md](docs/BACKENDS.md) | the emulator comparison behind keeping `vt100` |
-| [skills/termlens/SKILL.md](skills/termlens/SKILL.md) | the agent skill: rules, API cheat sheet, recipes |
-| [CHANGELOG.md](CHANGELOG.md) | every release, breaking changes under **Changed** / **Removed** |
+| [docs/DESIGN.md](https://github.com/vyncint/termlens/blob/main/docs/DESIGN.md) | the four layers, wait semantics and the three rules, the snapshot text format, why the emulator is where it is |
+| [docs/STABILITY.md](https://github.com/vyncint/termlens/blob/main/docs/STABILITY.md) | what 1.0 means, and what the promise covers |
+| [docs/LIMITATIONS.md](https://github.com/vyncint/termlens/blob/main/docs/LIMITATIONS.md) | everything termlens does not model or claim, with reasons |
+| [docs/BACKENDS.md](https://github.com/vyncint/termlens/blob/main/docs/BACKENDS.md) | the emulator comparison behind keeping `vt100` |
+| [skills/termlens/SKILL.md](https://github.com/vyncint/termlens/blob/main/skills/termlens/SKILL.md) | the agent skill: rules, API cheat sheet, recipes |
+| [CHANGELOG.md](https://github.com/vyncint/termlens/blob/main/CHANGELOG.md) | every release, breaking changes under **Changed** / **Removed** |
 | [docs.rs](https://docs.rs/termlens) | the API reference |
 
 ## Contributing
 
-Pull requests are welcome — [CONTRIBUTING.md](CONTRIBUTING.md) has the dev
+Pull requests are welcome — [CONTRIBUTING.md](https://github.com/vyncint/termlens/blob/main/CONTRIBUTING.md) has the dev
 setup, the testing policy and the DCO sign-off. Three things to know before
 starting: every change lands with tests; anything touching wait semantics
-must pass the 100-iteration [stress workflow](.github/workflows/stress.yml)
+must pass the 100-iteration [stress workflow](https://github.com/vyncint/termlens/blob/main/.github/workflows/stress.yml)
 on Linux, macOS and Windows; snapshot updates are reviewed diffs
 (`cargo insta review`), never blind accepts. Security reports go to
-[SECURITY.md](SECURITY.md).
+[SECURITY.md](https://github.com/vyncint/termlens/blob/main/SECURITY.md).
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
-[MIT license](LICENSE-MIT) at your option. Unless you explicitly state
+Licensed under either of [Apache License, Version 2.0](https://github.com/vyncint/termlens/blob/main/LICENSE-APACHE) or
+[MIT license](https://github.com/vyncint/termlens/blob/main/LICENSE-MIT) at your option. Unless you explicitly state
 otherwise, any contribution intentionally submitted for inclusion in the
 work by you, as defined in the Apache-2.0 license, shall be dual licensed as
 above, without any additional terms or conditions.


### PR DESCRIPTION
Closes #341.

## The bug

`crates/termlens/Cargo.toml` sets `readme = "../../README.md"`, so the root README ships as this crate's readme. **crates.io rewrites a relative link against the crate's directory, not the repository root** — so `docs/DESIGN.md` was served as

```
https://github.com/vyncint/termlens/blob/HEAD/crates/termlens/docs/DESIGN.md   → 404
```

There is no `crates/termlens/docs/`. **All ten relative links on the published 0.10.2 page are dead** — verified one at a time against the live rendering, not inferred: DESIGN, STABILITY, LIMITATIONS, BACKENDS, the skill, CHANGELOG, CONTRIBUTING, SECURITY, both licences, the stress workflow.

**Nothing in this repository could see it.** The same file renders correctly on GitHub, where it really is at the root. The only broken surface was the one most new readers arrive at.

## The fix

Absolute links — the only shape correct from both roots. All eleven targets rewritten and each checked to return 200.

`.github/scripts/check-readme-links.sh` (in `ci.yml`) keeps it that way, and does **two** things:

1. refuses a relative link, naming the absolute URL to use instead;
2. asserts every absolute target **still exists in this checkout** — offline, deterministic, and it catches a renamed or deleted file, which a checker that only asks GitHub would report as fine or miss entirely.

Both failure paths were exercised: a relative link → exit 1 with the suggested URL; an absolute link to `docs/GONE.md` → exit 1 naming the missing path.

## Scope, stated plainly

**This reaches future releases only.** crates.io renders each version's readme as published, so the 0.10.2 page and every earlier one stay broken — nothing can change them. The fix becomes visible at the next publish.

## Not fixed here

`launchbound-space` and `launchbound-cli` have the identical defect — `readme = "../../README.md"` and **8 broken links each** at 2.2.0 (`docs/ARCHITECTURE.md`, `docs/LIMITATIONS.md` twice, `docs/SAFETY.md`, `action/`, `rust-toolchain.toml`, both licences). Different repo, noted in #341.

reconverge and mossaic are clean — reconverge gives every crate its own `readme = "README.md"` with no relative links, which is the other way to avoid this.

Closes #341

Signed-off-by: Vyncint Ng <115854244+vyncint@users.noreply.github.com>