### PR TITLE
feat!: Screen::unsupported() returns an Unsupported view; unsupported_overflow() is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ listed under a **Changed** or **Removed** heading, in a bullet that begins
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `Screen::unsupported()` returns an [`Unsupported`] view
+  instead of `&[Arc<str>]`, and `Screen::unsupported_overflow()` is
+  removed — the view carries the count (#330). The one breaking change of
+  the 0.11 stability candidate, and the last before 1.0.
+
+  The old return type was the storage: `Arc<str>` is how the screen keeps
+  the list cheap to clone, and exposing the slice locked that
+  representation into the public API for good. The ergonomics showed it —
+  consumers wrote `.iter().map(|q| &**q)` to get at plain strings, and
+  "nothing was dropped" took two calls. The view is `Copy`, borrows the
+  screen, and compares equal to an array or slice of `&str` when the
+  retained shapes match in order *and* nothing overflowed, so a pin is one
+  line: `assert_eq!(s.unsupported(), ["^[[59m"]);`.
+
+  | 0.10 | 0.11 |
+  | --- | --- |
+  | `s.unsupported().is_empty()` | unchanged (and now also false when shapes overflowed) |
+  | `s.unsupported().len()` | unchanged — the retained count, at most 32 |
+  | `s.unsupported().iter().map(\|q\| &**q)` | `s.unsupported().iter()` |
+  | `s.unsupported().iter().map(\|q\| q.to_string()).collect::<Vec<_>>()` | `s.unsupported().iter().map(str::to_owned).collect::<Vec<_>>()` |
+  | `s.unsupported().iter().any(\|q\| &**q == "^[[5m")` | `s.unsupported().contains("^[[5m")` |
+  | `&*s.unsupported()[0]` | `s.unsupported().iter().next()` |
+  | `s.unsupported_overflow()` | `s.unsupported().overflow()` |
+  | `assert!(s.unsupported().is_empty()); assert_eq!(s.unsupported_overflow(), 0);` | `assert_eq!(s.unsupported(), []);` or `assert!(s.unsupported().is_empty())` |
+
+  `Debug` prints `["^[[59m"]`, or `["^[[20h", …] (+8 more)` when shapes
+  overflowed. `UnsupportedIter` is the view's `IntoIterator` type.
+
+  What the semver gate saw, forced to `patch` against 0.10.3, in all three
+  feature views: `inherent_method_missing: Screen::unsupported_overflow`.
+  The changed return type of `unsupported()` itself is *not* a lint
+  `cargo-semver-checks` 0.50.0 has, which is worth knowing about the gate:
+  it catches a removed or gated item, not a re-typed one; the in-tree tests
+  and every consumer's compile do.
+
 ### Added
 
 - **A frozen saved-screen corpus** (#327). Nothing pinned that a file

--- a/crates/termlens/src/lib.rs
+++ b/crates/termlens/src/lib.rs
@@ -126,7 +126,7 @@ pub use graphics::{
 pub use keys::{Chord, Input, Key};
 pub use screen::{
     Cell, Clipboard, Color, CursorShape, Link, Location, MouseMode, MouseModes, Screen, ScreenDiff,
-    ScreenWithStyles, Style,
+    ScreenWithStyles, Style, Unsupported, UnsupportedIter,
 };
 #[cfg(unix)]
 pub use terminal::Signal;

--- a/crates/termlens/src/screen.rs
+++ b/crates/termlens/src/screen.rs
@@ -277,6 +277,125 @@ pub enum CursorShape {
 
 /// What an application copied with `OSC 52`, as observed at one snapshot.
 ///
+/// What the emulator did not implement while producing a [`Screen`] — the
+/// view [`Screen::unsupported`] returns.
+///
+/// Distinct sequence shapes, first seen first, in the form the timeout
+/// messages use (`^[[20h` for `CSI 20 h`), at most 32 retained;
+/// [`overflow`](Self::overflow) counts the distinct shapes beyond those, so
+/// a stream that invents thousands cannot grow a snapshot and "nothing was
+/// dropped" is one check, [`is_empty`](Self::is_empty).
+///
+/// A view rather than a slice, so how the screen stores the list — cheap to
+/// clone, today — is not part of the public API. `Copy`, borrowing the
+/// screen; compares equal to an array or slice of `&str` when the retained
+/// shapes match in order and nothing overflowed, so a pin reads
+/// `assert_eq!(s.unsupported(), ["^[[59m"])`.
+#[derive(Clone, Copy)]
+pub struct Unsupported<'a> {
+    retained: &'a [Arc<str>],
+    overflow: u64,
+}
+
+impl<'a> Unsupported<'a> {
+    /// True when nothing unsupported was seen at all — no retained shape
+    /// and no overflow.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.retained.is_empty() && self.overflow == 0
+    }
+
+    /// Distinct shapes retained (at most 32). Not the total: add
+    /// [`overflow`](Self::overflow) for that.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.retained.len()
+    }
+
+    /// The retained shapes, first seen first.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &'a str> + 'a {
+        self.retained.iter().map(|shape| &**shape)
+    }
+
+    /// Whether `sequence` — in the same form, e.g. `"^[[5m"` — is among the
+    /// retained shapes. A shape past the retention bound is counted in
+    /// [`overflow`](Self::overflow) and cannot be found here.
+    #[must_use]
+    pub fn contains(&self, sequence: &str) -> bool {
+        self.retained.iter().any(|shape| &**shape == sequence)
+    }
+
+    /// Distinct shapes seen beyond the 32 retained, counted only.
+    #[must_use]
+    pub fn overflow(&self) -> u64 {
+        self.overflow
+    }
+}
+
+impl<'a> IntoIterator for Unsupported<'a> {
+    type Item = &'a str;
+    type IntoIter = UnsupportedIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        UnsupportedIter(self.retained.iter())
+    }
+}
+
+/// The iterator over an [`Unsupported`] view's retained shapes.
+#[derive(Debug, Clone)]
+pub struct UnsupportedIter<'a>(std::slice::Iter<'a, Arc<str>>);
+
+impl<'a> Iterator for UnsupportedIter<'a> {
+    type Item = &'a str;
+    fn next(&mut self) -> Option<&'a str> {
+        self.0.next().map(|shape| &**shape)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for UnsupportedIter<'_> {}
+
+impl fmt::Debug for Unsupported<'_> {
+    /// `["^[[59m"]`, or `["^[[20h", …] (+8 more)` when shapes overflowed.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()?;
+        if self.overflow > 0 {
+            write!(f, " (+{} more)", self.overflow)?;
+        }
+        Ok(())
+    }
+}
+
+impl PartialEq for Unsupported<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.overflow == other.overflow && self.iter().eq(other.iter())
+    }
+}
+
+impl Eq for Unsupported<'_> {}
+
+/// Equal to a slice of shapes when the retained shapes match in order and
+/// nothing overflowed — so `assert_eq!(s.unsupported(), ["^[[59m"])` pins
+/// the whole record, and an empty array pins "nothing unsupported".
+impl PartialEq<[&str]> for Unsupported<'_> {
+    fn eq(&self, other: &[&str]) -> bool {
+        self.overflow == 0 && self.iter().eq(other.iter().copied())
+    }
+}
+
+impl<const N: usize> PartialEq<[&str; N]> for Unsupported<'_> {
+    fn eq(&self, other: &[&str; N]) -> bool {
+        *self == other[..]
+    }
+}
+
+impl PartialEq<&[&str]> for Unsupported<'_> {
+    fn eq(&self, other: &&[&str]) -> bool {
+        *self == **other
+    }
+}
+
 /// Read it from a snapshot via [`Screen::clipboard`]. A toast on screen
 /// proves the copy path ran; this proves the payload, which is usually the
 /// behaviour actually under test.
