### PR TITLE
feat: the candidate's additive API, a versioned JSON, a frozen corpus, and inspect's round trip

### DIFF
--- a/.github/scripts/check-cli-contract.sh
+++ b/.github/scripts/check-cli-contract.sh
@@ -74,18 +74,28 @@ for sub in inspect diff render; do
   fi
 done
 
-# --- inspect drives a real PTY and prints a screen with its trailer.
+# --- inspect drives a real PTY: the screen on stdout, the trailer on stderr.
 expect "inspect a program"         0 "$BIN" inspect sh -c 'printf hi'
-"$BIN" inspect sh -c 'printf hi' > "$WORK/raw.txt" 2>/dev/null || true
-contains "inspect prints the screen"  "hi"            "$WORK/raw.txt"
-contains "inspect prints the header"  "size: "        "$WORK/raw.txt"
-contains "inspect prints the trailer" "--- exited: "  "$WORK/raw.txt"
+"$BIN" inspect sh -c 'printf hi' > "$WORK/a.snap" 2> "$WORK/a.err" || true
+contains "inspect prints the screen"          "hi"            "$WORK/a.snap"
+contains "inspect prints the header"          "size: "        "$WORK/a.snap"
+contains "inspect's trailer goes to stderr"   "--- exited: "  "$WORK/a.err"
+if grep -q '^--- ' "$WORK/a.snap"; then
+  printf '  FAIL  %-46s stdout carries a trailer line\n' "inspect > file is a screen" >&2
+  status=1
+else
+  printf '  ok    %-46s no trailer on stdout\n' "inspect > file is a screen"
+fi
 
-# A saved screen is that output without the human trailer (see the note in
-# `install.yml`: the trailer is not part of the snapshot format).
-sed '/^--- exited:/d' "$WORK/raw.txt" > "$WORK/a.snap"
-"$BIN" inspect sh -c 'printf bye' 2>/dev/null | sed '/^--- exited:/d' > "$WORK/b.snap"
+# `inspect … > file` is a saved screen: what stdout carried, unedited, is
+# what render and diff read below (#340). Before 0.11 the trailer followed
+# the screen on stdout and nothing the CLI wrote was a file it would read.
+"$BIN" inspect sh -c 'printf bye' > "$WORK/b.snap" 2>/dev/null || true
 printf 'not a saved screen at all\n' > "$WORK/junk.txt"
+# A file saved by a 0.10 inspect, trailer and all, still reads.
+{ cat "$WORK/a.snap"; echo "--- exited: exit code 0 ---"; } > "$WORK/old.snap"
+expect "a 0.10 inspect file, trailer included" 0 "$BIN" render --text "$WORK/old.snap"
+expect "diff, inspect output against itself" 0 "$BIN" diff "$WORK/a.snap" "$WORK/a.snap"
 
 # --- render, every format, from a saved screen.
 expect "render --text"             0 "$BIN" render --text "$WORK/a.snap"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,61 @@ listed under a **Changed** or **Removed** heading, in a bullet that begins
 
 ### Added
 
