### PR TITLE
docs: the stability candidate's contract and process

### DIFF
--- a/.github/scripts/check-candidate-statement.sh
+++ b/.github/scripts/check-candidate-statement.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# The stability-candidate statement is made in three places — README.md,
+# the CHANGELOG header and docs/STABILITY.md — and #328/#334 ask that they
+# say the same thing in the same words. Three hand-maintained copies of one
+# promise drift; this makes the promise checked rather than maintained.
+# The canonical text is the paragraph in docs/STABILITY.md that opens with
+# the bold "0.11.0 is the stability candidate" and ends at the blank line.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+statement="$(awk '
+  /^\*\*0\.11\.0 is the stability candidate\*\*/ { on = 1 }
+  on && /^$/ { exit }
+  on { print }
+' docs/STABILITY.md)"
+
+if [ -z "$statement" ]; then
+  echo "::error::docs/STABILITY.md has no stability-candidate statement"
+  exit 1
+fi
+
+status=0
+for doc in README.md CHANGELOG.md; do
+  if python3 - "$doc" "$statement" <<'PY'
+import sys
+doc, statement = sys.argv[1], sys.argv[2]
+sys.exit(0 if statement in open(doc, encoding="utf-8").read() else 1)
+PY
+  then
+    echo "candidate statement: $doc carries it verbatim ($(printf '%s\n' "$statement" | wc -l | tr -d ' ') lines)"
+  else
+    echo "::error::$doc does not carry the stability-candidate statement in the same words as docs/STABILITY.md:"
+    printf '%s\n' "$statement" | sed 's/^/  /'
+    status=1
+  fi
+done
+exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,10 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo doc --no-deps
       - run: cargo doc --no-deps --all-features
+      # The stability-candidate statement is made in README.md, the CHANGELOG
+      # header and docs/STABILITY.md, in the same words (#328, #334). Three
+      # copies of one promise drift; this is the check that stops it.
+      - run: .github/scripts/check-candidate-statement.sh
 
   deny:
     name: deny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-Until 1.0, minor versions (0.x) may contain breaking changes; they are always
