### PR TITLE
ci: move the semver baseline to v0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
         with:
           tool: cargo-semver-checks
       - run: tools/semver-gate-selftest/run.sh
-      - run: .github/scripts/check-semver.sh 0.10.3
+      - run: .github/scripts/check-semver.sh 0.11.0
         env:
           BREAKING_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'breaking') }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ cargo +1.85 check -p termlens --all-features --all-targets --locked           # 
 cargo +1.85 check -p termlens --no-default-features --all-targets --locked
 cargo clippy --workspace --all-targets --all-features --target x86_64-pc-windows-msvc -- -D warnings   # the Windows build, from any host: `rustup target add x86_64-pc-windows-msvc` once
 tools/semver-gate-selftest/run.sh                       # the semver gate can fail (cargo install cargo-semver-checks)…
-.github/scripts/check-semver.sh 0.10.3                  # …and the public API is compatible with the last published release
+.github/scripts/check-semver.sh 0.11.0                  # …and the public API is compatible with the last published release
 ```
 
 The list is written out here rather than left as a pointer because a first


### PR DESCRIPTION
`docs/RELEASING.md` step 5: termlens 0.11.0 is on crates.io (published 2026-09-10T21:35Z by [run 34532570645](https://github.com/vyncint/termlens/actions/runs/34532570645)), so the semver gate now compares every pull request against it. One literal, in `ci.yml`'s `semver` job and the matching line of CONTRIBUTING §1 (`gates-listed` green).

From here a removed, renamed or feature-gated promised item fails the gate under `patch` unless a new candidate is declared. This PR's own `semver` run is the first against the new baseline: tree `0.11.0` vs published `0.11.0`, type `patch`, and it must report no change.