+- **A frozen saved-screen corpus** (#327). Nothing pinned that a file
+  written by 0.10.1 still parses: the insta snapshots are re-recorded when
+  output changes, so a change to the header, the `styles:` block or the
+  JSON shape would have updated them and passed.
+  `crates/termlens/tests/compat/0.10.1/` holds six shapes — plain text,
+  every style token, a hidden cursor, wide and combining characters, a
+  masked screen, and the style-blind text of a styled screen — each with
+  its JSON twin, written by the **published** 0.10.1 through a registry
+  dependency. A file there is never edited; a new version adds a
+  directory. `tests/compat.rs` parses every text file and re-renders it
+  byte for byte, reads every JSON twin as the same picture and
+  re-serialises it to its own document, and the CLI suite renders each
+  file with `termlens render --text`. Editing a corpus file was observed
+  to fail the test.
+
+- **The JSON a `Screen` serialises to carries `"format": 1`** (#329),
+  first in the document. `termlens diff` and `termlens render` read that
+  JSON back as a saved artifact, so it is a persisted format, not a wire
+  between two copies of one version, and it now says which shape it is.
+  A file written by 0.10 has no such field and reads as format 1, since
+  that is what it is; a number this build does not know is refused with a
+  message naming both numbers. The shape is specified in
+  `docs/DESIGN.md` §3 beside the text format: field names, the cursor
+  object, how a hidden cursor and wide/continuation cells are encoded,
+  and that nothing a `Screen` holds is omitted.
+
+- **`Screen::cursor_visible()`** (#331). The tuple `cursor()` returns is
+  unchanged; the new accessor is for the assertion that reads
+  `s.cursor().2` today and says nothing at the call site.
+
+- **`termlens::ScreenWithStyles` is exported** (#332). `Screen::with_styles`
+  returned it, but the type lived in a private module and was not in the
+  crate's re-export list — reachable but unnameable, so it could not be
+  stored in a field or returned from a helper. A doctest names it from a
+  consumer.
+
+- **`Location::is_on_screen()`, `is_in_history()` and `col()`** (#306),
+  for the one-fact questions `Screen::locate` is asked most — "still
+  visible?" and "what column?" — without a `match`. Deliberately no
+  `row()`: a grid row and a history row are different things, and the
+  rustdoc says so.
+
+- **`ScreenDiff::changed_rows()` and `style_changes()`** (#308). The diff
+  computed both and exposed neither, so a test that wanted "the highlight
+  moved from row 1 to row 2 and nothing else changed" dedup'd `cells()` or
+  matched a substring of the rendering. Both read fields already stored;
+  the rendering is unchanged.
+
+- **`Color` implements `Display`** (#315), producing exactly the `styles:`
+  block token — `4` for an indexed colour, `#1e1e2e` for RGB, and the word
+  `default` for [`Color::Default`], which the block never writes because a
+  default-styled span is omitted. The block now uses it, so the two
+  halves of the documented format — this and `Screen::parse` — sit
+  together; every existing snapshot is unchanged.
+
 - **A semver gate on every pull request, forced and per feature view**
   (#323). The only check was in `release.yml`, on the tag, and it let the
   version number decide how much to check: a `0.10 -> 0.11` bump is
@@ -40,6 +95,22 @@ listed under a **Changed** or **Removed** heading, in a bullet that begins
   at the floor today, without a bump.
 
 ### Fixed
+
+- **`termlens inspect … > file` saves a screen `diff` and `render` read**
+  (#340). `inspect` was the only command that produced a screen and the
+  only two that consumed one refused its output: the `--- exited: … ---`
+  trailer went to stdout under the screen, so a redirect captured it and
+  `render` exited 2 on line 26. Measured against the published 0.10.2; no
+  flag suppressed it, and the workaround was a `sed` a user had to
+  invent. The trailer now goes to **stderr** — a human at a terminal
+  still sees both — and stdout carries the screen alone. The CLI also
+  drops exactly those three trailer shapes when they are the last line of
+  a file, so a screen saved by a 0.10 `inspect` reads too; a grid row
+  that merely begins with `---` is content. `docs/DESIGN.md` §3 now says
+  what a reader skips at each end of a file and that `Screen::parse`
+  skips neither. `.github/scripts/check-cli-contract.sh` asserts the
+  round trip against the published binary on every release; run against
+  the published 0.10.3 it fails on exactly this.
 
 - **The minimal library build is now actually tested** (#324). Cargo
   unifies features across every package in one invocation, and

--- a/README.md
+++ b/README.md
@@ -169,9 +169,10 @@ insta::assert_snapshot!(s.mask_matches(&regex::Regex::new(r"\d\d:\d\d:\d\d")?, '
 ```
 
 `Screen::diff(&other)` reports what changed between two screens cell by
-cell; `Screen::parse` reads a saved snapshot back, so the text termlens
-prints — an insta `.snap`, the block a wait error leaves in a log — is also
-its input format.
+cell — `changed_rows()`, `style_changes()`, and a rendering of only the rows
+that changed; `Screen::parse` reads a saved snapshot back, so the text
+termlens prints — an insta `.snap`, the block a wait error leaves in a log,
+what `termlens inspect` writes to stdout — is also its input format.
 
 ## What a test can see
 
@@ -179,7 +180,7 @@ its input format.
 | --- | --- |
 | What does the user see? | `text()`, `row_text(row)`, `cell(row, col)`, `contains`, `find`, `find_all`; with `regex`: `matches`, `find_match`, `wait_until_matches` |
 | Is it styled as claimed? | `cell(..).style()` — colours, bold/dim, italic, underline, reverse, **blink**, **conceal**, **strikethrough** |
-| Where is the cursor, and what shape? | `cursor()`, `cursor_shape()`, `cursor_blink()` |
+| Where is the cursor, and what shape? | `cursor()`, `cursor_visible()`, `cursor_shape()`, `cursor_blink()` |
 | Which modes did the application turn on? | `alternate_screen()`, `bracketed_paste()`, `mouse_mode()`, `focus_events()`, `application_cursor()`, `insert_mode()` |
 | What did it tell the terminal out of band? | `title()`, `clipboard()` (`OSC 52`), `links()` (`OSC 8`) |
 | Did something happen that changed no cell? | `repaints()`, `bells()`, `visual_bells()`, `graphics()`, `frame_timings()` |

--- a/crates/termlens-cli/src/main.rs
+++ b/crates/termlens-cli/src/main.rs
@@ -11,8 +11,9 @@
 //! Exit codes: 0 ran; `diff` exits 1 when the screens differ; 2 means the
 //! command itself could not run — bad arguments, an unreadable file, a
 //! program that could not be spawned. `inspect` is a viewer, not a gate:
-//! the program's own exit status is reported under the screen, not
-//! propagated.
+//! the program's own exit status is reported on stderr under the screen,
+//! not propagated — and the screen alone goes to stdout, so `inspect … >
+//! file` is a saved screen `diff` and `render` read back (#340).
 
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
@@ -29,9 +30,10 @@ commands:
   diff [--color WHEN] <a> <b>          compare two saved screens; exit 1 when they differ
   render --svg|--html|--ansi|--text <a>  render a saved screen
 
-A saved screen is the snapshot text format termlens prints — an insta .snap
-with or without its header, the block a wait error prints, a
-TERMLENS_ARTIFACT_DIR file — or the JSON the crate's `serde` feature writes.
+A saved screen is the snapshot text format termlens prints — what `inspect`
+writes to stdout, an insta .snap with or without its header, the block a
+wait error prints, a TERMLENS_ARTIFACT_DIR file — or the JSON the crate's
+`serde` feature writes.
 
 Exit code 0: the command ran (diff: the screens are the same picture).
 Exit code 1: diff found a difference. Exit code 2: termlens itself could not
@@ -52,8 +54,10 @@ The child environment is cleared by default except for PATH; --inherit-env
 keeps the caller's environment, and repeatable --env sets selected values.
 --ansi paints the screen in colour instead of the plain text format.
 
-The trailer under the screen says what the program did — its exit status,
-or that it was still running at the deadline. Exit code 2 means inspect
+The screen goes to stdout and nothing else does, so `inspect … > file`
+saves a screen that `termlens diff` and `termlens render` read back. The
+trailer that says what the program did — its exit status, or that it was
+still running at the deadline — goes to stderr. Exit code 2 means inspect
 itself could not run: bad arguments, or a program that could not be spawned.";
 
 const DIFF_USAGE: &str = "\
@@ -117,7 +121,11 @@ fn main() -> ExitCode {
 // ---------------------------------------------------------------- saved screens
 
 /// Read a saved screen: an insta `.snap` (its `---` header dropped), the
-/// text format, or JSON.
+/// text format (an `inspect` trailer from before 0.11 dropped), or JSON.
+///
+/// The two decorations this skips are the two termlens itself writes
+/// around a screen, and `Screen::parse` accepts neither — the library
+/// reads the format, the tool knows its own wrappers (`docs/DESIGN.md` §3).
 fn load(path: &Path) -> Result<Screen, String> {
     let raw = std::fs::read_to_string(path).map_err(|e| format!("{}: {e}", path.display()))?;
     // A checkout on Windows may have given the file CRLF endings; the
@@ -128,7 +136,7 @@ fn load(path: &Path) -> Result<Screen, String> {
         return serde_json::from_str(body)
             .map_err(|e| format!("{}: not a termlens Screen: {e}", path.display()));
     }
-    Screen::parse(body).map_err(|e| format!("{}: {e}", path.display()))
+    Screen::parse(strip_inspect_trailer(body)).map_err(|e| format!("{}: {e}", path.display()))
 }
 
 /// insta writes `---\n<metadata>\n---\n` above the content; the content is
@@ -137,6 +145,31 @@ fn strip_insta_header(text: &str) -> &str {
     text.strip_prefix("---\n")
         .and_then(|rest| rest.find("\n---\n").map(|end| &rest[end + 5..]))
         .unwrap_or(text)
+}
+
+/// `inspect` before 0.11 wrote its `--- exited: … ---` trailer to stdout,
+/// so a screen saved with `> file` then carried it (#340). The trailer now
+/// goes to stderr, and a file saved that way still reads: the last
+/// non-blank line is dropped when it is one of the three trailers
+/// `inspect` writes — exactly those, so a grid row that happens to start
+/// with `---` is left alone.
+fn strip_inspect_trailer(text: &str) -> &str {
+    let trimmed = text.trim_end_matches('\n');
+    let start = trimmed.rfind('\n').map_or(0, |at| at + 1);
+    let last = &trimmed[start..];
+    let is_trailer = last.ends_with(" ---")
+        && [
+            "--- exited: ",
+            "--- still running at the deadline",
+            "--- waiting for the program failed: ",
+        ]
+        .iter()
+        .any(|prefix| last.starts_with(prefix));
+    if is_trailer {
+        &trimmed[..start]
+    } else {
+        text
+    }
 }
 
 // ------------------------------------------------------------------------ diff
@@ -413,24 +446,23 @@ fn inspect(args: Vec<String>) -> ExitCode {
         Err(e) => return fail(&e.to_string()),
     };
 
-    let mut out = String::new();
-    match t.wait_exit() {
-        Ok(status) => {
-            out.push_str(&inspect_render(&t.screen(), ansi));
-            out.push_str(&format!("\n--- exited: {status} ---\n"));
-        }
+    // The screen to stdout, the trailer to stderr (#340): `inspect … > file`
+    // then saves exactly a screen, which `diff` and `render` read back,
+    // while a human at a terminal still sees both. Before 0.11 the trailer
+    // followed the screen on stdout and no CLI route produced a file the
+    // CLI would accept.
+    let trailer = match t.wait_exit() {
+        Ok(status) => format!("--- exited: {status} ---"),
         Err(termlens::Error::Timeout { .. }) => {
             // Still running at the deadline: settle on a quiet screen
             // instead, bounded by the deadline too unless the silence window
             // asked for is itself longer.
             let _ = t.wait_idle_for(idle, timeout.max(idle));
-            out.push_str(&inspect_render(&t.screen(), ansi));
-            out.push_str("\n--- still running at the deadline (killed on exit) ---\n");
+            "--- still running at the deadline (killed on exit) ---".to_owned()
         }
-        Err(e) => {
-            out.push_str(&inspect_render(&t.screen(), ansi));
-            out.push_str(&format!("\n--- waiting for the program failed: {e} ---\n"));
-        }
-    }
-    print(&out)
+        Err(e) => format!("--- waiting for the program failed: {e} ---"),
+    };
+    let code = print(&format!("{}\n", inspect_render(&t.screen(), ansi)));
+    eprintln!("{trailer}");
+    code
 }

--- a/crates/termlens-cli/tests/cli.rs
+++ b/crates/termlens-cli/tests/cli.rs
@@ -236,3 +236,117 @@ fn subcommand_version_prints_same_string_as_top_level() -> termlens::Result<()> 
     }
     Ok(())
 }
+
+/// `inspect … > file` is a saved screen (#340): the screen alone goes to
+/// stdout and the trailer to stderr, so the file a redirect captures is
+/// what `render` and `diff` read. Driven without a PTY here on purpose —
+/// through one, both streams land on the same screen and the split is
+/// invisible.
+#[test]
+#[cfg_attr(windows, ignore = "the program under inspection is a POSIX shell")]
+fn inspect_stdout_is_a_saved_screen_and_the_trailer_is_on_stderr() -> termlens::Result<()> {
+    use std::process::Command;
+    let bin = env!("CARGO_BIN_EXE_termlens");
+    let out = Command::new(bin)
+        .args(["inspect", "--size", "20x3", "sh", "-c", "printf 'hi there'"])
+        .output()?;
+    assert!(out.status.success(), "{out:?}");
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    let stderr = String::from_utf8(out.stderr).expect("utf-8");
+    assert!(stdout.starts_with("size: 20x3  cursor: "), "{stdout:?}");
+    assert!(stdout.contains("hi there"), "{stdout:?}");
+    assert!(!stdout.contains("---"), "no trailer on stdout: {stdout:?}");
+    assert_eq!(
+        stderr.trim_end(),
+        "--- exited: exit code 0 ---",
+        "{stderr:?}"
+    );
+    // What the library reads from it is the screen inspect saw.
+    let parsed = Screen::parse(&stdout)?;
+    assert_eq!(parsed.size(), (20, 3));
+    assert_eq!(parsed.find("hi there"), Some((0, 0)));
+
+    // And the CLI reads its own output back: render, and diff against itself.
+    let path =
+        std::env::temp_dir().join(format!("termlens-cli-inspect-{}.txt", std::process::id()));
+    std::fs::write(&path, &stdout)?;
+    let file = path.to_str().unwrap();
+    let render = Command::new(bin)
+        .args(["render", "--text", file])
+        .output()?;
+    assert_eq!(render.status.code(), Some(0), "{render:?}");
+    let diff = Command::new(bin).args(["diff", file, file]).output()?;
+    assert_eq!(diff.status.code(), Some(0), "{diff:?}");
+
+    // A file a 0.10 inspect saved — trailer on stdout — still reads.
+    let old = path.with_extension("old.txt");
+    std::fs::write(&old, format!("{stdout}--- exited: exit code 0 ---\n"))?;
+    let render = Command::new(bin)
+        .args(["render", "--text", old.to_str().unwrap()])
+        .output()?;
+    assert_eq!(render.status.code(), Some(0), "{render:?}");
+    let diff = Command::new(bin)
+        .args(["diff", file, old.to_str().unwrap()])
+        .output()?;
+    assert_eq!(
+        diff.status.code(),
+        Some(0),
+        "the trailer is not a row: {diff:?}"
+    );
+    // …while a grid row that merely starts with `---` is content.
+    let dashes = path.with_extension("dashes.txt");
+    std::fs::write(&dashes, "size: 20x2  cursor: 0,0\n--- not a trailer\n")?;
+    let render = Command::new(bin)
+        .args(["render", "--text", dashes.to_str().unwrap()])
+        .output()?;
+    assert_eq!(render.status.code(), Some(0), "{render:?}");
+    assert!(
+        String::from_utf8_lossy(&render.stdout).contains("--- not a trailer"),
+        "{render:?}"
+    );
+    for p in [path, old, dashes] {
+        let _ = std::fs::remove_file(p);
+    }
+    Ok(())
+}
+
+/// The compatibility corpus (#327): every saved screen a published release
+/// wrote — text and JSON — is a file this CLI reads. The library's
+/// `tests/compat.rs` holds the round trips; this is the fourth check it
+/// names, from the tool's side.
+#[test]
+fn every_corpus_file_renders() -> termlens::Result<()> {
+    use std::process::Command;
+    let bin = env!("CARGO_BIN_EXE_termlens");
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../termlens/tests/compat");
+    let mut files: Vec<std::path::PathBuf> = std::fs::read_dir(&root)?
+        .map(|entry| entry.map(|e| e.path()))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|p| p.is_dir())
+        .flat_map(|dir| std::fs::read_dir(dir).expect("a version directory"))
+        .map(|entry| entry.expect("a corpus file").path())
+        .filter(|p| p.extension().is_some_and(|e| e == "txt" || e == "json"))
+        .collect();
+    files.sort();
+    assert!(
+        files.len() >= 12,
+        "the 0.10.1 corpus alone is twelve files, found {}",
+        files.len()
+    );
+    for file in files {
+        let out = Command::new(bin)
+            .args(["render", "--text", file.to_str().unwrap()])
+            .output()?;
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{}: {}",
+            file.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let text = String::from_utf8_lossy(&out.stdout);
+        assert!(text.starts_with("size: "), "{}: {text}", file.display());
+    }
+    Ok(())
+}

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -126,7 +126,7 @@ pub use graphics::{
 pub use keys::{Chord, Input, Key};
 pub use screen::{
     Cell, Clipboard, Color, CursorShape, Link, Location, MouseMode, MouseModes, Screen, ScreenDiff,
-    Style,
+    ScreenWithStyles, Style,
 };
 #[cfg(unix)]
 pub use terminal::Signal;

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -46,6 +46,25 @@ pub enum Color {
     Rgb(u8, u8, u8),
 }
 
+impl fmt::Display for Color {
+    /// The token the `styles:` block of the snapshot format writes
+    /// (`docs/DESIGN.md` §3): a palette index as decimal (`4`), an RGB
+    /// colour as `#rrggbb` (`#1e1e2e`). [`Color::Default`] renders as
+    /// `default`, which the block itself never writes — a default-styled
+    /// span is omitted, so absence means default — but a message that
+    /// prints a cell's colour needs a word for it.
+    ///
+    /// `Screen::parse` reads the indexed and RGB forms back, so a colour
+    /// printed this way round-trips through a saved screen.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Color::Default => f.write_str("default"),
+            Color::Indexed(i) => write!(f, "{i}"),
+            Color::Rgb(r, g, b) => write!(f, "#{r:02x}{g:02x}{b:02x}"),
+        }
+    }
+}
+
 /// Visual attributes of a [`Cell`].
 ///
 /// Inspect them per cell via [`Cell::style`], or snapshot them wholesale
@@ -562,6 +581,40 @@ pub enum Location {
     },
 }
 
+impl Location {
+    /// True when the needle is on the visible grid.
+    ///
+    /// ```text
+    /// assert!(s.locate("total").is_some_and(Location::is_on_screen));
+    /// ```
+    #[must_use]
+    pub fn is_on_screen(self) -> bool {
+        matches!(self, Location::Screen { .. })
+    }
+
+    /// True when the needle has scrolled off into the retained history.
+    #[must_use]
+    pub fn is_in_history(self) -> bool {
+        matches!(self, Location::History { .. })
+    }
+
+    /// The column, in either region: a real terminal column on the grid,
+    /// the display column of the row *as it was captured* in history.
+    /// Both are zero-based and both answer "how far along the row".
+    ///
+    /// There is deliberately no `row()`. The two rows are different
+    /// things — a grid row counted from the top of the screen, a history
+    /// row counted from the oldest retained line — and one accessor
+    /// returning either would invite exactly the confusion this enum
+    /// exists to prevent. Match on the variant when the row matters.
+    #[must_use]
+    pub fn col(self) -> u16 {
+        match self {
+            Location::Screen { col, .. } | Location::History { col, .. } => col,
+        }
+    }
+}
+
 /// An immutable snapshot of the terminal screen.
 ///
 /// Cheap to clone (the grid is shared behind an [`Arc`]); every clone
@@ -669,9 +722,29 @@ impl Screen {
     }
 
     /// Cursor position and visibility: `(row, col, visible)`.
+    ///
+    /// The position is what most callers want; for the visibility alone,
+    /// [`cursor_visible`](Self::cursor_visible) says so at the call site
+    /// instead of `.2`.
     #[must_use]
     pub fn cursor(&self) -> (u16, u16, bool) {
         (self.cursor_row, self.cursor_col, self.cursor_visible)
+    }
+
+    /// Whether the cursor is shown (`DECTCEM`, `CSI ? 25 h`/`l`) — the
+    /// third element of [`cursor`](Self::cursor), on its own, so an
+    /// assertion reads as what it checks:
+    ///
+    /// ```text
+    /// assert!(!s.cursor_visible(), "a list view hides the cursor: {s}");
+    /// ```
+    ///
+    /// The snapshot header renders this as `cursor: hidden`; a hidden
+    /// cursor's position is still reported by `cursor()` but is not part
+    /// of the picture [`diff`](Self::diff) compares.
+    #[must_use]
+    pub fn cursor_visible(&self) -> bool {
+        self.cursor_visible
     }
 
     /// The cursor shape the application asked for with `DECSCUSR`
@@ -2001,11 +2074,11 @@ impl Style {
 
     /// Fixed-order tokens for the `styles:` block (see `docs/DESIGN.md` §3).
     pub(crate) fn tokens(&self) -> String {
+        // `Display for Color` is the token; the block only ever writes a
+        // non-default one, since absence means default.
         fn color(prefix: &str, color: Color, out: &mut Vec<String>) {
-            match color {
-                Color::Default => {}
-                Color::Indexed(i) => out.push(format!("{prefix}={i}")),
-                Color::Rgb(r, g, b) => out.push(format!("{prefix}=#{r:02x}{g:02x}{b:02x}")),
+            if color != Color::Default {
+                out.push(format!("{prefix}={color}"));
             }
         }
         let mut tokens = Vec::new();
@@ -2033,6 +2106,21 @@ impl Style {
 }
 
 /// [`Screen`] rendered with its styles — see [`Screen::with_styles`].
+///
+/// Nameable, so it can be stored, returned from a helper or taken as a
+/// parameter rather than only passed straight to a snapshot macro:
+///
+/// ```
+/// use termlens::{Screen, ScreenWithStyles};
+///
+/// fn styled(screen: &Screen) -> ScreenWithStyles<'_> {
+///     screen.with_styles()
+/// }
+///
+/// let screen = Screen::parse("size: 4x1  cursor: 0,0\nhi")?;
+/// assert!(styled(&screen).to_string().ends_with("styles:\n(none)"));
+/// # Ok::<(), termlens::Error>(())
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub struct ScreenWithStyles<'a> {
     screen: &'a Screen,

--- a/crates/termlens/src/screen/diff.rs
+++ b/crates/termlens/src/screen/diff.rs
@@ -178,6 +178,30 @@ impl ScreenDiff {
     pub fn cells(&self) -> impl Iterator<Item = (u16, u16, &Cell, &Cell)> {
         self.cells.iter().map(|(r, c, a, b)| (*r, *c, a, b))
     }
+
+    /// The rows with at least one changed cell, ascending, each once —
+    /// so "the highlight moved from row 1 to row 2 and nothing else
+    /// changed" is `assert_eq!(diff.changed_rows().collect::<Vec<_>>(),
+    /// [1, 2])` rather than a dedup over [`cells`](Self::cells).
+    ///
+    /// Within the overlap of the two grids, like `cells`; a size or cursor
+    /// change alone leaves this empty while [`is_empty`](Self::is_empty)
+    /// is false.
+    pub fn changed_rows(&self) -> impl Iterator<Item = u16> + '_ {
+        self.rows.iter().map(|(row, ..)| *row)
+    }
+
+    /// The `styles:` runs of each changed row whose runs differ, as
+    /// `(row, before, after)` in the tokens [`Screen::with_styles`]
+    /// writes (`(none)` for an all-default row), ascending by row. A row
+    /// whose text changed under unchanged styles is not listed; a row
+    /// whose styles changed under unchanged text is, since a changed
+    /// style is a changed cell.
+    pub fn style_changes(&self) -> impl Iterator<Item = (u16, &str, &str)> {
+        self.style_changes
+            .iter()
+            .map(|(row, before, after)| (*row, before.as_str(), after.as_str()))
+    }
 }
 
 /// `a → b` when they differ, `a` alone when they do not.

--- a/crates/termlens/src/screen/parse.rs
+++ b/crates/termlens/src/screen/parse.rs
@@ -401,6 +401,30 @@ mod tests {
         assert!(many.cell(0, 3).unwrap().is_wide_continuation());
     }
 
+    /// `Display for Color` is the forward half of the token `parse_color`
+    /// reads (#315): the two halves of one documented format agree.
+    #[test]
+    fn a_colour_displays_as_the_token_the_parser_reads() {
+        for color in [
+            Color::Indexed(0),
+            Color::Indexed(4),
+            Color::Indexed(208),
+            Color::Indexed(255),
+            Color::Rgb(0x1e, 0x1e, 0x2e),
+            Color::Rgb(0, 0, 0),
+            Color::Rgb(255, 0, 7),
+        ] {
+            let token = color.to_string();
+            assert_eq!(parse_color(&token), Some(color), "{token}");
+        }
+        assert_eq!(Color::Indexed(4).to_string(), "4");
+        assert_eq!(Color::Rgb(0x1e, 0x1e, 0x2e).to_string(), "#1e1e2e");
+        // The block never writes a default colour — absence means default —
+        // so the parser does not read the word back; it is for messages.
+        assert_eq!(Color::Default.to_string(), "default");
+        assert_eq!(parse_color("default"), None);
+    }
+
     #[test]
     fn combining_marks_join_the_cell_before_them() {
         let screen = Screen::parse("size: 3x1  cursor: 0,0\ne\u{301}x").unwrap();

--- a/crates/termlens/src/screen/serde_impl.rs
+++ b/crates/termlens/src/screen/serde_impl.rs
@@ -7,6 +7,15 @@
 //! and there are exactly `rows` of them — through a validating constructor
 //! rather than a bare derive, so a hand-edited or truncated file is an
 //! error and never a screen that panics on its first `cell()`.
+//!
+//! The JSON is a persisted artifact, not a wire between two copies of one
+//! version: `termlens diff` and `termlens render` read it back as a saved
+//! screen, and consumers commit it. So it carries a **format number**
+//! (#329). `"format": 1` is the shape specified in `docs/DESIGN.md` §3;
+//! a file written before the field existed (0.10) reads as format 1, since
+//! that is what it is; a number this build does not know is refused with
+//! a message naming it rather than read as far as the fields happen to
+//! line up.
 
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -21,9 +30,16 @@ struct Cursor {
     visible: bool,
 }
 
-/// What a [`Screen`] is on the wire.
+/// The one shape this build writes and reads. A new number is a new
+/// stability candidate or a major version, never a silent change
+/// (`docs/STABILITY.md`).
+const JSON_FORMAT: u32 = 1;
+
+/// What a [`Screen`] is on the wire. `format` first, so a reader sees it
+/// before the grid.
 #[derive(Serialize)]
 struct Wire<'a> {
+    format: u32,
     cols: u16,
     rows: u16,
     cursor: Cursor,
@@ -31,8 +47,15 @@ struct Wire<'a> {
     state: &'a TermState,
 }
 
+/// 0.10 wrote no `format` field; its shape is format 1.
+fn format_when_absent() -> u32 {
+    JSON_FORMAT
+}
+
 #[derive(Deserialize)]
 struct OwnedWire {
+    #[serde(default = "format_when_absent")]
+    format: u32,
     cols: u16,
     rows: u16,
     cursor: Cursor,
@@ -44,6 +67,7 @@ impl Serialize for Screen {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let width = usize::from(self.cols).max(1);
         Wire {
+            format: JSON_FORMAT,
             cols: self.cols,
             rows: self.rows,
             cursor: Cursor {
@@ -61,6 +85,13 @@ impl Serialize for Screen {
 impl<'de> Deserialize<'de> for Screen {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let wire = OwnedWire::deserialize(deserializer)?;
+        if wire.format != JSON_FORMAT {
+            return Err(D::Error::custom(format!(
+                "saved-screen JSON format {} is not one this termlens reads (it reads format {JSON_FORMAT}); \
+                 a newer termlens wrote this file",
+                wire.format
+            )));
+        }
         if wire.cells.len() != usize::from(wire.rows) {
             return Err(D::Error::custom(format!(
                 "a {}x{} screen needs {} rows of cells, not {}",

--- a/crates/termlens/tests/compat.rs
+++ b/crates/termlens/tests/compat.rs
@@ -1,0 +1,284 @@
+//! The saved-screen formats stay readable (#327): every file under
+//! `tests/compat/<version>/` was written by that published release, is
+//! never edited, and must parse into the screen it was written from.
+//!
+//! Three checks per shape. The text file round-trips byte for byte — parse
+//! it, render it the way it was rendered (`Display`, or `with_styles`
+//! when it carries a block), compare. The JSON twin deserialises and shows
+//! the same picture as the text (`Screen::diff` is empty), and re-serialises
+//! to the file's own document plus the `format` field a 0.10 file lacks —
+//! so every field of the out-of-band state is pinned too, not only the
+//! grid. `crates/termlens-cli/tests/cli.rs` adds the fourth: `termlens
+//! render --text` exits 0 on each file.
+//!
+//! The JSON checks need the `serde` feature; the text checks run in every
+//! configuration, which is where a `cfg(feature = "serde")` mistake in the
+//! parser would show.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use termlens::Screen;
+
+/// `tests/compat/`, and every version directory in it, sorted.
+fn versions() -> Vec<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/compat");
+    let mut dirs: Vec<PathBuf> = fs::read_dir(&root)
+        .expect("tests/compat exists")
+        .map(|entry| entry.expect("a directory entry").path())
+        .filter(|path| path.is_dir())
+        .collect();
+    dirs.sort();
+    assert!(
+        !dirs.is_empty(),
+        "no version directories under {}",
+        root.display()
+    );
+    dirs
+}
+
+/// The six shapes every version directory carries, so a directory that is
+/// missing one fails rather than silently pinning less.
+const SHAPES: [&str; 6] = [
+    "plain",
+    "styled",
+    "hidden",
+    "wide",
+    "masked",
+    "text-of-styled",
+];
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("{}: {e}", path.display()))
+        // A checkout on Windows may have given the file CRLF endings; the
+        // format is line-based and the byte comparison below must not be
+        // about line endings.
+        .replace("\r\n", "\n")
+}
+
+/// Parse a text file and render it back the way it was written: with the
+/// `styles:` block when the file has one, plain `Display` otherwise. The
+/// header's row count decides where the grid ends (#296), so "has a block"
+/// is decided the same way the parser decides it — by what follows the
+/// declared rows — and not by searching for the word.
+fn round_trip(text: &str) -> (Screen, String) {
+    let screen = Screen::parse(text).expect("a corpus file parses");
+    let rows = usize::from(screen.rows());
+    let after_grid = text
+        .lines()
+        .skip(1 + rows)
+        .any(|line| !line.trim().is_empty());
+    let rendered = if after_grid {
+        format!("{}\n", screen.with_styles())
+    } else {
+        format!("{screen}\n")
+    };
+    (screen, rendered)
+}
+
+#[test]
+fn every_text_file_written_by_a_published_release_round_trips_byte_for_byte() {
+    for dir in versions() {
+        for shape in SHAPES {
+            let path = dir.join(format!("{shape}.txt"));
+            let text = read(&path);
+            let (_, rendered) = round_trip(&text);
+            assert_eq!(
+                rendered,
+                text,
+                "{} does not survive parse -> render",
+                path.display()
+            );
+        }
+    }
+}
+
+#[test]
+fn a_hand_edited_corpus_file_would_fail() {
+    // The check above can fail: a header field, a grid character and a
+    // style token each changed in memory, and each is caught.
+    let dir = &versions()[0];
+    let text = read(&dir.join("styled.txt"));
+    let (_, rendered) = round_trip(&text);
+    assert_eq!(rendered, text, "the unedited file round-trips");
+    for (from, to) in [
+        ("cursor: 2,17", "cursor: 2,18"),
+        ("myapp", "myapq"),
+        ("fg=6", "fg=7"),
+    ] {
+        let edited = text.replacen(from, to, 1);
+        assert_ne!(edited, text, "{from} is in the file");
+        let (_, rendered) = round_trip(&edited);
+        assert_eq!(
+            rendered, edited,
+            "an edit that is itself valid still round-trips"
+        );
+        assert_ne!(rendered, text, "…and no longer equals the frozen file");
+    }
+    // An edit that breaks the format is refused rather than read as far as
+    // it goes.
+    let truncated = text.replacen("styles:", "style:", 1);
+    assert!(Screen::parse(&truncated).is_err());
+}
+
+#[cfg(feature = "serde")]
+mod json {
+    use super::*;
+
+    #[test]
+    fn every_json_twin_reads_as_the_same_picture_as_its_text() {
+        for dir in versions() {
+            for shape in SHAPES {
+                let text_path = dir.join(format!("{shape}.txt"));
+                let json_path = dir.join(format!("{shape}.json"));
+                let (from_text, _) = round_trip(&read(&text_path));
+                let from_json: Screen = serde_json::from_str(&read(&json_path))
+                    .unwrap_or_else(|e| panic!("{}: {e}", json_path.display()));
+                let diff = from_text.diff(&from_json);
+                if shape == "text-of-styled" {
+                    // The text format is style-blind and this shape's text
+                    // was written without its block, so the JSON twin
+                    // carries styles the text cannot: the same text, and a
+                    // diff that is styles only.
+                    assert_eq!(from_json.to_string(), from_text.to_string());
+                    assert_eq!(diff.changed_rows().collect::<Vec<_>>(), [0], "{diff}");
+                    assert_eq!(
+                        diff.style_changes().collect::<Vec<_>>(),
+                        [(0, "(none)", "0-2 fg=1")],
+                        "{diff}"
+                    );
+                    continue;
+                }
+                assert!(
+                    diff.is_empty(),
+                    "{} and {} show different pictures:\n{diff}",
+                    text_path.display(),
+                    json_path.display()
+                );
+            }
+        }
+    }
+
+    /// The whole document, not only the grid: a `Screen` read from a
+    /// corpus file serialises back to that file's JSON, with the one
+    /// addition every reader of a 0.10 file makes — `"format": 1`, which
+    /// 0.10 did not write and which is what its shape is (#329).
+    #[test]
+    fn every_json_twin_re_serialises_to_itself_plus_the_format_field() {
+        for dir in versions() {
+            for shape in SHAPES {
+                let path = dir.join(format!("{shape}.json"));
+                let mut file: serde_json::Value = serde_json::from_str(&read(&path)).unwrap();
+                let screen: Screen = serde_json::from_value(file.clone()).unwrap();
+                let object = file.as_object_mut().expect("a JSON object");
+                object.entry("format").or_insert(serde_json::json!(1));
+                assert_eq!(
+                    serde_json::to_value(&screen).unwrap(),
+                    file,
+                    "{} does not survive deserialize -> serialize",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_0_10_json_file_has_no_format_field_and_a_0_11_one_does() {
+        for dir in versions() {
+            let version = dir.file_name().unwrap().to_string_lossy().into_owned();
+            let file: serde_json::Value =
+                serde_json::from_str(&read(&dir.join("plain.json"))).unwrap();
+            // 0.10 wrote no field; every later release writes `1`.
+            let one = serde_json::json!(1);
+            let expected = (!version.starts_with("0.10.")).then_some(&one);
+            assert_eq!(file.get("format"), expected, "{version}");
+        }
+    }
+}
+
+/// Writes a new version directory from *this* tree, for the release that
+/// this tree is about to become (docs/RELEASING.md). Ignored: it is a tool,
+/// not a check, and it is run once per release by hand —
+///
+/// ```sh
+/// TERMLENS_WRITE_CORPUS=0.11.0 cargo test -p termlens --features serde \
+///     --test compat write_corpus -- --ignored
+/// ```
+///
+/// The shapes are the six the README lists, produced the way the 0.10.1
+/// directory was (a `sh -c 'printf …; read _'` per shape, so the corpus
+/// does not depend on a fixture binary that itself moves). It refuses to
+/// overwrite: a directory that exists is a published release's record.
+#[cfg(all(unix, feature = "serde"))]
+#[test]
+#[ignore = "writes tests/compat/<version>/; run by hand at release time with TERMLENS_WRITE_CORPUS set"]
+fn write_corpus() -> termlens::Result<()> {
+    use std::time::Duration;
+    use termlens::Terminal;
+
+    let Ok(version) = std::env::var("TERMLENS_WRITE_CORPUS") else {
+        panic!("set TERMLENS_WRITE_CORPUS=<version> to write a corpus directory");
+    };
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/compat")
+        .join(&version);
+    assert!(
+        !dir.exists(),
+        "{} exists; a published release's corpus is never rewritten",
+        dir.display()
+    );
+    fs::create_dir_all(&dir).expect("create the version directory");
+
+    let sh = |size: (u16, u16), script: &str| -> termlens::Result<Terminal> {
+        Terminal::builder()
+            .size(size.0, size.1)
+            .env_clear()
+            .timeout(Duration::from_secs(20))
+            .arg("-c")
+            .arg(format!("{script}; read _"))
+            .spawn("/bin/sh")
+    };
+    let write = |name: &str, text: String, screen: &Screen| {
+        fs::write(dir.join(format!("{name}.txt")), format!("{text}\n")).expect("write text");
+        let json = serde_json::to_string_pretty(screen).expect("serialize");
+        fs::write(dir.join(format!("{name}.json")), format!("{json}\n")).expect("write json");
+    };
+
+    let mut t = sh((20, 4), "printf 'hello, world\\nsecond line'")?;
+    t.wait_until(|s| s.contains("second line"))?;
+    let s = t.screen();
+    write("plain", s.to_string(), &s);
+
+    let mut t = sh((30, 4), "printf '\\033[1;36mmyapp\\033[0m  \\033[7m> Alpha\\033[0m\\n\\033[2mnote\\033[0m \\033[3mit\\033[0m \\033[4;33mul\\033[0m \\033[5mbl\\033[0m \\033[8mhid\\033[0m \\033[9mst\\033[0m\\n\\033[48;2;30;30;46mrgb bg\\033[0m \\033[38;5;208mfg208\\033[0m DONE'")?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t.screen();
+    write("styled", s.with_styles().to_string(), &s);
+
+    let mut t = sh((20, 3), "printf 'cursor gone\\033[?25l'")?;
+    t.wait_until(|s| s.contains("cursor gone") && !s.cursor_visible())?;
+    let s = t.screen();
+    write("hidden", s.with_styles().to_string(), &s);
+
+    let mut t = sh((12, 3), "printf '東京 e\u{301} 😀!\\nabcdefghij東\\nEND'")?;
+    t.wait_until(|s| s.contains("END"))?;
+    let s = t.screen();
+    write("wide", s.with_styles().to_string(), &s);
+
+    let mut t = sh(
+        (30, 3),
+        "printf 'pw: \\033[8mhunter2\\033[28m at 12:34:56\\n\\033[1mid=\\033[0m 4711 DONE'",
+    )?;
+    t.wait_until(|s| s.contains("DONE"))?;
+    let s = t
+        .screen()
+        .mask_matching("12:34:56", '▒')
+        .mask_rect(4..11, 0..1);
+    write("masked", s.with_styles().to_string(), &s);
+
+    let mut t = sh((16, 2), "printf '\\033[31mred\\033[0m and plain'")?;
+    t.wait_until(|s| s.contains("plain"))?;
+    let s = t.screen();
+    write("text-of-styled", s.to_string(), &s);
+    Ok(())
+}

--- a/crates/termlens/tests/compat/0.10.1/hidden.json
+++ b/crates/termlens/tests/compat/0.10.1/hidden.json
@@ -1,0 +1,1071 @@
+{
+  "cols": 20,
+  "rows": 3,
+  "cursor": {
+    "row": 0,
+    "col": 11,
+    "visible": false
+  },
+  "cells": [
+    [
+      {
+        "contents": "c",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "u",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "r",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "s",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "o",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "r",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "g",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "o",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "n",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "e",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ]
+  ],
+  "state": {
+    "title": "",
+    "alternate_screen": false,
+    "bracketed_paste": false,
+    "application_cursor": false,
+    "mouse": "none",
+    "mouse_modes": 0,
+    "clipboard": null,
+    "bells": 0,
+    "focus_events": false,
+    "cursor_style": null,
+    "links": [],
+    "graphics": {
+      "counts": {
+        "kitty": 0,
+        "sixel": 0,
+        "deletes": 0,
+        "bytes": 0
+      },
+      "payloads": []
+    },
+    "repaints": 0,
+    "scrollback": [],
+    "scrollback_cells": null,
+    "wrapped": [
+      false,
+      false,
+      false
+    ],
+    "insert_mode": false,
+    "unsupported": [],
+    "unsupported_overflow": 0,
+    "visual_bells": 0
+  }
+}

--- a/crates/termlens/tests/compat/0.10.1/hidden.txt
+++ b/crates/termlens/tests/compat/0.10.1/hidden.txt
@@ -1,0 +1,7 @@
+size: 20x3  cursor: hidden
+cursor gone
+
+
+
+styles:
+(none)

--- a/crates/termlens/tests/compat/0.10.1/masked.json
+++ b/crates/termlens/tests/compat/0.10.1/masked.json
@@ -1,625 +1,13 @@
----
-source: crates/termlens/tests/export.rs
-expression: s
----
 {
-  "format": 1,
   "cols": 30,
-  "rows": 4,
+  "rows": 3,
   "cursor": {
-    "row": 2,
-    "col": 4,
+    "row": 1,
+    "col": 13,
     "visible": true
   },
   "cells": [
     [
-      {
-        "contents": "m",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "y",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "a",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "p",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "p",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": ">",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "A",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "l",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "p",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "h",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "a",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "汉",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": true,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": true
-      },
-      {
-        "contents": "字",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": true,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": true
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      }
-    ],
-    [
-      {
-        "contents": "n",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": true,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "o",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": true,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "t",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": true,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "e",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": true,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
       {
         "contents": "p",
         "style": {
@@ -689,7 +77,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "s",
+        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -706,7 +94,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "e",
+        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -723,7 +111,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "c",
+        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -740,7 +128,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "r",
+        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -757,7 +145,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "e",
+        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -768,6 +156,74 @@ expression: s
           "reverse": false,
           "blink": false,
           "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "a",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
           "strikethrough": false
         },
         "wide": false,
@@ -784,23 +240,6 @@ expression: s
           "underline": false,
           "reverse": false,
           "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
           "conceal": false,
           "strikethrough": false
         },
@@ -811,13 +250,7 @@ expression: s
         "contents": " ",
         "style": {
           "fg": "default",
-          "bg": {
-            "rgb": [
-              30,
-              30,
-              46
-            ]
-          },
+          "bg": "default",
           "bold": false,
           "dim": false,
           "italic": false,
@@ -831,30 +264,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": {
-            "rgb": [
-              30,
-              30,
-              46
-            ]
-          },
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
+        "contents": "▒",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -871,7 +281,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "",
+        "contents": "▒",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -888,7 +298,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "",
+        "contents": "▒",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -905,7 +315,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "",
+        "contents": "▒",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -922,7 +332,58 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "",
+        "contents": "▒",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "▒",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "▒",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "▒",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -1060,6 +521,159 @@ expression: s
     ],
     [
       {
+        "contents": "i",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "d",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "=",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": true,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "4",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "7",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "1",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "1",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
         "contents": "D",
         "style": {
           "fg": "default",
@@ -1112,159 +726,6 @@ expression: s
       },
       {
         "contents": "E",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -2110,11 +1571,13 @@ expression: s
     "wrapped": [
       false,
       false,
-      false,
       false
     ],
     "insert_mode": false,
-    "unsupported": [],
+    "unsupported": [
+      "^[[8m",
+      "^[[28m"
+    ],
     "unsupported_overflow": 0,
     "visual_bells": 0
   }

--- a/crates/termlens/tests/compat/0.10.1/masked.txt
+++ b/crates/termlens/tests/compat/0.10.1/masked.txt
@@ -1,0 +1,8 @@
+size: 30x3  cursor: 1,13
+pw:         at ▒▒▒▒▒▒▒▒
+id= 4711 DONE
+
+
+styles:
+0: 4-10 conceal
+1: 0-2 bold

--- a/crates/termlens/tests/compat/0.10.1/plain.json
+++ b/crates/termlens/tests/compat/0.10.1/plain.json
@@ -1,232 +1,13 @@
----
-source: crates/termlens/tests/export.rs
-expression: s
----
 {
-  "format": 1,
-  "cols": 30,
+  "cols": 20,
   "rows": 4,
   "cursor": {
-    "row": 2,
-    "col": 4,
+    "row": 1,
+    "col": 11,
     "visible": true
   },
   "cells": [
     [
-      {
-        "contents": "m",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "y",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "a",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "p",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "p",
-        "style": {
-          "fg": {
-            "indexed": 6
-          },
-          "bg": "default",
-          "bold": true,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": ">",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "A",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "l",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "p",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
       {
         "contents": "h",
         "style": {
@@ -234,348 +15,6 @@ expression: s
           "bg": "default",
           "bold": false,
           "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "a",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": true,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "汉",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": true,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": true
-      },
-      {
-        "contents": "字",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": true,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": true
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      }
-    ],
-    [
-      {
-        "contents": "n",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": true,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "o",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": true,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "t",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": true,
           "italic": false,
           "underline": false,
           "reverse": false,
@@ -592,7 +31,7 @@ expression: s
           "fg": "default",
           "bg": "default",
           "bold": false,
-          "dim": true,
+          "dim": false,
           "italic": false,
           "underline": false,
           "reverse": false,
@@ -604,7 +43,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": " ",
+        "contents": "l",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -621,7 +60,58 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "p",
+        "contents": "l",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "o",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": ",",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -655,7 +145,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": ":",
+        "contents": "o",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -666,74 +156,6 @@ expression: s
           "reverse": false,
           "blink": false,
           "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "s",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "e",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "c",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": true,
           "strikethrough": false
         },
         "wide": false,
@@ -750,7 +172,196 @@ expression: s
           "underline": false,
           "reverse": false,
           "blink": false,
-          "conceal": true,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "l",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "d",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "s",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
           "strikethrough": false
         },
         "wide": false,
@@ -767,14 +378,14 @@ expression: s
           "underline": false,
           "reverse": false,
           "blink": false,
-          "conceal": true,
+          "conceal": false,
           "strikethrough": false
         },
         "wide": false,
         "wide_continuation": false
       },
       {
-        "contents": "t",
+        "contents": "c",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -784,7 +395,58 @@ expression: s
           "underline": false,
           "reverse": false,
           "blink": false,
-          "conceal": true,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "o",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "n",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "d",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
           "strikethrough": false
         },
         "wide": false,
@@ -808,53 +470,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": {
-            "rgb": [
-              30,
-              30,
-              46
-            ]
-          },
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": {
-            "rgb": [
-              30,
-              30,
-              46
-            ]
-          },
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
+        "contents": "l",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -871,7 +487,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "",
+        "contents": "i",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -888,7 +504,24 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "",
+        "contents": "n",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "e",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -1059,176 +692,6 @@ expression: s
       }
     ],
     [
-      {
-        "contents": "D",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "O",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "N",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "E",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
       {
         "contents": "",
         "style": {
@@ -1571,176 +1034,6 @@ expression: s
       }
     ],
     [
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
       {
         "contents": "",
         "style": {

--- a/crates/termlens/tests/compat/0.10.1/plain.txt
+++ b/crates/termlens/tests/compat/0.10.1/plain.txt
@@ -1,0 +1,5 @@
+size: 20x4  cursor: 1,11
+hello, world
+second line
+
+

--- a/crates/termlens/tests/compat/0.10.1/styled.json
+++ b/crates/termlens/tests/compat/0.10.1/styled.json
@@ -1,14 +1,9 @@
----
-source: crates/termlens/tests/export.rs
-expression: s
----
 {
-  "format": 1,
   "cols": 30,
   "rows": 4,
   "cursor": {
     "row": 2,
-    "col": 4,
+    "col": 17,
     "visible": true
   },
   "cells": [
@@ -262,7 +257,7 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": " ",
+        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -276,40 +271,6 @@ expression: s
           "strikethrough": false
         },
         "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "汉",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": true,
         "wide_continuation": false
       },
       {
@@ -327,23 +288,6 @@ expression: s
           "strikethrough": false
         },
         "wide": false,
-        "wide_continuation": true
-      },
-      {
-        "contents": "字",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": true,
         "wide_continuation": false
       },
       {
@@ -361,7 +305,58 @@ expression: s
           "strikethrough": false
         },
         "wide": false,
-        "wide_continuation": true
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
       },
       {
         "contents": "",
@@ -621,7 +616,41 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "p",
+        "contents": "i",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": true,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "t",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": true,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -638,7 +667,45 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": "w",
+        "contents": "u",
+        "style": {
+          "fg": {
+            "indexed": 3
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": true,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "l",
+        "style": {
+          "fg": {
+            "indexed": 3
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": true,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -655,7 +722,41 @@ expression: s
         "wide_continuation": false
       },
       {
-        "contents": ":",
+        "contents": "b",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": true,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "l",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": true,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -666,6 +767,57 @@ expression: s
           "reverse": false,
           "blink": false,
           "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "h",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "i",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "d",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": true,
           "strikethrough": false
         },
         "wide": false,
@@ -699,76 +851,8 @@ expression: s
           "underline": false,
           "reverse": false,
           "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "e",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "c",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "r",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "e",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": true,
-          "strikethrough": false
+          "conceal": false,
+          "strikethrough": true
         },
         "wide": false,
         "wide_continuation": false
@@ -784,105 +868,8 @@ expression: s
           "underline": false,
           "reverse": false,
           "blink": false,
-          "conceal": true,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
           "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": {
-            "rgb": [
-              30,
-              30,
-              46
-            ]
-          },
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": " ",
-        "style": {
-          "fg": "default",
-          "bg": {
-            "rgb": [
-              30,
-              30,
-              46
-            ]
-          },
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
+          "strikethrough": true
         },
         "wide": false,
         "wide_continuation": false
@@ -1060,6 +1047,273 @@ expression: s
     ],
     [
       {
+        "contents": "r",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "g",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "b",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "b",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "g",
+        "style": {
+          "fg": "default",
+          "bg": {
+            "rgb": [
+              30,
+              30,
+              46
+            ]
+          },
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "f",
+        "style": {
+          "fg": {
+            "indexed": 208
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "g",
+        "style": {
+          "fg": {
+            "indexed": 208
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "2",
+        "style": {
+          "fg": {
+            "indexed": 208
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "0",
+        "style": {
+          "fg": {
+            "indexed": 208
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "8",
+        "style": {
+          "fg": {
+            "indexed": 208
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
         "contents": "D",
         "style": {
           "fg": "default",
@@ -1112,227 +1366,6 @@ expression: s
       },
       {
         "contents": "E",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
-        "style": {
-          "fg": "default",
-          "bg": "default",
-          "bold": false,
-          "dim": false,
-          "italic": false,
-          "underline": false,
-          "reverse": false,
-          "blink": false,
-          "conceal": false,
-          "strikethrough": false
-        },
-        "wide": false,
-        "wide_continuation": false
-      },
-      {
-        "contents": "",
         "style": {
           "fg": "default",
           "bg": "default",
@@ -2114,7 +2147,11 @@ expression: s
       false
     ],
     "insert_mode": false,
-    "unsupported": [],
+    "unsupported": [
+      "^[[5m",
+      "^[[8m",
+      "^[[9m"
+    ],
     "unsupported_overflow": 0,
     "visual_bells": 0
   }

--- a/crates/termlens/tests/compat/0.10.1/styled.txt
+++ b/crates/termlens/tests/compat/0.10.1/styled.txt
@@ -1,0 +1,10 @@
+size: 30x4  cursor: 2,17
+myapp  > Alpha
+note it ul bl hid st
+rgb bg fg208 DONE
+
+
+styles:
+0: 0-4 fg=6 bold; 7-13 reverse
+1: 0-3 dim; 5-6 italic; 8-9 fg=3 underline; 11-12 blink; 14-16 conceal; 18-19 strikethrough
+2: 0-5 bg=#1e1e2e; 7-11 fg=208

--- a/crates/termlens/tests/compat/0.10.1/text-of-styled.json
+++ b/crates/termlens/tests/compat/0.10.1/text-of-styled.json
@@ -1,0 +1,598 @@
+{
+  "cols": 16,
+  "rows": 2,
+  "cursor": {
+    "row": 0,
+    "col": 13,
+    "visible": true
+  },
+  "cells": [
+    [
+      {
+        "contents": "r",
+        "style": {
+          "fg": {
+            "indexed": 1
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "e",
+        "style": {
+          "fg": {
+            "indexed": 1
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "d",
+        "style": {
+          "fg": {
+            "indexed": 1
+          },
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "a",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "n",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "d",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "p",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "l",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "a",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "i",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "n",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ]
+  ],
+  "state": {
+    "title": "",
+    "alternate_screen": false,
+    "bracketed_paste": false,
+    "application_cursor": false,
+    "mouse": "none",
+    "mouse_modes": 0,
+    "clipboard": null,
+    "bells": 0,
+    "focus_events": false,
+    "cursor_style": null,
+    "links": [],
+    "graphics": {
+      "counts": {
+        "kitty": 0,
+        "sixel": 0,
+        "deletes": 0,
+        "bytes": 0
+      },
+      "payloads": []
+    },
+    "repaints": 0,
+    "scrollback": [],
+    "scrollback_cells": null,
+    "wrapped": [
+      false,
+      false
+    ],
+    "insert_mode": false,
+    "unsupported": [],
+    "unsupported_overflow": 0,
+    "visual_bells": 0
+  }
+}

--- a/crates/termlens/tests/compat/0.10.1/text-of-styled.txt
+++ b/crates/termlens/tests/compat/0.10.1/text-of-styled.txt
@@ -1,0 +1,3 @@
+size: 16x2  cursor: 0,13
+red and plain
+

--- a/crates/termlens/tests/compat/0.10.1/wide.json
+++ b/crates/termlens/tests/compat/0.10.1/wide.json
@@ -1,0 +1,663 @@
+{
+  "cols": 12,
+  "rows": 3,
+  "cursor": {
+    "row": 2,
+    "col": 3,
+    "visible": true
+  },
+  "cells": [
+    [
+      {
+        "contents": "東",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": true,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": true
+      },
+      {
+        "contents": "京",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": true,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": true
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "é",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": " ",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "😀",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": true,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": true
+      },
+      {
+        "contents": "!",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ],
+    [
+      {
+        "contents": "a",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "b",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "c",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "d",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "e",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "f",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "g",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "h",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "i",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "j",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "東",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": true,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": true
+      }
+    ],
+    [
+      {
+        "contents": "E",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "N",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "D",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      },
+      {
+        "contents": "",
+        "style": {
+          "fg": "default",
+          "bg": "default",
+          "bold": false,
+          "dim": false,
+          "italic": false,
+          "underline": false,
+          "reverse": false,
+          "blink": false,
+          "conceal": false,
+          "strikethrough": false
+        },
+        "wide": false,
+        "wide_continuation": false
+      }
+    ]
+  ],
+  "state": {
+    "title": "",
+    "alternate_screen": false,
+    "bracketed_paste": false,
+    "application_cursor": false,
+    "mouse": "none",
+    "mouse_modes": 0,
+    "clipboard": null,
+    "bells": 0,
+    "focus_events": false,
+    "cursor_style": null,
+    "links": [],
+    "graphics": {
+      "counts": {
+        "kitty": 0,
+        "sixel": 0,
+        "deletes": 0,
+        "bytes": 0
+      },
+      "payloads": []
+    },
+    "repaints": 0,
+    "scrollback": [],
+    "scrollback_cells": null,
+    "wrapped": [
+      false,
+      false,
+      false
+    ],
+    "insert_mode": false,
+    "unsupported": [],
+    "unsupported_overflow": 0,
+    "visual_bells": 0
+  }
+}

--- a/crates/termlens/tests/compat/0.10.1/wide.txt
+++ b/crates/termlens/tests/compat/0.10.1/wide.txt
@@ -1,0 +1,7 @@
+size: 12x3  cursor: 2,3
+東京 é 😀!
+abcdefghij東
+END
+
+styles:
+(none)

--- a/crates/termlens/tests/compat/README.md
+++ b/crates/termlens/tests/compat/README.md
@@ -1,0 +1,33 @@
+# Saved-screen compatibility corpus
+
+Files written by **published** releases of termlens, in the two formats a
+saved screen takes — the snapshot text format of `docs/DESIGN.md` §3 and
+the JSON the `serde` feature writes — and the test that holds every later
+release to reading them (`tests/compat.rs`).
+
+**The rule: a file in here is never edited. A new version adds a
+directory.** The insta snapshots under `tests/snapshots/` are regression
+*outputs* and are re-recorded when an intended change lands; these are
+frozen *inputs*, and a change to the header, the `styles:` block or the
+JSON shape that would re-record a snapshot fails here instead. That is the
+difference between "the format stays valid" as a sentence in STABILITY.md
+and as a thing CI checks.
+
+Each directory holds six shapes, as `<name>.txt` and its JSON twin
+`<name>.json`, written by that version from the same `Screen`:
+
+| shape | what it pins |
+| --- | --- |
+| `plain` | `Display` alone: the header, a visible cursor, trailing blank rows |
+| `styled` | `with_styles()` with every token the `styles:` block can carry — `fg=` indexed, `bg=#rrggbb`, and the eight attributes in SGR order |
+| `hidden` | `cursor: hidden` in the header, and `(none)` for a styles block with nothing in it |
+| `wide` | CJK, a combining mark, an emoji, and a wide glyph ending at the right margin |
+| `masked` | `mask_rect` and `mask_matching` output: a fill character and blanks, with the original's styles kept |
+| `text-of-styled` | `Display` of a screen that *has* styles: the text format is style-blind, and the JSON twin carries them anyway |
+
+`0.10.1/` was written by the published 0.10.1 through a registry
+dependency (`termlens = "=0.10.1"`), not a path — the JSON there has no
+`format` field and, for `styled`, lists the SGR parameters 0.10.1 wrongly
+named as unsupported (#320), because that is what 0.10.1 wrote. Later
+directories are written by the release they are named after, from a
+consumer of the published crate.

--- a/crates/termlens/tests/export.rs
+++ b/crates/termlens/tests/export.rs
@@ -59,6 +59,17 @@ fn a_diff_shows_only_what_changed_and_where() -> termlens::Result<()> {
     );
     assert!(a.diff(&a).is_empty());
     assert_eq!(a.diff(&a).to_string(), "no difference");
+    // #308: which rows changed, and which style runs, as an API rather
+    // than a substring of the rendering. Row 0 lost a digit under the
+    // same style; row 1 lost its reverse-video highlight.
+    assert_eq!(diff.changed_rows().collect::<Vec<_>>(), [0, 1], "{diff}");
+    assert_eq!(
+        diff.style_changes().collect::<Vec<_>>(),
+        [(1, "0-5 reverse", "(none)")],
+        "{diff}"
+    );
+    assert!(a.diff(&a).changed_rows().next().is_none());
+    assert!(a.diff(&a).style_changes().next().is_none());
     insta::assert_snapshot!("diff_rendering", diff.to_string());
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
@@ -165,6 +176,43 @@ mod json {
         Ok(())
     }
 
+    /// The JSON is a persisted artifact, so it says which shape it is
+    /// (#329): `"format": 1`, first. A 0.10 file has no such field and is
+    /// format 1 by definition; a number this build does not know is
+    /// refused with a message that names it.
+    #[test]
+    fn the_json_carries_its_format_and_reads_a_file_without_one() -> termlens::Result<()> {
+        let mut t = emit(&["ab\nDONE", "--wait"])?;
+        t.wait_until(|s| s.contains("DONE"))?;
+        let screen = t.screen();
+        let json = serde_json::to_string(&screen).expect("serializes");
+        assert!(
+            json.starts_with("{\"format\":1,"),
+            "the format number leads the document: {}",
+            &json[..40]
+        );
+
+        // What 0.10 wrote: the same document without the field.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value.as_object_mut().unwrap().remove("format").is_some());
+        let old: termlens::Screen =
+            serde_json::from_value(value.clone()).expect("a 0.10 file reads");
+        assert_eq!(old, screen, "and is the same screen");
+
+        // What a later termlens might write.
+        value["format"] = serde_json::json!(2);
+        let err = serde_json::from_value::<termlens::Screen>(value)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("format 2") && err.contains("reads format 1"),
+            "refused with the numbers: {err}"
+        );
+        t.send(Key::Enter)?;
+        assert!(t.wait_exit()?.success());
+        Ok(())
+    }
+
     #[test]
     fn a_screen_that_does_not_hold_together_is_refused() -> termlens::Result<()> {
         let mut t = emit(&["ab\nDONE", "--wait"])?;
@@ -259,9 +307,10 @@ fn a_wide_character_with_a_combining_mark_round_trips() -> termlens::Result<()> 
 )]
 fn a_hidden_cursor_round_trips_as_the_same_picture() -> termlens::Result<()> {
     let mut t = emit(&["--raw", r"hello\e[2;3H\e[?25l", "--wait"])?;
-    t.wait_until(|s| s.contains("hello") && !s.cursor().2)?;
+    t.wait_until(|s| s.contains("hello") && !s.cursor_visible())?;
     let screen = t.screen();
     assert_eq!(screen.cursor(), (1, 2, false));
+    assert!(!screen.cursor_visible(), "the tuple and the accessor agree");
 
     let parsed = Screen::parse(&screen.with_styles().to_string())?;
     assert_eq!(

--- a/crates/termlens/tests/fixtures.rs
+++ b/crates/termlens/tests/fixtures.rs
@@ -28,7 +28,7 @@ fn hello_tui_draws_a_static_alt_screen_frame() -> termlens::Result<()> {
 
     let screen = t.screen();
     assert!(screen.contains("status: ready"), "{screen}");
-    let (_, _, cursor_visible) = screen.cursor();
+    let cursor_visible = screen.cursor_visible();
     assert!(!cursor_visible, "hello-tui hides the cursor");
     assert_eq!(screen.find("hello-tui"), Some((1, 2)));
     insta::assert_snapshot!(t.screen());

--- a/crates/termlens/tests/state.rs
+++ b/crates/termlens/tests/state.rs
@@ -234,7 +234,7 @@ fn a_soft_reset_returns_the_modes_a_screen_can_observe() -> termlens::Result<()>
             && s.bracketed_paste()
             && s.mouse_mode() == MouseMode::PressRelease
             && s.focus_events()
-            && !s.cursor().2
+            && !s.cursor_visible()
             && s.cursor_shape() == CursorShape::Bar
     })?;
 
@@ -249,7 +249,10 @@ fn a_soft_reset_returns_the_modes_a_screen_can_observe() -> termlens::Result<()>
     assert!(!s.bracketed_paste(), "{s}");
     assert_eq!(s.mouse_mode(), MouseMode::None, "{s}");
     assert!(!s.focus_events(), "{s}");
-    assert!(s.cursor().2, "DECTCEM: the cursor is visible again: {s}");
+    assert!(
+        s.cursor_visible(),
+        "DECTCEM: the cursor is visible again: {s}"
+    );
     assert_eq!(s.cursor_shape(), CursorShape::Default, "{s}");
     assert_eq!(s.cursor_blink(), None, "{s}");
 

--- a/crates/termlens/tests/styled_history.rs
+++ b/crates/termlens/tests/styled_history.rs
@@ -141,6 +141,16 @@ fn locate_says_which_region_holds_the_needle() -> termlens::Result<()> {
         matches!(s.locate("line 1"), Some(Location::Screen { .. })),
         "{s}"
     );
+    // #306: the one-fact questions without a match. The column is the
+    // same number either region reports; the row deliberately is not
+    // offered, since a grid row and a history row are different things.
+    let ready = s.locate("READY").expect("on the grid");
+    assert!(ready.is_on_screen() && !ready.is_in_history());
+    assert_eq!(ready.col(), 0);
+    let secret = s.locate("SECRET").expect("in history");
+    assert!(secret.is_in_history() && !secret.is_on_screen());
+    assert_eq!(secret.col(), 4);
+    assert!(s.locate("line 1").is_some_and(Location::is_on_screen));
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -539,7 +539,8 @@ Rules:
    is `<row>: <spans>` with spans joined by `; `. A span is an inclusive,
    0-based column range (`start-end`, or just `start` for one column)
    followed by style tokens in fixed order: `fg=`, `bg=` (indexed colors
-   as decimal, RGB as `#rrggbb`), then `bold`, `dim`, `italic`,
+   as decimal, RGB as `#rrggbb` — the token `Color`'s `Display` writes and
+   `Screen::parse` reads), then `bold`, `dim`, `italic`,
    `underline`, `blink`, `reverse`, `conceal`, `strikethrough` — SGR order,
    which is the order the original five were already in, so an existing
    span's tokens are unchanged unless the cell carries one of the three
@@ -680,6 +681,79 @@ Rules:
 The `insta` feature (default) re-exports `insta` and ships
 `assert_screen_snapshot!` so the snapshotting insta version can't drift
 from the one the macro targets.
+
+### What a reader skips, and what it does not
+
+The format proper begins at the `size:` header and ends with the grid or
+the `styles:` block. `Screen::parse` accepts exactly that — every other
+line is an `Error::Parse` naming it. termlens itself writes two things
+*around* a screen, and its own reader, the `termlens` CLI, skips both:
+
+- **Above:** the insta header, `---` / `source: …` / `---`, which a `.snap`
+  file carries over the content that was snapshotted.
+- **Below:** the trailer `termlens inspect` wrote to stdout before 0.11 —
+  `--- exited: … ---`, `--- still running at the deadline … ---`,
+  `--- waiting for the program failed: … ---`. Since 0.11 the trailer goes
+  to **stderr** and stdout carries the screen alone, so `termlens inspect
+  prog > file` saves a screen `diff` and `render` read back (#340); the
+  CLI still drops exactly those three shapes when they are the last line of
+  a file, so a file saved by a 0.10 `inspect` reads too. Nothing else
+  trailing is skipped: a grid row that merely begins with `---` is content.
+
+The split is deliberate. The library reads the *format*; the tool knows
+its own *wrappers*. A consumer parsing a file with `Screen::parse` sees
+the strict format and nothing else, and the list of decorations is the
+CLI's to extend.
+
+### The JSON shape (`serde` feature)
+
+With the `serde` feature a `Screen` serialises to JSON, and the CLI reads
+that JSON back as a saved screen — so it is a persisted artifact, and it
+is specified here next to the text format (#329). Format **1**:
+
+```json
+{
+  "format": 1,
+  "cols": 30, "rows": 4,
+  "cursor": { "row": 2, "col": 4, "visible": true },
+  "cells": [ [ { "contents": "m", "style": { … }, "wide": false, "wide_continuation": false }, … ], … ],
+  "state": { "title": "", "alternate_screen": false, … }
+}
+```
+
+- `format` — the shape number, first. A file without it was written by
+  0.10 and *is* format 1; a reader that meets a number it does not know
+  refuses the file and names both numbers rather than reading as far as
+  the fields line up. A new number is a new stability candidate or a
+  major version, never a silent change.
+- `cols`, `rows` — the geometry, in the terminal's order.
+- `cursor` — three named fields. A hidden cursor keeps its position here
+  (`"visible": false`), unlike the text format, where `cursor: hidden`
+  drops it; `Screen::diff` treats a hidden cursor's position as not part
+  of the picture either way.
+- `cells` — **rows of cells**, `rows` arrays of exactly `cols` objects, so
+  a JSON diff reads by row. A cell is `contents` (a string: one grapheme,
+  possibly with combining marks; `""` for an erased cell and for the
+  continuation half of a wide character), `style`, `wide` and
+  `wide_continuation`. A style is `fg`, `bg` and the eight attribute
+  booleans in SGR order; a colour is `"default"`, `{"indexed": 4}` or
+  `{"rgb": [30, 30, 46]}`.
+- `state` — the out-of-band state the text format omits, every field the
+  accessors on `Screen` expose: the title, the mode flags, the mouse
+  protocol and the tracking-mode set, the clipboard, the counters, the
+  cursor style, the links, the graphics record, the scrollback (text, and
+  cells when retained), the wrap flags, insert mode, the unsupported
+  sequences with their overflow count, the visual bells.
+
+Nothing is omitted that a `Screen` holds, which is why reading the JSON
+back gives a `Screen` that is `==` to the original where the text format
+gives one that only `diff`s empty. Every row must hold `cols` cells and
+there must be `rows` of them; a file that does not hold together is an
+error, never a screen that panics on its first `cell()`.
+
+The compatibility corpus under `crates/termlens/tests/compat/` holds both
+formats as written by each published release, and `tests/compat.rs`
+holds every later release to reading them (#327).
 
 ### Masks
 


### PR DESCRIPTION
Closes #327
Closes #329
Closes #331
Closes #332
Closes #306
Closes #308
Closes #315
Closes #340

Everything in the 0.11 milestone that is additive or a fix. The one break (#330) is the next PR, alone, under the `breaking` label; the contract docs (#328, #334) follow it.

**#327 — the frozen corpus.** `crates/termlens/tests/compat/0.10.1/` holds six shapes as text and JSON twin — plain, every style token, a hidden cursor, wide/combining/emoji, a masked screen, the style-blind text of a styled screen — written by the **published** 0.10.1 through `termlens = "=0.10.1"`, not a path. `tests/compat.rs`: every text file parses and re-renders byte for byte; every JSON twin reads as the same picture as its text and re-serialises to its own document plus `"format": 1`; the CLI suite renders every file. A test edits a file three ways in memory and each edit is caught. An `#[ignore]`d writer produces the next version's directory at release time; run against this tree it reproduces all six 0.10.1 text files byte for byte (the JSON differs by `format` and by the #320 fix, as it should). README states the rule: never edited, a new version adds a directory.

**#329 — `"format": 1`**, first in the document. A 0.10 file without the field reads as format 1 (measured on the corpus); `format: 2` is refused with a message naming both numbers. `docs/DESIGN.md` §3 specifies the shape — field names, the cursor object, wide/continuation cells, colours, the state — beside the text format. The insta JSON snapshot changed by exactly one line (`"format": 1`), reviewed.

**#340 — `inspect … > file` is a saved screen.** The trailer goes to stderr; stdout carries the screen alone. Option 1 from the issue, plus the CLI dropping exactly the three pre-0.11 trailer shapes as the last line of a file, so a screen saved by a 0.10 `inspect` reads too; `Screen::parse` itself skips nothing, and DESIGN §3 now says which decorations the CLI skips at each end. `check-cli-contract.sh` asserts the round trip — **against the published 0.10.3 it fails on exactly these assertions** (installed with `cargo install termlens-cli --version =0.10.3 --locked`, run locally). A `Command`-driven test checks the stream split, since through a PTY both streams land on one screen.

**Additive API:** #331 `cursor_visible()` (tuple unchanged; the crate's own tests use it where they meant visibility); #332 `ScreenWithStyles` exported, doctest names it from a consumer; #306 `Location::{is_on_screen, is_in_history, col}` with the deliberately absent `row()` explained; #308 `ScreenDiff::{changed_rows, style_changes}` (also dogfooded by the corpus test's style-blind shape); #315 `Display for Color`, round-trips with `parse_color`, the styles block uses it, every existing snapshot unchanged.

**Verified locally:** fmt; clippy in all four configurations; rustdoc both ways; `cargo test --workspace --all-features` and default; the four isolated `-p termlens` sets; feature isolation; CLI contract; README links; skill snippets; gates-listed; deny; MSRV over the three configurations at 1.85.1 (which caught a temporary borrow the stable compiler accepts — fixed); semver gate against 0.10.3: patch-compatible in all three views, as an additive PR should be.

**Not done here:** the `0.11.0` corpus directory (written at release from the release tree — the writer is in this PR); SKILL.md and STABILITY.md wording (#334, #328); consumer migrations. Known transient: `install.yml`'s daily `cli` job runs main's contract script against the *published* 0.10.3 and will fail on the #340 assertions until 0.11.0 is published — that is the script correctly saying main's contract is ahead of the published binary.