@@ -1007,32 +1126,45 @@ impl Screen {
     }
 
     /// Escape sequences the emulator did not implement, so the grid below
-    /// them is not what a terminal would show. Distinct shapes, first seen
-    /// first, in the form the timeout messages use (`^[[20h` for
-    /// `CSI 20 h`), at most 32 — [`unsupported_overflow`](Self::unsupported_overflow)
-    /// counts the rest.
+    /// them is not what a terminal would show — as an [`Unsupported`] view:
+    /// distinct shapes, first seen first, in the form the timeout messages
+    /// use (`^[[20h` for `CSI 20 h`), at most 32 retained, with
+    /// [`overflow`](Unsupported::overflow) counting the rest.
     ///
     /// Empty for an application that uses only what the emulator renders,
     /// which is what makes it worth asserting: the failure this catches is
     /// the one where a test passes against a plausible-looking wrong screen
     /// because the sequence that would have made it right was dropped.
     /// Sequences termlens handles itself — the character sets, tab stops,
-    /// insert mode, the queries it answers or names, the modes it tracks —
-    /// are not listed, since the screen does show their effect. A request to
-    /// resize the window (`CSI 8 ; rows ; cols t`) *is* listed: the grid's
-    /// size is the test's to set, so the request is recorded rather than
-    /// honoured.
+    /// insert mode, the queries it answers or names, the modes it tracks,
+    /// the SGR attributes the shadow parser recovers — are not listed,
+    /// since the screen does show their effect. A request to resize the
+    /// window (`CSI 8 ; rows ; cols t`) *is* listed: the grid's size is the
+    /// test's to set, so the request is recorded rather than honoured.
+    ///
+    /// ```no_run
+    /// # fn main() -> termlens::Result<()> {
+    /// # let mut t = termlens::Terminal::builder()
+    /// #     .args(["-c", "printf '\\033[20htext'; read q"]).spawn("sh")?;
+    /// # t.wait_until(|s| s.contains("text"))?;
+    /// let s = t.screen();
+    /// assert_eq!(s.unsupported(), ["^[[20h"]);
+    /// assert!(s.unsupported().contains("^[[20h"));
+    /// assert_eq!(s.unsupported().overflow(), 0);
+    /// # t.send(termlens::Key::Enter); t.wait_exit()?; Ok(())
+    /// # }
+    /// ```
+    ///
+    /// (`no_run` because the doctest suite also runs on Windows, where
+    /// ConPTY drops the sequence before termlens sees it and the record is
+    /// the console's — the behaviour is pinned in `tests/unsupported.rs`,
+    /// which is `ignore`d there with that reason.)
     #[must_use]
