### PR TITLE
ci: a forced, per-view semver gate; isolated feature tests; MSRV over features

### DIFF
--- a/.github/scripts/check-feature-isolation.sh
+++ b/.github/scripts/check-feature-isolation.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# The minimal library build must be minimal (#324).
+#
+# Cargo unifies features across every package selected in one invocation,
+# and `termlens-cli` depends on the library with `features = ["serde"]` — so
+# `cargo test --workspace --no-default-features` tested a library that had
+# `serde` on, and a `cfg(feature = "serde")` mistake in the library could
+# not be caught here. It was not hypothetical: `tests/record.rs` used
+# `serde_json` unconditionally and `cargo test -p termlens
+# --no-default-features` did not build.
+#
+# The `features` job now selects the library alone for every reduced
+# configuration; this asserts that selection really is isolated, by asking
+# Cargo for the library's own dependency tree — normal edges only, since the
+# dev-dependencies (insta) legitimately pull serde in for the tests — and
+# refusing any mention of serde in it.
+#
+# Usage: check-feature-isolation.sh
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+tree="$(cargo tree -p termlens --no-default-features -e normal,features)"
+if printf '%s\n' "$tree" | grep -q 'serde'; then
+  echo "::error::the minimal termlens build (-p termlens --no-default-features) still resolves serde:"
+  printf '%s\n' "$tree" | grep -n 'serde' | sed 's/^/  /'
+  exit 1
+fi
+echo "feature isolation: the minimal termlens tree ($(printf '%s\n' "$tree" | wc -l | tr -d ' ') lines) mentions no serde"

--- a/.github/scripts/check-semver.sh
+++ b/.github/scripts/check-semver.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# The semver gate (#323): termlens's public API against the last published
+# release, with the release type forced and every feature view checked.
+#
+# Two holes in a naive `cargo semver-checks` run, both measured and both
+# asserted by tools/semver-gate-selftest/run.sh:
+#
+#   * The version number decides how much is checked. A 0.10 -> 0.11 bump is
+#     inferred as a major release and every check is skipped, so any
+#     contributor who bumps the version in the same PR as a break gets a
+#     green gate. The type is therefore forced here and never inferred.
+#   * `--all-features` cannot see an item moved behind a feature: that view
+#     never loses the item. Cargo calls that removal a major change, so the
+#     default and explicit-only views run as well.
+#
+# The baseline is a literal: the last *published* version, which is the one
+# a consumer can install. It moves in a follow-up PR after each release, not
+# in the release PR — a version that is not on crates.io yet cannot be a
+# baseline (docs/RELEASING.md). Never a moving "latest".
+#
+# The release type is `patch` unless a break is *declared*, in one of two
+# places, because the pull-request label alone is invisible on a push to
+# main and turned main red after the first labelled break merged elsewhere:
+#
+#   1. the pull request carries the `breaking` label (BREAKING_LABEL=true,
+#      set by the workflow from the event payload);
+#   2. CHANGELOG.md records the break: a bullet beginning `- **Breaking`
+#      under `## [Unreleased]`, or under the section for the tree's own
+#      version when that version is ahead of the baseline — the state main is
+#      in between a release merge and the baseline bump that follows publish.
+#
+# A declared break runs with `--release-type major`. Not `minor`: on a 0.x
+# crate cargo-semver-checks still calls a removed item a major change under
+# `minor`, so the label would not have let the one intended break through
+# (the self-test pins this too).
+#
+# Usage: check-semver.sh <baseline-version>
+#   env BREAKING_LABEL=true   the PR carries the `breaking` label
+set -euo pipefail
+
+baseline=${1:?usage: check-semver.sh <baseline-version>}
+package=termlens
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+version="$(cargo metadata --no-deps --format-version 1 \
+  | jq -r --arg p "$package" '.packages[] | select(.name == $p) | .version')"
+
+# A `- **Breaking` bullet inside one `## [section]` of the CHANGELOG.
+declares_break() {
+  awk -v want="$1" '
+    /^## \[/ { in_section = (index($0, "## [" want "]") == 1) }
+    in_section && /^- \*\*Breaking/ { found = 1 }
+    END { exit !found }
+  ' CHANGELOG.md
+}
+
+declared=""
+if [ "${BREAKING_LABEL:-false}" = "true" ]; then
+  declared="the pull request carries the \`breaking\` label"
+elif declares_break Unreleased; then
+  declared="CHANGELOG.md declares a break under [Unreleased]"
+elif [ "$version" != "$baseline" ] && declares_break "$version"; then
+  declared="CHANGELOG.md declares a break under [$version], which is ahead of the $baseline baseline"
+fi
+
+if [ -n "$declared" ]; then
+  release_type=major
+else
+  release_type=patch
+fi
+
+checker="$(cargo semver-checks --version)"
+echo "semver gate: $checker"
+echo "  package $package $version against published $baseline; release type $release_type${declared:+ ($declared)}"
+
+status=0
+for view in default-features only-explicit-features all-features; do
+  echo "::group::$view"
+  if ! cargo semver-checks --package "$package" \
+        --baseline-version "$baseline" \
+        --release-type "$release_type" \
+        "--$view"; then
+    echo "::error::the $view view of $package $version is not $release_type-compatible with $baseline (release type $release_type)"
+    status=1
+  fi
+  echo "::endgroup::"
+done
+
+# The job summary records what checked what, so a green run is legible later.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### semver gate"
+    echo
+    echo "- checker: \`$checker\`"
+    echo "- baseline: \`$package $baseline\` (published); tree: \`$version\`"
+    echo "- release type: \`$release_type\`${declared:+ — $declared}"
+    echo "- views: default-features, only-explicit-features, all-features"
+    echo "- result: $([ "$status" -eq 0 ] && echo pass || echo FAIL)"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "semver gate: PASS — $package $version is $release_type-compatible with $baseline in all three views"
+fi
+exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,11 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
-      - run: cargo clippy --workspace --all-targets --no-default-features --features decode -- -D warnings
+      # The reduced sets select the library alone: with --workspace the CLI's
+      # `features = ["serde"]` is unified into the library and the "minimal"
+      # build being linted is not minimal (#324).
+      - run: cargo clippy -p termlens --all-targets --no-default-features -- -D warnings
+      - run: cargo clippy -p termlens --all-targets --no-default-features --features decode -- -D warnings
 
   # CI runners have no TTY; termlens creates its own PTYs. This suite passing
   # headless is the proof of the crate's core value claim.
