### PR TITLE
test(timeouts): let the child write before measuring wait_idle's silence

### DIFF
--- a/crates/termlens/tests/timeouts.rs
+++ b/crates/termlens/tests/timeouts.rs
@@ -43,13 +43,25 @@ fn wait_frame_for_overrides_the_builder_default() -> termlens::Result<()> {
 #[test]
 fn wait_idle_for_overrides_the_builder_default() -> termlens::Result<()> {
     let mut t = slow_app(&["busy", "--wait"]);
-    // A 200ms quiet period cannot be observed under the 150ms builder
-    // deadline at all — the wait would expire before the silence does.
+    // Let the child's first output land before measuring the silence.
+    // `wait_idle` counts quiet from the call, and a child that has not
+    // started writing yet is trivially quiet: the stress workflow saw this
+    // resolve after 200 ms of *nothing* on a loaded Windows runner (ConPTY
+    // holds the child until its startup handshake is answered), and the
+    // screen assertion below then failed on an empty grid — a race in this
+    // test, not in the wait. The per-call override is still what is under
+    // test: a 200 ms quiet period cannot be observed under the 150 ms
+    // builder deadline at all.
+    t.wait_until_for(|s| s.contains("busy"), Duration::from_secs(30))?;
     let start = Instant::now();
     t.wait_idle_for(Duration::from_millis(200), Duration::from_secs(30))?;
+    // The quiet window counts from the last byte, which landed a moment
+    // before `start`, so the elapsed time is a hair under 200 ms; what the
+    // test needs is that it is past the 150 ms builder deadline, under
+    // which the same call would have errored instead.
     assert!(
-        start.elapsed() >= Duration::from_millis(200),
-        "resolved before the quiet period elapsed: {:?}",
+        start.elapsed() > Duration::from_millis(150),
+        "resolved inside the builder deadline, so the override did not apply: {:?}",
         start.elapsed()
     );
     assert!(t.screen().contains("busy"), "{}", t.screen());


### PR DESCRIPTION
The early stress run on the candidate tree ([34527017048](https://github.com/vyncint/termlens/actions/runs/34527017048)) failed one shard — `windows-latest, 8 threads`, iteration 24/25 — in `wait_idle_for_overrides_the_builder_default`:

```
panicked at crates\termlens\tests\timeouts.rs:55:5:
size: 80x24  cursor: 0,0
(24 blank rows)
```

`wait_idle_for(200 ms, 30 s)` resolved after 200 ms of *nothing*: the child had not yet written `busy`. That is the documented behaviour — DESIGN §2: quiet is counted from the call, and a child that has not started writing is quiet — on a loaded four-core runner where ConPTY holds the child until its `CSI 6 n` handshake is answered. A race in the **test**, not in the wait: `wait.rs` and `terminal.rs` are untouched by 0.11, and the other fourteen shards (Linux ×5, macOS ×5, Windows ×4) passed their 100 iterations.

**Fix.** Wait for `busy` first, then measure the silence. The assertion becomes "the wait outlived the 150 ms builder deadline" rather than "≥ 200 ms elapsed": the quiet window counts from the last byte, which lands a moment before the clock starts, so the elapsed time is a hair under 200 ms *by construction* (measured 199.03 ms locally) — and the override of the default is what the test is about. Five local runs green.

**What this is not:** a sleep, a loosened timeout, or an ignore. The stress workflow will run again on the release commit before the tag, per RELEASING step 0.