-    pub fn unsupported(&self) -> &[Arc<str>] {
-        &self.state.unsupported
-    }
-
-    /// Distinct unsupported sequences beyond the 32 that
-    /// [`unsupported`](Self::unsupported) keeps, counted so a stream that
-    /// emits thousands cannot grow a snapshot.
-    #[must_use]
-    pub fn unsupported_overflow(&self) -> u64 {
-        self.state.unsupported_overflow
+    pub fn unsupported(&self) -> Unsupported<'_> {
+        Unsupported {
+            retained: &self.state.unsupported,
+            overflow: self.state.unsupported_overflow,
+        }
     }
 
     /// Visual bells (`ESC g`) the application requested — a flash rather

--- a/crates/termlens/tests/unsupported.rs
+++ b/crates/termlens/tests/unsupported.rs
@@ -17,11 +17,7 @@ fn emit(steps: &[&str]) -> termlens::Result<Terminal> {
 }
 
 fn shapes(t: &Terminal) -> Vec<String> {
-    t.screen()
-        .unsupported()
-        .iter()
-        .map(|s| s.to_string())
-        .collect()
+    t.screen().unsupported().iter().map(str::to_owned).collect()
 }
 
 /// A sequence nobody honours is named, in the form the timeout messages
@@ -37,7 +33,20 @@ fn an_unimplemented_sequence_is_listed_once() -> termlens::Result<()> {
     ])?;
     t.wait_until(|s| s.contains("text"))?;
     assert_eq!(shapes(&t), ["^[[20h", "^[D"]);
-    assert_eq!(t.screen().unsupported_overflow(), 0);
+    // The view pins the whole record in one comparison (#330): the shapes
+    // in order, and that nothing overflowed.
+    let s = t.screen();
+    assert_eq!(s.unsupported(), ["^[[20h", "^[D"]);
+    assert_eq!(s.unsupported().overflow(), 0);
+    assert_eq!(s.unsupported().len(), 2);
+    assert!(!s.unsupported().is_empty());
+    assert!(s.unsupported().contains("^[D"));
+    assert!(!s.unsupported().contains("^[[20l"));
+    assert_eq!(format!("{:?}", s.unsupported()), r#"["^[[20h", "^[D"]"#);
+    assert_eq!(
+        s.unsupported().into_iter().collect::<Vec<_>>(),
+        ["^[[20h", "^[D"]
+    );
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
@@ -61,6 +70,10 @@ fn an_application_using_only_what_is_implemented_reports_nothing() -> termlens::
     ])?;
     t.wait_until(|s| s.contains("DONE"))?;
     assert_eq!(shapes(&t), Vec::<String>::new(), "{}", t.screen());