@@ -90,6 +93,14 @@ jobs:
   # Additivity makes a gap there unlikely, not impossible, and the cell
   # costs about ninety seconds.
   #
+  # Each reduced configuration selects the library alone (#324). Cargo
+  # unifies features across every package in one invocation, and
+  # termlens-cli depends on the library with `features = ["serde"]`, so the
+  # `--workspace` form of these tested a "minimal" library that had serde on
+  # — and `tests/record.rs` used serde_json unconditionally without anything
+  # here noticing. `check-feature-isolation.sh` asserts the selection really
+  # is isolated, so the --workspace form cannot come back quietly.
+  #
   # Priced and deferred, deliberately (#226): the default set on the macOS
   # leg — a second full suite per PR for a fault class the stress workflow
   # is better placed to find. The other half #226 deferred, a
@@ -108,10 +119,11 @@ jobs:
           toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: cargo test --workspace --no-default-features
-      - run: cargo test --workspace --no-default-features --features decode
-      - run: cargo test --workspace --no-default-features --features regex
-      - run: cargo test --workspace --no-default-features --features serde
+      - run: .github/scripts/check-feature-isolation.sh
+      - run: cargo test -p termlens --no-default-features
+      - run: cargo test -p termlens --no-default-features --features decode
+      - run: cargo test -p termlens --no-default-features --features regex
+      - run: cargo test -p termlens --no-default-features --features serde
       - run: cargo test --workspace
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -205,6 +217,49 @@ jobs:
       - run: cargo check --workspace --exclude ratatui-app --locked --all-targets
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.msrv }}
+      # --all-targets does not enable optional features, so `decode`, `regex`
+      # and the library's `serde` code had never met 1.85 in CI while the
+      # README advertised one MSRV for the crate (#325). Both ends of the
+      # feature axis, for the library alone so nothing is unified in.
+      - run: cargo check -p termlens --all-features --all-targets --locked
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.msrv }}
+      - run: cargo check -p termlens --no-default-features --all-targets --locked
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.msrv }}
+
+  # The public API against the last published release, on every pull request
+  # and every push to main (#323). Two things a naive run gets wrong, both
+  # measured and both pinned by the self-test that runs first: a version bump
+  # in the same PR as a break makes the inferred release type "major" and
+  # skips every check, so the type is forced; and --all-features cannot see
+  # an item moved behind a feature, so three views run. A deliberate break
+  # carries the `breaking` label (the release type becomes `major`, and the
+  # diagnostics go in the PR description) — and is recorded in CHANGELOG.md
+  # as a `- **Breaking` bullet, which is what keeps main green after the
+  # merge, where no label exists. `.github/scripts/check-semver.sh` has the
+  # rules; docs/RELEASING.md says when the baseline literal below moves.
+  #
+  # The checker is a prebuilt binary downloaded every run: never built from
+  # source and never restored from a cache, so a green run is evidence about
+  # this tree and today's checker rather than about the day a cache filled.
+  semver:
+    name: semver
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@fa23953489c080190314742a9b907f8e97c6767c # v2.87.10
+        with:
+          tool: cargo-semver-checks
+      - run: tools/semver-gate-selftest/run.sh
+      - run: .github/scripts/check-semver.sh 0.10.3
+        env:
+          BREAKING_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking') }}
 
   docs:
     name: docs
