### PR TITLE
release: v0.10.3 — the crates.io page's links work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ listed under a **Changed** or **Removed** heading.
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-09-10
+
 ### Fixed
 
 - **Every link on the crates.io page pointed at a 404** (#341). The root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "emit"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "libc",
 ]
@@ -432,7 +432,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form-echo"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "crossterm",
 ]
@@ -524,7 +524,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-tui"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "crossterm",
  "termlens",
@@ -544,7 +544,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image-echo"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "miniz_oxide",
 ]
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-app"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ratatui",
  "serde_json",
@@ -1217,7 +1217,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "resize-echo"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "crossterm",
 ]
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "termlens"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "insta",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "termlens-cli"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "serde_json",
  "termlens",
@@ -1696,7 +1696,7 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-torture"
-version = "0.10.2"
+version = "0.10.3"
 
 [[package]]
 name = "unicode-truncate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 members = ["crates/termlens", "crates/termlens-cli", "fixtures/*"]
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 # Minimum supported Rust version. Checked by the `msrv` CI job, which reads
 # this field; bumping it is a minor (not patch) change per our SemVer policy.

--- a/crates/termlens-cli/Cargo.toml
+++ b/crates/termlens-cli/Cargo.toml
@@ -23,7 +23,7 @@ doc = false
 # The version is the one release bumps alongside `workspace.package.version`
 # (docs/RELEASING.md); a path dependency needs it to publish. `serde` so a
 # saved screen can be JSON as well as the text format.
-termlens = { version = "0.10.2", path = "../termlens", default-features = false, features = ["serde"] }
+termlens = { version = "0.10.3", path = "../termlens", default-features = false, features = ["serde"] }
 serde_json.workspace = true
 
 [lints]


### PR DESCRIPTION
One reason, deliberately.

## Why now rather than batched

The published 0.10.2 page has **11 dead links** — every relative link in the README, rewritten by crates.io against `crates/termlens/` instead of the repo root. #342 fixed it, and **crates.io renders each version's readme as published**, so the fix is invisible until a release. That page is the project's main discovery surface; it shouldn't sit broken while work accumulates for a bigger patch.

Nothing else is bundled. The remaining cheap wins — #305 (DESIGN §3), #314 (CONTRIBUTING), #319 (CHANGELOG links) and the fixture/test issues — are **repo-surface and need no release at all**; they go live when they merge. The CLI flag additions (#312, #313, #317) would need one, but they're a day's work and would have held this behind them. The library additions stay behind #328, which defines what "promised" means.

## What ships

`docs: make the README's links absolute` (#342, closing #341), plus the guard that keeps it fixed: `.github/scripts/check-readme-links.sh` refuses a relative link *and* asserts every absolute target still exists in the checkout — offline, so it also catches a renamed file a GitHub-based checker would miss.

## Verified

`cargo test --workspace --all-features` **518 passed, 0 failed**; fmt; the README-links guard; `gates-listed`; `skill-snippets`; the CLI contract against a path build.

After the tag, `install.yml`'s `cli` leg runs from `release.yml` — the same one that caught #310 in the published 0.10.1 before I trusted it.

Signed-off-by: Vyncint Ng <115854244+vyncint@users.noreply.github.com>