+    // The one-line pin for "nothing unsupported": an empty array compares
+    // equal only when nothing was retained and nothing overflowed.
+    assert_eq!(t.screen().unsupported(), [], "{}", t.screen());
+    assert!(t.screen().unsupported().is_empty());
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())
@@ -101,9 +114,21 @@ fn the_record_is_bounded() -> termlens::Result<()> {
     let mut t = emit(&["--raw", &stream, "DONE", "--wait"])?;
     t.wait_until(|s| s.contains("DONE"))?;
     let s = t.screen();
-    assert_eq!(s.unsupported().len(), 32, "{s}");
-    assert_eq!(s.unsupported_overflow(), 8, "{s}");
-    assert_eq!(&*s.unsupported()[0], "^[[20h");
+    let unsupported = s.unsupported();
+    assert_eq!(unsupported.len(), 32, "{s}");
+    assert_eq!(unsupported.overflow(), 8, "{s}");
+    assert_eq!(unsupported.iter().next(), Some("^[[20h"));
+    // Overflow is part of the record: a view that dropped shapes is not
+    // empty and does not equal the list of what it kept.
+    assert!(!unsupported.is_empty());
+    let kept: Vec<&str> = unsupported.iter().collect();
+    assert_ne!(unsupported, kept.as_slice(), "8 shapes were dropped");
+    let debug = format!("{unsupported:?}");
+    assert!(debug.ends_with("] (+8 more)"), "{debug}");
+    assert!(
+        !unsupported.contains("^[[59h"),
+        "a shape past the bound is counted, not findable"
+    );
     t.send(Key::Enter)?;
     assert!(t.wait_exit()?.success());
     Ok(())


### PR DESCRIPTION
Closes #330

The one breaking change of the 0.11 stability candidate, and the last before 1.0. Lands alone, under the `breaking` label, so the gate's exception path is exercised once and visibly.

**What changes.** `Screen::unsupported()` returns `Unsupported<'_>` — a `Copy` view borrowing the screen: `is_empty()`, `len()`, `iter()`, `contains(&str)`, `overflow()`, `IntoIterator` (`UnsupportedIter`), `Debug` (`["^[[59m"]`, or `["^[[20h", …] (+8 more)`), and `PartialEq` against `[&str; N]`, `[&str]` and `&[&str]` that holds only when the retained shapes match in order **and** nothing overflowed. `Screen::unsupported_overflow()` is removed. `Arc` appears nowhere in the public signature. The storage is unchanged.

**Migration** (every in-tree and known consumer site is one of these rows — the table is in the CHANGELOG entry, which begins with the `**Breaking:**` marker the gate reads):

| 0.10 | 0.11 |
| --- | --- |
| `s.unsupported().is_empty()` | unchanged (and now also false when shapes overflowed) |
| `s.unsupported().iter().map(\|q\| &**q)` | `s.unsupported().iter()` |
| `s.unsupported().iter().any(\|q\| &**q == "^[[5m")` | `s.unsupported().contains("^[[5m")` |
| `&*s.unsupported()[0]` | `s.unsupported().iter().next()` |
| `s.unsupported_overflow()` | `s.unsupported().overflow()` |
| `assert!(s.unsupported().is_empty()); assert_eq!(s.unsupported_overflow(), 0);` | `assert_eq!(s.unsupported(), []);` |

**The forced diagnostics**, `.github/scripts/check-semver.sh 0.10.3` run on this tree *without* the label — release type `patch`, all three views identical:

```
    Checking termlens v0.10.3 -> v0.10.3 (assume patch change)
     Checked [   0.006s] 223 checks: 222 pass, 1 fail, 0 warn, 31 skip
--- failure inherent_method_missing: pub method removed or renamed ---
Failed in:
  Screen::unsupported_overflow, previously in file …/termlens-0.10.3/src/screen.rs:961
     Summary semver requires new major version: 1 major and 0 minor checks failed
```

Worth knowing about the gate, and recorded in the CHANGELOG entry: the changed return type of `unsupported()` itself is **not** a lint cargo-semver-checks 0.50.0 has — it reported only the removed method beside it. The gate catches a removed or gated item, not a re-typed one; the in-tree tests and every consumer's compile do. STABILITY.md (next PR) says so under "not checked".

With the label (or the CHANGELOG marker, which is what keeps `main` green after this merges): release type `major`, PASS in all three views — measured locally both ways.

**Tests.** `tests/unsupported.rs` migrated to the view and extended: the array comparison pins shapes *and* zero overflow; the bounded record (32 kept, 8 overflowed) is not empty, is not equal to the list of what it kept, prints `(+8 more)`, and does not `contains` a shape past the bound; `IntoIterator`; the empty-array pin for "nothing unsupported". A doctest on `unsupported()` runs a real PTY.

**Verified locally:** fmt, clippy (all features and minimal, `-D warnings`), rustdoc, `cargo test --workspace --all-features`, `cargo test -p termlens --no-default-features`, skill snippets, MSRV 1.85 over all features.

**Not done here:** the STABILITY/RELEASING/SKILL wording for the candidate (#328/#334, next PR); the six consumer migrations, which happen against crates.io after 0.11.0 is published, never against a path.