@@ -279,7 +334,7 @@ jobs:
   required-green:
     name: required-green
     if: always()
-    needs: [fmt, clippy, test, features, windows-check, windows, msrv, docs, deny, zizmor, gates-listed, skill]
+    needs: [fmt, clippy, test, features, windows-check, windows, msrv, semver, docs, deny, zizmor, gates-listed, skill]
     runs-on: ubuntu-latest
     steps:
       - name: Verify every needed job succeeded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,37 +36,20 @@ jobs:
             exit 1
           fi
 
-  # Re-run the exact CI gates (fmt, clippy, test matrix, msrv, docs, deny).
+  # Re-run the exact CI gates (fmt, clippy, test matrix, msrv, docs, deny),
+  # the semver gate included: ci.yml's `semver` job checks the tree against
+  # the last published release with the release type forced, in three
+  # feature views (#323). A release with a declared break passes because
+  # its CHANGELOG section records it (`- **Breaking`); an undeclared one
+  # fails here before anything is published.
   ci:
     name: ci
     needs: verify-version
     uses: ./.github/workflows/ci.yml
 
-  semver:
-    name: cargo-semver-checks
-    needs: verify-version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-      - name: Look for a published baseline on crates.io
-        id: published
-        run: |
-          status="$(curl -sS -o /dev/null -w '%{http_code}' https://crates.io/api/v1/crates/termlens)"
-          echo "crates.io responded ${status}"
-          echo "found=$([ "$status" = "200" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-      - name: Skip (first release, no baseline)
-        if: steps.published.outputs.found != 'true'
-        run: echo "termlens is not on crates.io yet; skipping semver checks gracefully."
-      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
-        if: steps.published.outputs.found == 'true'
-        with:
-          package: termlens
-
   publish:
     name: publish to crates.io
-    needs: [ci, semver]
+    needs: ci
     runs-on: ubuntu-latest
     # The `release` environment only deploys from v* tags, so an OIDC
     # publish token can never be minted from a branch.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.pending-snap
 .DS_Store
+/tools/semver-gate-selftest/*/target
+/tools/semver-gate-selftest/*/Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Until 1.0, minor versions (0.x) may contain breaking changes; they are always
-listed under a **Changed** or **Removed** heading.
+listed under a **Changed** or **Removed** heading, in a bullet that begins
+**Breaking:** — the semver gate in CI reads that marker.
 
 ## [Unreleased]