-listed under a **Changed** or **Removed** heading, in a bullet that begins
-**Breaking:** — the semver gate in CI reads that marker.
+**0.11.0 is the stability candidate**: from that release no promised item
+changes incompatibly before 1.0. A change that must break one ships as a
+new candidate (0.12.0) with a migration table and restarts the observation
+window in [#335](https://github.com/vyncint/termlens/issues/335); a patch
+release does not. 1.0 follows the readiness criteria in that issue, not a
+date.
+
+A breaking change is always listed under a **Changed** or **Removed**
+heading, in a bullet that begins **Breaking:** — the semver gate in CI
+reads that marker.
 
 ## [Unreleased]
 
@@ -46,6 +53,36 @@ listed under a **Changed** or **Removed** heading, in a bullet that begins
   `cargo-semver-checks` 0.50.0 has, which is worth knowing about the gate:
   it catches a removed or gated item, not a re-typed one; the in-tree tests
   and every consumer's compile do.
+
+- **`docs/STABILITY.md` now states the contract the candidate freezes
+  under** (#328), and every sentence of it names the job or test that
+  checks it or says that nothing does. Promised: the documented public API
+  of every termlens-owned item in every supported feature configuration
+  (`semver` and `features` jobs), the snapshot text format and the
+  versioned JSON (the compatibility corpus), the CLI's commands, flags,
+  exit codes and input formats (`check-cli-contract.sh` against the tree
+  and the published binary), the coordinate conventions, the platform list
+  and the MSRV policy. Named as third-party boundaries, and nothing else
+  delegated: the `insta` re-export and macro, the `regex::Regex` parameter
+  type, the serde traits. Not promised: diagnostic prose, internal
+  representation, the *timing* of the settle heuristics, the budgets'
+  defaults, the renderers' exact bytes. The former "versioned with the
+  feature's dependency" clause — which exempted termlens-owned items such
+  as `Bitmap`, `find_match` and the JSON shape from termlens's own
+  versioning — is gone. The README and this header carry the candidate
+  statement in the same words, and
+  `.github/scripts/check-candidate-statement.sh` fails when one drifts.
+
+- **The release and contribution process for the candidate is written
+  down** (#334). `docs/RELEASING.md`: what may break and how a break is
+  declared (the `breaking` label, the pasted diagnostics, the
+  `- **Breaking:**` bullet), release candidates as `v1.0.0-rc.N`
+  pre-releases, the stress workflow on the exact commit to be tagged, the
+  corpus directory frozen at each release, and the semver baseline moved
+  after publish. `CONTRIBUTING.md` §1 lists every new gate and §7 says the
+  API is frozen. The skill describes 0.11: the stability statement, the
+  `Unsupported` view, `cursor_visible()`, the new accessors, and that
+  `inspect`'s stdout is a saved screen.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ cargo build -p termlens-cli                              # then the CLI's docume
 .github/scripts/check-cli-contract.sh target/debug/termlens
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps
 RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features
+.github/scripts/check-candidate-statement.sh              # README, CHANGELOG and STABILITY state the candidate in the same words
 cargo deny check                          # cargo install cargo-deny
 pipx run zizmor==1.29.0 --persona=pedantic .github/workflows/   # workflow audit; needs GH_TOKEN for the online checks
 cargo +1.85 check --workspace --exclude ratatui-app --locked --all-targets    # the MSRV: `rust-version` in Cargo.toml (the ratatui fixture needs 1.88)
@@ -221,6 +222,15 @@ allowlist is a list on purpose, so that widening it is a visible decision.
 - Review: expect actionable review within a few days. Small, focused PRs get
   reviewed faster. Update `CHANGELOG.md` under `[Unreleased]` for any
   user-facing change.
+- **The public API is frozen.** 0.11.0 is the stability candidate
+  ([docs/STABILITY.md](docs/STABILITY.md)): the `semver` job checks every
+  PR against the last published release with the release type forced to
+  `patch`, so removing, renaming, re-typing or feature-gating a promised
+  item fails CI. If a change genuinely must break one, say so in the PR and
+  a maintainer decides whether it becomes a new candidate — the `breaking`
+  label, the pasted diagnostics and the `- **Breaking:**` CHANGELOG bullet
+  are described in [docs/RELEASING.md](docs/RELEASING.md). Additive
+  changes need none of that.
 
 ## 8. Release process
 

--- a/README.md
+++ b/README.md
@@ -279,12 +279,20 @@ reason. The measurement is `tests/conpty_probe.rs`; the decision is
 
 ## Stability and versioning
 
-termlens is `0.x`. [docs/STABILITY.md](https://github.com/vyncint/termlens/blob/main/docs/STABILITY.md) states what 1.0
-means — three decisions written down with the measurement behind each —
-and which public items the compatibility promise covers. **0.11 is the
-stability candidate**: from that release no promised item changes
-incompatibly before 1.0, and 1.0 follows the readiness criteria tracked in
-[#335](https://github.com/vyncint/termlens/issues/335), not a date.
+**0.11.0 is the stability candidate**: from that release no promised item
+changes incompatibly before 1.0. A change that must break one ships as a
+new candidate (0.12.0) with a migration table and restarts the observation
+window in [#335](https://github.com/vyncint/termlens/issues/335); a patch
+release does not. 1.0 follows the readiness criteria in that issue, not a
+date.
+
+[docs/STABILITY.md](https://github.com/vyncint/termlens/blob/main/docs/STABILITY.md)
+states what is promised — the documented public API in every supported
+feature configuration, the snapshot text format, the versioned JSON, the
+CLI's commands, flags, exit codes and input formats — which job or test
+checks each part, what follows a dependency's versioning instead, and what
+is deliberately not promised; and the three decisions, with their
+measurements, that 1.0 rests on.
 
 **MSRV is Rust 1.85**, set by the default `insta` feature's dependency tree
 and checked in CI against the committed lockfile; a bump is a minor

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,19 +19,55 @@ One page, copy-pasteable. Maintainers only.
   minted from a branch. (Optionally set the environment name `release`
   on the crates.io side too, for the server-side binding.)
 
+## The stability candidate, and what may break
+
+0.11.0 is the **stability candidate** ([STABILITY.md](STABILITY.md), "What
+the promise covers"). From it, no promised item changes incompatibly
+before 1.0. What that means for a release:
+
+- **A patch or minor release breaks nothing.** The `semver` job holds it:
+  every pull request is checked against the last published release with
+  the release type forced to `patch`, in three feature views. A red
+  `semver` on a PR is the answer, not an obstacle.
+- **A necessary break is a new candidate** — `0.12.0`, never a patch — and
+  restarts the observation window in
+  [#335](https://github.com/vyncint/termlens/issues/335). Its pull request
+  carries the **`breaking` label** (a maintainer applies it; the gate then
+  runs with `--release-type major`), its description pastes the
+  diagnostics the *forced* run produced (run
+  `.github/scripts/check-semver.sh <baseline>` without the label to get
+  them), and its CHANGELOG entry is a bullet beginning **`- **Breaking:**`**
+  under **Changed** or **Removed** whose text matches those diagnostics and
+  carries a migration table. The marker is what keeps `main` green after
+  the merge, where no label exists, and what lets the release tag pass the
+  same gate — so a break without the marker is a break the gate refuses,
+  on the PR and again on the tag.
+- **Release candidates for 1.0** are tagged `v1.0.0-rc.N` and publish to
+  crates.io as pre-releases; a consumer opts in with an exact requirement
+  (`termlens = "=1.0.0-rc.1"`), and Cargo never resolves a pre-release
+  from `"0.11"` or `"1"`. The `v1.0.0` tag follows the readiness criteria
+  in #335 — an external pilot, eight weeks of stable use from its first
+  green run, every maintained consumer on the candidate, the daily
+  fresh-install evidence — and **a date is never one of them**.
+
 ## Before a 1.0 tag
 
 `v1.0.0` requires all three sections of [STABILITY.md](STABILITY.md) —
 Windows, backend, styled history — to be filled in with their decision
-and the measurement behind it, and the "What the promise covers" list to
-match `lib.rs`. A 1.0 with an open section is a 0.x with a bigger number.
+and the measurement behind it, the "What the promise covers" section to
+match `lib.rs`, and every criterion in #335 to be recorded as met, with
+its evidence. A 1.0 with an open section is a 0.x with a bigger number.
 
 ## Cutting vX.Y.Z
 
 ```sh
-# 0. Green main + no flakes: run the stress workflow and wait for it.
+# 0. Green main + no flakes: run the stress workflow on the exact commit
+#    that will be tagged — not an older main — and wait for it. All three
+#    OSes, all five shards, must pass. A release PR that lands after the
+#    stress run is a different tree; run it again on the merged commit
+#    before tagging.
 gh workflow run stress.yml --ref main
-gh run watch                                  # both OSes must pass
+gh run watch                                  # ubuntu, macos, windows × 5 shards
 
 # 1. Bump the version (workspace.package.version in root Cargo.toml), and
 #    the same number in crates/termlens-cli/Cargo.toml's `termlens = { version
@@ -39,9 +75,16 @@ gh run watch                                  # both OSes must pass
 $EDITOR Cargo.toml crates/termlens-cli/Cargo.toml
 cargo check --workspace                       # refreshes Cargo.lock
 
-# 2. Move the CHANGELOG section.
+# 2. Move the CHANGELOG section. A `- **Breaking:**` bullet moves with it,
+#    which is what lets the tag's semver run pass (see above).
 $EDITOR CHANGELOG.md                          # [Unreleased] -> [X.Y.Z] - YYYY-MM-DD
                                               # add a fresh empty [Unreleased] above
+
+# 2b. Freeze this release's saved-screen shapes into the compatibility
+#     corpus (crates/termlens/tests/compat/README.md), from this tree:
+TERMLENS_WRITE_CORPUS=X.Y.Z cargo test -p termlens --features serde \
+    --test compat write_corpus -- --ignored
+cargo test -p termlens --all-features --test compat   # the new directory passes
 
 # 3. Land it.
 git checkout -b chore/release-vX.Y.Z

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -1,11 +1,14 @@
 # What 1.0 means
 
-termlens is `0.x`, and every minor is allowed to break a consumer. 1.0 is
-not a feature list — it is **three decisions written down with the
-measurement that decided each**, plus a statement of which public items
-the promise covers. A 1.0 tag requires all three sections below to be
-filled in ([RELEASING.md](RELEASING.md) says so), and each was allowed to
-come out *no*: an honest no is a 1.0 that means something.
+termlens is `0.x`. Until 0.11 every minor was allowed to break a consumer;
+**from 0.11.0, the stability candidate, no promised item changes
+incompatibly before 1.0** — the promise is the last section of this page.
+1.0 is not a feature list — it is **three decisions written down with the
+measurement that decided each**, plus that statement of which public items
+the promise covers and what checks each part of it. A 1.0 tag requires all
+three sections below to be filled in ([RELEASING.md](RELEASING.md) says
+so), and each was allowed to come out *no*: an honest no is a 1.0 that
+means something.
 
 Decided in 0.10 (September 2026). The issue each was decided in links
 back here.
@@ -98,28 +101,110 @@ because the one assertion that needs it can ask.
 
 ## What the promise covers
 
-Once the three sections above stand, 1.0 promises semver over:
+**0.11.0 is the stability candidate**: from that release no promised item
+changes incompatibly before 1.0. A change that must break one ships as a
+new candidate (0.12.0) with a migration table and restarts the observation
+window in [#335](https://github.com/vyncint/termlens/issues/335); a patch
+release does not. 1.0 follows the readiness criteria in that issue, not a
+date.
 
-- every `pub` item exported from `lib.rs` without a feature gate: the
-  `Terminal`/`TerminalBuilder` surface, `Screen` and its accessors,
-  `Cell`, `Style`, `Color`, the mode enums, `Error` (`#[non_exhaustive]`,
-  so variants may be *added*), `bin!`;
-- the snapshot text format of [DESIGN.md](DESIGN.md) §3, which
-  `Screen::parse` reads back — a snapshot file recorded under 1.0 stays
-  valid;
-- the coordinate conventions: `(row, col)` for cells, `(cols, rows)` for
-  geometry.
+The criteria are an external pilot, eight weeks of stable use counted from
+its first green run, every maintained consumer on the candidate from
+crates.io, and the daily fresh-install evidence. The README and the
+CHANGELOG header carry the statement above in the same words, and
+`.github/scripts/check-candidate-statement.sh` fails when one drifts.
 
-Behind features, versioned with the feature's dependency rather than with
-termlens: `insta` (the macro follows insta), `decode`, `regex`, `serde`
-(the JSON shape follows the types' derives).
+Additive change is not a break: a new item, a new variant of a
+`#[non_exhaustive]` enum such as `Error`, a new field of a
+`#[non_exhaustive]` struct such as `Style`, a new CLI flag, a new key in
+the JSON `state` object.
 
-Documented as heuristics, promised to keep their *shape* and not their
-timing: `wait_idle` and `wait_stable` (a quiet window is a judgement),
-`snapshot_after`'s 100 ms settle, and the frame-history and record
-budgets, whose defaults may move.
+Every sentence below names the job or test that checks it, or says that
+nothing does. The jobs are in `.github/workflows/ci.yml`; a sentence with
+no check is a promise kept by review alone, and the list of those is meant
+to be short.
 
-Not covered: the `Emulator` trait and everything under `emu/` (internal),
-the exact text of error messages (they carry screens; the prefixes in the
-skill's failure table are kept stable, the rest is prose), the fixtures,
-and `termlens-cli`'s output format beyond its exit codes.
+### Promised
+
+- **The documented public Rust API of every item termlens owns, in every
+  supported feature configuration** — `default` (`insta`),
+  `--no-default-features`, each single feature (`decode`, `regex`, `serde`)
+  and all features together. Semver over all of it: an item is not removed,
+  renamed, re-typed or moved behind a feature in any of those
+  configurations without a new candidate. *Checked by* the `semver` job
+  (`.github/scripts/check-semver.sh`: cargo-semver-checks against the last
+  published release, release type forced to `patch`, in the default,
+  explicit-only and all-features views; `tools/semver-gate-selftest/` proves
+  the gate fails on a removed and on a gated item) and by the `features`
+  job, which builds and tests each reduced configuration for the library
+  alone (`.github/scripts/check-feature-isolation.sh`). *Not checked, and
+  said so:* a method whose signature changes under the same name — the
+  0.11 change to `unsupported()` was exactly that, and cargo-semver-checks
+  0.50.0 reported only the removed `unsupported_overflow()` beside it. That
+  class is caught by the crate's own tests and every consumer's compile,
+  and by review.
+- **The snapshot text format** of [DESIGN.md](DESIGN.md) §3, which
+  `Screen::parse` reads back: the header, the grid, the `styles:` block and
+  its tokens. A file written by any release from 0.10.1 on parses in every
+  later release and renders back byte for byte. *Checked by*
+  `crates/termlens/tests/compat.rs` over the frozen corpus in
+  `tests/compat/<version>/` — the definition of "the format stays valid" —
+  and by `crates/termlens-cli/tests/cli.rs`, which renders every corpus
+  file through the CLI.
+- **The JSON shape** (`serde` feature), format `1`, specified in DESIGN §3.
+  JSON written by 0.10 or later is readable by every later release; a new
+  format number is a new candidate, never a silent change. *Checked by* the
+  same corpus test (every JSON twin reads as the same picture as its text
+  and re-serialises to its own document) and by `tests/export.rs`.
+- **The CLI's contract**: the commands `inspect`, `diff` and `render`, their
+  accepted flags, the exit-code meanings (0 ran, 1 `diff` found a
+  difference, 2 the tool could not run) and the saved-screen input formats
+  — the text format with or without an insta header or a pre-0.11 `inspect`
+  trailer, and the JSON. Flags may be added; `inspect`'s stdout is a saved
+  screen. *Checked by* `.github/scripts/check-cli-contract.sh` against the
+  tree on every pull request (`test` job) and against the **published**
+  binary on every release and every day (`install.yml`, `cli` job).
+- **The coordinate conventions**: `(row, col)` for cells, `(cols, rows)` for
+  geometry, both zero-based. *Checked by* the crate's own suite; there is no
+  separate gate, since every accessor test encodes them.
+- **The platform list** of §1: Linux and macOS in full, Windows for what
+  survives ConPTY's re-render, each exclusion named in
+  [LIMITATIONS.md](LIMITATIONS.md). *Checked by* the `test` matrix and the
+  required `windows` leg on every pull request, and `stress.yml` on all
+  three before a release.
+- **The MSRV policy**: `rust-version` in `Cargo.toml` is real for every
+  supported feature configuration, and a bump is a minor release. *Checked
+  by* the `msrv` job, which compiles the workspace, `-p termlens
+  --all-features` and `-p termlens --no-default-features` at that toolchain
+  against the committed lockfile.
+
+### Third-party boundaries, named as such
+
+Three things follow a dependency's versioning rather than termlens's, and
+nothing else is delegated:
+
+- the `termlens::insta` re-export and what `assert_screen_snapshot!`
+  expands to follow **`insta`**'s versioning;
+- the `regex::Regex` parameter type of `matches`, `find_match`,
+  `find_all_matches`, `mask_matches` and `wait_until_matches` follows
+  **`regex`**'s major version;
+- the `Serialize`/`Deserialize` impls follow **`serde`** 1.x. The JSON
+  *shape* does not: it is termlens's, format-numbered above.
+
+### Not promised
+
+- Human-readable prose: timeout and error messages (the prefixes in the
+  skill's failure table are kept, the rest is prose), `inspect`'s trailer,
+  the painting of `termlens diff` on a terminal, `Debug` output.
+- Internal representation: the `Emulator` trait and everything under
+  `emu/`, the storage behind any accessor (which is why `unsupported()`
+  returns a view), the fixtures.
+- The *timing* of the heuristics: `wait_idle`, `wait_stable` and
+  `snapshot_after`'s settle are judgements about a quiet window; their
+  shape is promised, their thresholds are not. The frame-history and
+  record budgets keep their shape and their defaults may move.
+- The SVG, HTML and ANSI renderings' exact bytes: what they show is what
+  the screen shows, and the markup may change.
+
+*Nothing checks these, by construction — they are the room the crate keeps
+for itself.*

--- a/skills/termlens/SKILL.md
+++ b/skills/termlens/SKILL.md
@@ -5,10 +5,12 @@ description: Write, fix or review headless terminal tests for a Rust CLI or TUI 
 
 # Testing terminal programs with termlens
 
-Written against **termlens 0.10.1**. Every `rust` block below is a complete
-integration test that is compiled against the crate in CI, so the API it
-shows is the API that exists. The recipes spawn a binary called `myapp`
-that draws a list with a `> ` highlight, a status line ending in
+Written against **termlens 0.11.0**, the stability candidate: from 0.11.0
+no promised public item changes incompatibly before 1.0, so the API below
+is one to build on, not one to expect to move. Every `rust` block below is
+a complete integration test that is compiled against the crate in CI, so
+the API it shows is the API that exists. The recipes spawn a binary called
+`myapp` that draws a list with a `> ` highlight, a status line ending in
 `Ready: j/k move, q quits`, and prints usage on `--help`; substitute your
 application's own texts where the comments say so.
 
@@ -21,6 +23,13 @@ Playwright for the terminal. Linux and macOS in full; on Windows (ConPTY)
 screen assertions work and frame assertions do not — `wait_frame`,
 `record`, graphics and mouse modes are Unix-only there, and a test that
 needs one is `#[cfg_attr(windows, ignore = "…")]` with the reason.
+
+**The API is stable.** 0.11.0 is the stability candidate: the documented
+public API in every feature configuration, the snapshot text format, the
+JSON shape and the CLI's contract do not change incompatibly before 1.0
+(the crate's `docs/STABILITY.md` says exactly what is promised and what
+checks it). Write against it as you would against a 1.x crate; do not
+pin a patch version or hedge for the next minor.
 
 Use it for the things an in-process mock cannot see:
 
@@ -96,7 +105,8 @@ your test ── send(Key) · click · paste · resize ──▶ PTY     └─�
 
 6. **Two coordinate orders exist; do not mix them.** Everything that
    addresses a cell is **row-first**: `find` → `(row, col)`, `cell(row,
-   col)`, `row_text(row)`, `cursor()` → `(row, col, visible)`. Everything
+   col)`, `row_text(row)`, `cursor()` → `(row, col, visible)` (and
+   `cursor_visible()` for the flag alone). Everything
    that speaks of terminal geometry or a pointer is **column-first**:
    `size()` → `(cols, rows)`, `resize(cols, rows)`, `click(col, row)`,
    `scroll(col, row, …)`, `drag(button, from_col, from_row, to_col,
@@ -154,7 +164,7 @@ your test ── send(Key) · click · paste · resize ──▶ PTY     └─�
 
 ```toml
 [dev-dependencies]
-termlens = "0.10"
+termlens = "0.11"
 insta = "1"          # for the snapshot recipes; termlens also re-exports it as `termlens::insta`
 ```
 
@@ -326,8 +336,7 @@ fn cells_styles_and_wide_characters() -> termlens::Result<()> {
     // Regions and the cursor. rect_text is (cols, rows), like size().
     let list_pane = s.rect_text(0..20, 0..6);
     assert!(list_pane.contains("Gamma"), "{list_pane}");
-    let (_, _, visible) = s.cursor();
-    assert!(!visible, "a list view hides the cursor: {s}");
+    assert!(!s.cursor_visible(), "a list view hides the cursor: {s}");
 
     t.send(termlens::Key::Char('q'))?;
     assert!(t.wait_exit()?.success());
@@ -458,13 +467,14 @@ from_r, to_c, to_r)`, `scroll(col, row, Scroll::Down)`, `resize(cols, rows)`,
 | `full_text()` / `scrollback_text()` / `scrollback_rows()` | history + screen / history / count |
 | `scrollback_cell(row, col)` / `styled_scrollback()` | history as cells, with `scrollback_styles(true)` |
 | `size()` / `cols()` / `rows()` | `(cols, rows)` |
-| `cursor()` | `(row, col, visible)`; `cursor_shape()`, `cursor_blink()` |
+| `cursor()` / `cursor_visible()` | `(row, col, visible)` / the flag alone; `cursor_shape()`, `cursor_blink()` |
 | `alternate_screen()`, `bracketed_paste()`, `application_cursor()`, `focus_events()` | mode flags |
 | `mouse_mode()` / `mouse_modes()` | reporting protocol / the set the app enabled |
 | `title()`, `clipboard()`, `links()`, `bells()`, `repaints()`, `graphics()` | out-of-band state |
-| `unsupported()` / `insert_mode()` | sequences the emulator did not implement (`^[[20h`…), so a plausible grid can be told from a right one / IRM left on |
-| `with_styles()` | `Display` with a `styles:` block; snapshot this to catch colour regressions |
-| `diff(&other)` | `ScreenDiff`: `is_empty()`, `cells()`, and a `Display` of only the rows that changed |
+| `unsupported()` / `insert_mode()` | an `Unsupported` view of the sequences the emulator did not implement (`^[[20h`…) — `is_empty()`, `contains("^[[5m")`, `iter()`, `overflow()`, and `assert_eq!(s.unsupported(), ["^[[59m"])` pins it — so a plausible grid can be told from a right one / IRM left on |
+| `with_styles()` | `ScreenWithStyles`, a `Display` with a `styles:` block; snapshot this to catch colour regressions |
+| `diff(&other)` | `ScreenDiff`: `is_empty()`, `cells()`, `changed_rows()`, `style_changes()`, and a `Display` of only the rows that changed |
+| `locate(needle)` | `Option<Location>`: `is_on_screen()`, `is_in_history()`, `col()` |
 | `mask_rect(cols, rows)` / `mask_matching(literal, fill)` / `mask_cells(pred)` | a new `Screen` with those cells replaced, styles and columns intact. `mask_matching` is a literal (rows included — it spans a wrap the way `find_all` does); `mask_cells` blanks by predicate |
 | `to_ansi()` / `to_svg()` / `to_html()` | renderings a person can see; `Screen::parse(text)` reads the text format back |
 
@@ -532,9 +542,11 @@ directory (see §9b).
   colour), `termlens diff old.snap new.snap.new` prints the cell diff of two
   saved screens and exits 1 if anything changed, `termlens render --svg
   failing.snap` makes an image. A saved screen is any text termlens prints
-  — an insta `.snap`, the grid a wait error leaves in a log.
+  — what `inspect` writes to stdout (`termlens inspect myapp > before.txt`;
+  its trailer goes to stderr), an insta `.snap`, the grid a wait error
+  leaves in a log — or the JSON the `serde` feature writes.
 - In CI, set `TERMLENS_ARTIFACT_DIR: ${{ runner.temp }}/termlens` on the
-  test step and add `uses: vyncint/termlens/.github/actions/report@v0.10.0`
+  test step and add `uses: vyncint/termlens/.github/actions/report@v0.10.1`
   with `if: failure()` after it: every screen a failing wait embedded, and
   every `.snap.new` with its diff, lands in the pull request's step summary.
 


### PR DESCRIPTION
Closes #328
Closes #334

Stacked on #346 (the `Unsupported` view), which it documents; GitHub retargets this to `main` when that merges.

**#328 — the contract.** `docs/STABILITY.md`'s "What the promise covers" is rewritten as what 0.11 freezes under. Every sentence names the job or test that checks it, or says that nothing does:

- *Promised:* the documented public API of every termlens-owned item in every supported feature configuration (`semver` + `features` jobs); the snapshot text format and the versioned JSON (the compatibility corpus, `tests/compat.rs`, the CLI corpus test); the CLI's commands, flags, exit codes and saved-screen input formats (`check-cli-contract.sh`, tree and published binary); the coordinate conventions; the platform list; the MSRV policy (`msrv` job over three configurations). Additive change is spelled out as not a break.
- *Named as third-party boundaries, nothing else delegated:* the `insta` re-export and macro, the `regex::Regex` parameter type, the serde traits — the JSON *shape* is termlens's.
- *Not promised:* diagnostic prose, internal representation, the settle heuristics' timing, budget defaults, the renderers' exact bytes.
- *Not checked, and said so:* a method re-typed under the same name — cargo-semver-checks 0.50.0 did not see the `unsupported()` return-type change in #346, only the removed method beside it.

The phrase "versioned with the dependency" now appears only for the three boundaries. The README and the CHANGELOG header carry the candidate statement **verbatim**; `.github/scripts/check-candidate-statement.sh` (in the `docs` job, listed in CONTRIBUTING §1) extracts the paragraph from STABILITY.md and fails when either copy differs — observed to exit 1 on a one-word drift.

**#334 — the process.** `docs/RELEASING.md`: a new section on what may break and how a break is declared; `v1.0.0-rc.N` pre-releases and that a date is never a criterion; the stress workflow on the *exact* commit to be tagged; step 2b freezing the release's corpus directory; step 5 (from #344) moving the semver baseline after publish. `CONTRIBUTING.md` §7: the API is frozen, and what to do when a change must break. `skills/termlens/SKILL.md`: written against 0.11.0 with the stability statement in §1, `termlens = "0.11"`, the `Unsupported` view line, `cursor_visible()`, `ScreenWithStyles`, `changed_rows`/`style_changes`, `Location` accessors, and `inspect`'s stdout as a saved screen; `check-skill-snippets.sh` passes.

**Deviation from #334, deliberate:** the issue asks the release PR to move `baseline-version` "in the same commit as the version bump". A version that is not yet on crates.io cannot be a baseline, so RELEASING moves it in a follow-up PR after publish and explains why; the CHANGELOG marker is what keeps `main` and the tag green in between. The report action tag in the README and skill stays `@v0.10.1` until `v0.11.0` exists; the release PR bumps both.

**Verified:** `check-candidate-statement.sh`, `check-readme-links.sh`, `check-skill-snippets.sh`, `check-ci-gates-listed.sh` (19 commands), zizmor pedantic — all pass locally.