+
+### Added
+
+- **A semver gate on every pull request, forced and per feature view**
+  (#323). The only check was in `release.yml`, on the tag, and it let the
+  version number decide how much to check: a `0.10 -> 0.11` bump is
+  inferred as a major release and every check is skipped, so a public
+  function removed in the same PR as the bump passed. And `--all-features`
+  cannot see an item moved behind a feature — that view never loses the
+  item — while Cargo calls exactly that a major change.
+
+  `ci.yml` now runs `cargo-semver-checks` against the last published
+  release with the release type forced to `patch`, three times: default
+  features, only explicit features, all features. A deliberate break
+  carries the `breaking` pull-request label and is recorded in this file as
+  a `- **Breaking` bullet, which is what keeps `main` green after the merge
+  where no label exists; either declaration switches the run to `major`
+  (`minor` still fails a removed item on a 0.x crate — measured, and pinned).
+  `tools/semver-gate-selftest/` holds three one-file model crates and a
+  script that asserts the gate fails on a removed item and on a gated item,
+  and passes the baseline against itself, so the gate was seen to fail
+  before it was trusted to pass. The baseline is a literal in `ci.yml`,
+  moved after each publish (`docs/RELEASING.md`).
+
+- **The MSRV job compiles every feature configuration** (#325). It ran
+  `--all-targets` under the default set only, so `decode`, `regex` and the
+  library's `serde` code had never met Rust 1.85 in CI while the README
+  advertised one MSRV for the crate. Both ends of the feature axis compile
+  at the floor today, without a bump.
+
+### Fixed
+
+- **The minimal library build is now actually tested** (#324). Cargo
+  unifies features across every package in one invocation, and
+  `termlens-cli` depends on the library with `features = ["serde"]`, so
+  `cargo test --workspace --no-default-features` tested a library with
+  `serde` on. The `features` job selects the library alone for each
+  reduced configuration and asserts the isolation
+  (`.github/scripts/check-feature-isolation.sh`). It was not hypothetical:
+  `tests/record.rs` used `serde_json` unconditionally, and
+  `cargo test -p termlens --no-default-features` did not build until this
+  release added it as a dev-dependency.
 
 ## [0.10.3] - 2026-09-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,14 @@ nothing in CI should surprise you:
 ```sh
 cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo clippy --workspace --all-targets --no-default-features -- -D warnings
-cargo clippy --workspace --all-targets --no-default-features --features decode -- -D warnings
+cargo clippy -p termlens --all-targets --no-default-features -- -D warnings                    # the library alone: --workspace would unify the CLI's `serde` in
+cargo clippy -p termlens --all-targets --no-default-features --features decode -- -D warnings
 cargo clippy --workspace --all-targets -- -D warnings    # default features: what `cargo add termlens --dev` gives you
-cargo test --workspace --no-default-features
-cargo test --workspace --no-default-features --features decode
-cargo test --workspace --no-default-features --features regex
-cargo test --workspace --no-default-features --features serde
+.github/scripts/check-feature-isolation.sh              # the minimal library tree really is minimal
+cargo test -p termlens --no-default-features
+cargo test -p termlens --no-default-features --features decode
+cargo test -p termlens --no-default-features --features regex
+cargo test -p termlens --no-default-features --features serde
 cargo test --workspace                                   # default features
 cargo build -p termlens-cli                              # then the CLI's documented exit codes:
 .github/scripts/check-cli-contract.sh target/debug/termlens
@@ -41,7 +42,11 @@ RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features
 cargo deny check                          # cargo install cargo-deny
 pipx run zizmor==1.29.0 --persona=pedantic .github/workflows/   # workflow audit; needs GH_TOKEN for the online checks
 cargo +1.85 check --workspace --exclude ratatui-app --locked --all-targets    # the MSRV: `rust-version` in Cargo.toml (the ratatui fixture needs 1.88)
+cargo +1.85 check -p termlens --all-features --all-targets --locked           # …and every optional feature at the same floor
+cargo +1.85 check -p termlens --no-default-features --all-targets --locked
 cargo clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc -- -D warnings   # the Windows build, from any host: `rustup target add x86_64-pc-windows-msvc` once
+tools/semver-gate-selftest/run.sh                       # the semver gate can fail (cargo install cargo-semver-checks)…
+.github/scripts/check-semver.sh 0.10.3                  # …and the public API is compatible with the last published release
 ```
 
 The list is written out here rather than left as a pointer because a first

--- a/crates/termlens/Cargo.toml
+++ b/crates/termlens/Cargo.toml
@@ -61,6 +61,11 @@ libc.workspace = true
 [dev-dependencies]
 insta.workspace = true
 anyhow.workspace = true
+# `tests/record.rs` reads an asciicast event back as JSON whatever features
+# are on. It compiled without this only because `--workspace` unified the
+# CLI's `serde` feature into the library (#324); `cargo test -p termlens
+# --no-default-features` did not build.
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -52,21 +52,41 @@ gh pr create --fill && gh pr merge --squash --auto
 git checkout main && git pull
 git tag vX.Y.Z
 git push origin vX.Y.Z
+
+# 5. Once release.yml has published: move the semver gate's baseline to the
+#    version that is now on crates.io. One literal, in one place — the
+#    `.github/scripts/check-semver.sh X.Y.Z` step of ci.yml's `semver` job
+#    (and the same line in CONTRIBUTING.md §1, or `gates-listed` fails).
+#    After the release PR and not in it: a version that is not on crates.io
+#    yet cannot be a baseline, and left at the old release the gate would
+#    compare every later PR against a version nobody installs any more.
+git checkout -b ci/semver-baseline-vX.Y.Z
+$EDITOR .github/workflows/ci.yml CONTRIBUTING.md
+git commit -s -am "ci: move the semver baseline to vX.Y.Z"
+gh pr create --fill && gh pr merge --squash --auto
 ```
+
+Between the release merge and step 5, `main` compares `X.Y.Z` against the
+previous release. That is green when the release broke nothing, and green
+for a release whose CHANGELOG section records its break as a `- **Breaking`
+bullet — the gate reads that marker (`.github/scripts/check-semver.sh`), so
+a break that was declared stays declared after the label on its pull
+request is out of sight.
 
 Pushing the tag runs `release.yml`, which:
 
 1. fails unless tag == `crates/termlens` version,
-2. re-runs the full CI gates (`workflow_call` into ci.yml),
-3. runs `cargo-semver-checks` against the last published release
-   (skipped gracefully on the first release),
-4. `cargo publish -p termlens` then `cargo publish -p termlens-cli`, both
+2. re-runs the full CI gates (`workflow_call` into ci.yml) — the semver
+   gate among them, against the last published release with the release
+   type forced (`.github/scripts/check-semver.sh`),
+3. `cargo publish -p termlens` then `cargo publish -p termlens-cli`, both
    via Trusted Publishing (OIDC); each crate needs its own publisher
    link, and the step says so if one is missing,
-5. creates the GitHub Release with notes extracted from the CHANGELOG
+4. creates the GitHub Release with notes extracted from the CHANGELOG
    section for that version (`.github/scripts/extract-changelog.sh`), and
-6. runs the registry-consumer check against that published version on Linux
-   and macOS.
+5. runs the registry-consumer check — the library as `cargo add termlens`
+   and the CLI as `cargo install termlens-cli`, held to its exit-code
+   contract — against that published version on Linux and macOS.
 
 ## Bootstrapping a brand-new crate
 

--- a/tools/semver-gate-selftest/baseline/Cargo.toml
+++ b/tools/semver-gate-selftest/baseline/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gate-model"
+version = "0.10.1"
+edition = "2021"
+publish = false
+
+[features]
+render = []
+
+# Standalone on purpose: a member of the termlens workspace would be built,
+# formatted and linted as part of the product, and this is a test fixture
+# for the gate, not code anyone ships.
+[workspace]

--- a/tools/semver-gate-selftest/baseline/src/lib.rs
+++ b/tools/semver-gate-selftest/baseline/src/lib.rs
@@ -1,0 +1,4 @@
+//! The published API the other two models are compared against.
+pub fn kept() {}
+pub fn removed() {}
+pub fn to_svg() {}

--- a/tools/semver-gate-selftest/bumped/Cargo.toml
+++ b/tools/semver-gate-selftest/bumped/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gate-model"
+version = "0.11.0"
+edition = "2021"
+publish = false
+
+[features]
+render = []
+
+# Standalone on purpose: a member of the termlens workspace would be built,
+# formatted and linted as part of the product, and this is a test fixture
+# for the gate, not code anyone ships.
+[workspace]

--- a/tools/semver-gate-selftest/bumped/src/lib.rs
+++ b/tools/semver-gate-selftest/bumped/src/lib.rs
@@ -1,0 +1,5 @@
+//! `removed` is gone, and the version was bumped 0.10.1 -> 0.11.0 in the
+//! same change — which is what makes the inferred release type skip
+//! every check.
+pub fn kept() {}
+pub fn to_svg() {}

--- a/tools/semver-gate-selftest/gated/Cargo.toml
+++ b/tools/semver-gate-selftest/gated/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gate-model"
+version = "0.10.1"
+edition = "2021"
+publish = false
+
+[features]
+render = []
+
+# Standalone on purpose: a member of the termlens workspace would be built,
+# formatted and linted as part of the product, and this is a test fixture
+# for the gate, not code anyone ships.
+[workspace]

--- a/tools/semver-gate-selftest/gated/src/lib.rs
+++ b/tools/semver-gate-selftest/gated/src/lib.rs
@@ -1,0 +1,6 @@
+//! `to_svg` moved behind a feature that is off by default. `--all-features`
+//! never loses the item and cannot see it; the default view can.
+pub fn kept() {}
+pub fn removed() {}
+#[cfg(feature = "render")]
+pub fn to_svg() {}

--- a/tools/semver-gate-selftest/run.sh
+++ b/tools/semver-gate-selftest/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Proves the semver gate can fail, before it is trusted to pass (#323).
+#
+# Three one-file crates model the two ways a real break slips past a naive
+# `cargo semver-checks` run:
+#
+#   baseline/  0.10.1 with `kept`, `removed`, `to_svg` and an empty feature
+#   bumped/    0.11.0 with `removed` deleted — a break *and* a version bump
+#   gated/     0.10.1 with `to_svg` moved behind the off-by-default feature
+#
+# Measured with cargo-semver-checks 0.50.0: a 0.10 -> 0.11 bump is inferred as
+# a major release and every check is skipped, so the deleted function passes;
+# and `--all-features` never loses `to_svg`, so the gating is invisible in
+# that view. Both are asserted below *as the holes they are*, so that a
+# checker version which closes one makes this script fail and the forcing in
+# `.github/scripts/check-semver.sh` gets reconsidered in the open rather than
+# left as cargo cult.
+#
+# Usage: tools/semver-gate-selftest/run.sh
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+status=0
+
+# `<label> <expected: zero|nonzero> <crate> <cargo-semver-checks args…>`
+expect() {
+  label=$1
+  want=$2
+  crate=$3
+  shift 3
+  got=0
+  cargo semver-checks --manifest-path "$crate/Cargo.toml" --baseline-root baseline "$@" \
+    > out.log 2>&1 || got=$?
+  case "$want:$got" in
+    zero:0 | nonzero:[1-9]*)
+      printf '  ok    %-58s exit %s\n' "$label" "$got" ;;
+    *)
+      printf '  FAIL  %-58s exit %s, expected %s\n' "$label" "$got" "$want" >&2
+      sed 's/^/        /' out.log >&2
+      status=1 ;;
+  esac
+}
+
+echo "semver gate self-test: $(cargo semver-checks --version)"
+
+# A crate against itself passes under the strictest type: the harness works.
+expect "baseline against itself, forced patch" zero baseline --release-type patch --default-features
+
+# Hole 1: the version number decides how much is checked. Inferred, the
+# bump to 0.11.0 reads as a major release and nothing is checked at all.
+expect "bumped, inferred release type (the hole)" zero bumped --all-features
+expect "bumped, forced patch" nonzero bumped --release-type patch --all-features
+# The exception path a `breaking` label switches on. `minor` is not enough:
+# on a 0.x crate cargo-semver-checks still treats a removed item as major.
+expect "bumped, forced minor (still fails on 0.x)" nonzero bumped --release-type minor --all-features
+expect "bumped, forced major (the exception path)" zero bumped --release-type major --all-features
+
+# Hole 2: `--all-features` cannot see an item moved behind a feature. The
+# default and explicit-only views can, which is why the gate runs all three.
+expect "gated, forced patch, all-features (the hole)" zero gated --release-type patch --all-features
+expect "gated, forced patch, default-features" nonzero gated --release-type patch --default-features
+expect "gated, forced patch, only-explicit-features" nonzero gated --release-type patch --only-explicit-features
+
+rm -f out.log
+if [ "$status" -eq 0 ]; then
+  echo "semver gate self-test: PASS — the gate fails where it must and passes where it must"
+fi
+exit "$status"


### PR DESCRIPTION
Closes #323
Closes #324
Closes #325

Three enforcement gaps, each reproduced before it was closed.

**#323 — the semver gate.** The only check ran on the release tag and let the version number decide how much to check: a 0.10 → 0.11 bump is inferred as a major release and every check is skipped (measured: `0 checks: 0 pass, 254 skip … no semver update required`, exit 0, with a public fn removed), and `--all-features` cannot see an item moved behind a feature.

- `semver` job in `ci.yml`, in `required-green`: `cargo-semver-checks` against the last published release (`0.10.3`, a literal) with `--release-type patch` forced, in three views — default, only-explicit, all features.
- A break is declared by the `breaking` label **or** a `- **Breaking` bullet in `CHANGELOG.md` under `[Unreleased]` (or under the tree's own version's section when that is ahead of the baseline). The second route is what keeps `main` green after a labelled merge, where `github.event.pull_request` does not exist. Either switches the run to `major`.
- Not `minor`, as the issue proposed: measured, `--release-type minor` still fails a removed item on a 0.x crate (exit 100). The self-test pins that.
- `tools/semver-gate-selftest/run.sh` — three one-file model crates; asserts the baseline passes against itself, `bumped` fails under forced patch, `gated` fails in the default and explicit-only views, **and** asserts the two holes (inferred type passes, all-features passes) so a checker version that closes one makes the self-test fail and the forcing gets reconsidered in the open. Flipping an expectation was observed to exit 1.
- The checker is a prebuilt binary (`taiki-e/install-action`, pinned by SHA, verified against the `v2.87.10` tag), downloaded every run, never cached.
- `release.yml`'s own semver job is removed: it re-runs `ci.yml` already, and a second copy would be a second baseline literal to drift. `docs/RELEASING.md` gains step 5 — the baseline moves **after** publish, in a follow-up PR, since a version not yet on crates.io cannot be a baseline (this deviates from #334's "same commit as the version bump", deliberately; noted there).

Observed locally against this tree: removing `Screen::unsupported_overflow` → all three views fail; with the CHANGELOG marker → `major`, pass; with `BREAKING_LABEL=true` → `major`, pass; a marker in an older released section → still `patch`.

**#324 — isolated feature tests.** `cargo test --workspace --no-default-features` unified the CLI's `serde` into the library. Every reduced configuration now selects `-p termlens`, and `check-feature-isolation.sh` asserts the library's own tree (normal edges) mentions no serde — the `--workspace` shape mentions it 26 times. It was real: `tests/record.rs` used `serde_json` unconditionally and `cargo test -p termlens --no-default-features` did not build; `serde_json` is now a dev-dependency. All four reduced configurations pass in isolation (211/225/211/211 unit tests plus the integration files).

**#325 — MSRV over features.** `cargo +1.85 check -p termlens --all-features --all-targets --locked` and the `--no-default-features` twin, both green today without a bump.

**Not done here:** the STABILITY/RELEASING rewrite for the candidate (#328, #334), the corpus (#327) and the JSON version (#329) — separate PRs so they go through this gate. `gates-listed`, `cargo fmt`, zizmor pedantic (local 1.29.0, no findings) all pass.
